### PR TITLE
feat(risk): D4 backend wiring — un-dormants WS recovery poller

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ mypy src/ --strict              # type check
 ## Architecture
 
 - **47 analysis engines** in `src/analytics/` + 1 export module in `src/export/` — each standalone, no cross-dependencies
-- **API**: FastAPI with 121 endpoints under `/api/v1/` across 23 routers, rate-limited critical endpoints
+- **API**: FastAPI with 122 endpoints under `/api/v1/` across 23 routers, rate-limited critical endpoints
 - **Frontend**: SvelteKit + Tailwind v4, 54 pages, Svelte 5 runes ($state, $derived, $effect), dark mode, i18n (en/pt-BR/es), keyboard shortcuts (?)
 - **Database**: Supabase PostgreSQL with RLS, 24 migrations in `supabase/migrations/`
 - **Auth**: Supabase Auth (Google + LinkedIn + Microsoft OAuth), ES256 JWT

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Every methodology is traceable to published standards: AACE Recommended Practice
 | Schedule formats | 2 (Primavera P6 XER + Microsoft Project XML) |
 | Tests passing | 1435 backend + 26 Vitest composables + Playwright E2E |
 | Frontend pages | 54 (Schedule Viewer, EVM S-Curve, Cost Integration, Health Score, NLP Query, Early Warning, Lifecycle Phase, …) |
-| API endpoints | 121 across 23 routers |
+| API endpoints | 122 across 23 routers |
 | SVG chart components | 11 (incl. EVM S-Curve) + ScheduleViewer (hand-crafted, no chart.js) |
 | Released versions | v0.1.0 → v4.1.0 |
 | Live platform | [meridianiq.vitormr.dev](https://meridianiq.vitormr.dev) |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,6 +1,6 @@
 # API Reference
 
-Generated from `src/api/app.py` — **121 endpoints** across **23 routers**. Interactive Swagger UI is served at `/docs` when the API is running; this document is a static browseable index.
+Generated from `src/api/app.py` — **122 endpoints** across **23 routers**. Interactive Swagger UI is served at `/docs` when the API is running; this document is a static browseable index.
 
 All paths are prefixed with the deployment base URL (e.g. `https://meridianiq.fly.dev`). Auth column: `none` (public), `optional` (degrades gracefully), `required` (returns 401 without bearer token).
 
@@ -15,7 +15,7 @@ Regenerate with: `python3 scripts/generate_api_reference.py`
 - [Forensics](#forensics) — 10 endpoints
 - [TIA](#tia) — 4 endpoints
 - [EVM](#evm) — 6 endpoints
-- [Risk](#risk) — 8 endpoints
+- [Risk](#risk) — 9 endpoints
 - [Analysis](#analysis) — 11 endpoints
 - [Intelligence](#intelligence) — 8 endpoints
 - [What-If](#what-if) — 7 endpoints
@@ -121,6 +121,7 @@ _Monte Carlo QSRA per AACE RP 57R-09_
 |---|---|---|---|---|
 | `POST` | `/api/v1/risk/simulate/{project_id}` | Run Monte Carlo schedule risk simulation (QSRA) on a project. | `SimulationResultSchema` | optional |
 | `GET` | `/api/v1/risk/simulations` | List all risk simulations. | `SimulationListResponse` | optional |
+| `GET` | `/api/v1/risk/simulations/by-job/{job_id}` | Look up a risk simulation by its progress channel job_id. | `RiskSimulationByJobResponse` | optional |
 | `GET` | `/api/v1/risk/simulations/{simulation_id}` | Get full risk simulation result with all analysis data. | `SimulationResultSchema` | optional |
 | `GET` | `/api/v1/risk/simulations/{simulation_id}/criticality` | Get criticality index data for a risk simulation. | `CriticalityResponse` | optional |
 | `GET` | `/api/v1/risk/simulations/{simulation_id}/histogram` | Get histogram data for a risk simulation. | `HistogramResponse` | optional |

--- a/src/api/routers/risk.py
+++ b/src/api/routers/risk.py
@@ -18,6 +18,7 @@ from ..schemas import (
     PValueSchema,
     RiskSCurvePointSchema,
     RiskSCurveResponse,
+    RiskSimulationByJobResponse,
     RunSimulationRequest,
     SensitivityEntrySchema,
     SimulationListResponse,
@@ -218,6 +219,10 @@ async def run_risk_simulation(
     risk_store.add(result)
 
     if job_id:
+        # ADR-0019 §"W1 — D4" — bind job_id → simulation_id so the
+        # WS-recovery poller can recover the result if the WS dropped
+        # before the terminal `done` frame arrived.
+        risk_store.bind_job(job_id, result.simulation_id)
         publish(job_id, {"type": "done", "simulation_id": result.simulation_id})
 
     return _simulation_to_schema(result)
@@ -231,6 +236,47 @@ def list_risk_simulations(
     risk_store = get_risk_store()
     items = [SimulationSummarySchema(**s) for s in risk_store.list_all()]
     return SimulationListResponse(simulations=items)
+
+
+@router.get(
+    "/api/v1/risk/simulations/by-job/{job_id}",
+    response_model=RiskSimulationByJobResponse,
+)
+def get_risk_simulation_by_job(
+    job_id: str,
+    _user: object = Depends(optional_auth),
+) -> RiskSimulationByJobResponse:
+    """Look up a risk simulation by its progress channel job_id.
+
+    Per ADR-0019 §"W1 — D4". Used by the WebSocket-progress recovery
+    poller (frontend ``recoveryPoller``) to determine whether a
+    Monte Carlo simulation completed after a transient WS disconnect.
+
+    Returns 200 in both states — the poller's contract distinguishes
+    completion via the ``simulation_id`` value (string → done, null →
+    still running or never bound).
+
+    Args:
+        job_id: Progress channel id allocated by
+            ``POST /api/v1/jobs/progress/start``.
+
+    Raises:
+        HTTPException: 403 when the channel is bound to a different
+            user (matches ``run_risk_simulation`` ownership check).
+    """
+    from ..progress import get_channel_owner
+
+    owner = get_channel_owner(job_id)
+    caller_id = _user["id"] if isinstance(_user, dict) else None
+    if owner is not None and caller_id is not None and owner != caller_id:
+        raise HTTPException(
+            status_code=403,
+            detail="job_id is bound to another user",
+        )
+
+    risk_store = get_risk_store()
+    sid = risk_store.get_simulation_id_by_job(job_id)
+    return RiskSimulationByJobResponse(simulation_id=sid)
 
 
 @router.get(

--- a/src/api/routers/risk.py
+++ b/src/api/routers/risk.py
@@ -38,6 +38,43 @@ from src.analytics.risk import (
 router = APIRouter()
 
 
+def _assert_channel_owner(job_id: str, user: object) -> None:
+    """Reject cross-user access to a progress channel — shared 403 gate.
+
+    Used by every endpoint that consumes a ``job_id`` previously bound to
+    a user via ``POST /api/v1/jobs/progress/start``. Centralizes the
+    ownership check so a single regression locks down all consumers
+    (``run_risk_simulation`` and ``get_risk_simulation_by_job`` today;
+    any future endpoint accepting a ``job_id`` should call this helper
+    rather than re-implement the comparison).
+
+    Anonymous calls are allowed through: when the caller is unauthenticated
+    (``user is None`` or has no ``"id"`` key) the ownership check is
+    skipped entirely. This matches the pre-existing semantics of
+    ``run_risk_simulation`` (Wave 0 #7 hardening) — a bound channel
+    rejects MISMATCHED authenticated users, not anonymous ones.
+
+    Args:
+        job_id: Progress channel identifier.
+        user: ``optional_auth`` dependency value — typically ``dict``
+            with an ``"id"`` key, or ``None`` for unauthenticated.
+
+    Raises:
+        HTTPException: 403 with ``"job_id is bound to another user"``
+            when the channel is owned by a user_id different from the
+            authenticated caller's id.
+    """
+    from ..progress import get_channel_owner
+
+    owner = get_channel_owner(job_id)
+    caller_id = user["id"] if isinstance(user, dict) else None
+    if owner is not None and caller_id is not None and owner != caller_id:
+        raise HTTPException(
+            status_code=403,
+            detail="job_id is bound to another user",
+        )
+
+
 def _simulation_to_schema(result: Any) -> SimulationResultSchema:
     """Convert a SimulationResult dataclass to its Pydantic schema.
 
@@ -130,7 +167,7 @@ async def run_risk_simulation(
     """
     import asyncio
 
-    from ..progress import get_channel, get_channel_owner, publish, thread_safe_publisher
+    from ..progress import get_channel, publish, thread_safe_publisher
 
     store = get_store()
     risk_store = get_risk_store()
@@ -183,15 +220,8 @@ async def run_risk_simulation(
     progress_callback = None
     if job_id:
         # Wave 0 #7 hardening: the caller may only use a job_id they own
-        # (the channel was bound on POST /api/v1/jobs/progress/start). If
-        # the channel is bound AND the authenticated user differs, reject.
-        owner = get_channel_owner(job_id)
-        caller_id = _user["id"] if isinstance(_user, dict) else None
-        if owner is not None and caller_id is not None and owner != caller_id:
-            raise HTTPException(
-                status_code=403,
-                detail="job_id is bound to another user",
-            )
+        # (the channel was bound on POST /api/v1/jobs/progress/start).
+        _assert_channel_owner(job_id, _user)
     if job_id and get_channel(job_id) is not None:
         publish_event = thread_safe_publisher(job_id)
 
@@ -264,15 +294,7 @@ def get_risk_simulation_by_job(
         HTTPException: 403 when the channel is bound to a different
             user (matches ``run_risk_simulation`` ownership check).
     """
-    from ..progress import get_channel_owner
-
-    owner = get_channel_owner(job_id)
-    caller_id = _user["id"] if isinstance(_user, dict) else None
-    if owner is not None and caller_id is not None and owner != caller_id:
-        raise HTTPException(
-            status_code=403,
-            detail="job_id is bound to another user",
-        )
+    _assert_channel_owner(job_id, _user)
 
     risk_store = get_risk_store()
     sid = risk_store.get_simulation_id_by_job(job_id)

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -1072,6 +1072,29 @@ class SimulationListResponse(BaseModel):
     simulations: list[SimulationSummarySchema] = Field(default_factory=list)
 
 
+class RiskSimulationByJobResponse(BaseModel):
+    """Response for GET /api/v1/risk/simulations/by-job/{job_id}.
+
+    Per ADR-0019 §"W1 — D4". Used by the WebSocket-progress recovery
+    poller (frontend ``recoveryPoller`` in ``useWebSocketProgress``):
+    on transient WS disconnect after the run was accepted, the
+    poller calls this endpoint to learn whether the simulation
+    actually completed. The endpoint always returns 200 — semantic
+    distinction is in the ``simulation_id`` value:
+
+    * ``simulation_id`` is a string → simulation completed; the
+      poller flips the composable to ``done`` with this id.
+    * ``simulation_id`` is ``null`` → simulation still running OR
+      the job_id was never bound; the poller keeps polling until
+      the recovery window expires.
+
+    Authorisation matches the WebSocket channel's owner (see
+    ``get_channel_owner``). Cross-user job_id lookups return 403.
+    """
+
+    simulation_id: str | None = None
+
+
 class HistogramResponse(BaseModel):
     """Response for GET /api/v1/risk/simulations/{id}/histogram."""
 

--- a/src/api/storage.py
+++ b/src/api/storage.py
@@ -379,13 +379,18 @@ class RiskStore:
     def bind_job(self, job_id: str, simulation_id: str) -> None:
         """Index a completed simulation by its progress channel job_id.
 
-        Per ADR-0019 §"W1 — D4". The risk page WebSocket-progress flow
-        allocates a ``job_id`` before invoking ``POST
-        /api/v1/risk/simulate``; on completion the result is stored via
-        ``add()`` and the job_id is bound here so a subsequent
-        ``GET /api/v1/risk/simulations/by-job/{job_id}`` lookup can
-        recover the simulation_id even if the WebSocket disconnected
-        before the terminal frame arrived. Closes the W1 dormancy.
+        Per ADR-0019 §"W1 — D4". Closes the W1 dormancy by enabling
+        ``GET /api/v1/risk/simulations/by-job/{job_id}`` lookups for
+        the WebSocket recovery poller.
+
+        **Atomicity caveat:** ``add()`` and ``bind_job()`` are
+        individually thread-safe (each acquires ``_lock``) but the
+        sequence ``risk_store.add(result); risk_store.bind_job(job_id,
+        sid)`` is NOT jointly atomic. A poller calling
+        ``get_simulation_id_by_job(job_id)`` between the two calls
+        sees ``None`` and continues polling — the next poll (5s
+        default cadence) catches up. Acceptable race for the WS
+        recovery scenario; revisit if a stricter contract is needed.
 
         Args:
             job_id: Progress channel id from ``POST /jobs/progress/start``.
@@ -409,7 +414,8 @@ class RiskStore:
             stored for that job_id (still running, never started, or
             store was cleared).
         """
-        return self._jobs.get(job_id)
+        with self._lock:
+            return self._jobs.get(job_id)
 
     def get(self, simulation_id: str) -> SimulationResult | None:
         """Retrieve a simulation result by simulation_id.
@@ -420,7 +426,8 @@ class RiskStore:
         Returns:
             The stored ``SimulationResult``, or ``None`` if not found.
         """
-        return self._simulations.get(simulation_id)
+        with self._lock:
+            return self._simulations.get(simulation_id)
 
     def list_all(self) -> list[dict[str, Any]]:
         """List all stored simulations with summary info.

--- a/src/api/storage.py
+++ b/src/api/storage.py
@@ -356,6 +356,7 @@ class RiskStore:
     def __init__(self) -> None:
         """Initialise an empty store."""
         self._simulations: dict[str, SimulationResult] = {}
+        self._jobs: dict[str, str] = {}
         self._counter: int = 0
         self._lock = threading.Lock()
 
@@ -374,6 +375,41 @@ class RiskStore:
             result.simulation_id = sid
             self._simulations[sid] = result
         return sid
+
+    def bind_job(self, job_id: str, simulation_id: str) -> None:
+        """Index a completed simulation by its progress channel job_id.
+
+        Per ADR-0019 §"W1 — D4". The risk page WebSocket-progress flow
+        allocates a ``job_id`` before invoking ``POST
+        /api/v1/risk/simulate``; on completion the result is stored via
+        ``add()`` and the job_id is bound here so a subsequent
+        ``GET /api/v1/risk/simulations/by-job/{job_id}`` lookup can
+        recover the simulation_id even if the WebSocket disconnected
+        before the terminal frame arrived. Closes the W1 dormancy.
+
+        Args:
+            job_id: Progress channel id from ``POST /jobs/progress/start``.
+            simulation_id: Identifier returned by ``add()``.
+        """
+        with self._lock:
+            self._jobs[job_id] = simulation_id
+
+    def get_simulation_id_by_job(self, job_id: str) -> str | None:
+        """Look up the simulation_id bound to a progress channel job_id.
+
+        Used by the WebSocket recovery poller (frontend composable
+        ``recoveryPoller``) to determine whether a simulation completed
+        after a transient WS disconnect.
+
+        Args:
+            job_id: Progress channel id.
+
+        Returns:
+            The bound simulation_id, or ``None`` if no result has been
+            stored for that job_id (still running, never started, or
+            store was cleared).
+        """
+        return self._jobs.get(job_id)
 
     def get(self, simulation_id: str) -> SimulationResult | None:
         """Retrieve a simulation result by simulation_id.
@@ -419,6 +455,7 @@ class RiskStore:
         """Remove all stored simulations."""
         with self._lock:
             self._simulations.clear()
+            self._jobs.clear()
             self._counter = 0
 
 

--- a/tests/test_risk_api.py
+++ b/tests/test_risk_api.py
@@ -345,17 +345,77 @@ class TestRiskByJobEndpoint:
         finally:
             progress_module.close_channel("job-owned-by-alice-anon")
 
-    # NOTE on the 403 path: the cross-user ownership check in
-    # ``get_risk_simulation_by_job`` is byte-identical to the one in
-    # ``run_risk_simulation`` (same ``get_channel_owner`` lookup, same
-    # ``caller_id`` comparison, same 403 message). A dedicated 403
-    # test here would require FastAPI ``dependency_overrides`` to fake
-    # the authenticated caller. Under this repository's full test
-    # suite the override is correctly registered (verified via debug
-    # logs) but FastAPI's resolver bypasses it for ``optional_auth``,
-    # likely due to an inter-test pollution path that this test cannot
-    # be made robust against in isolation. The contract is exercised
-    # end-to-end by ``test_anonymous_caller_with_owned_channel_allowed``
-    # above (channel-owner lookup is invoked) and the 403 branch
-    # itself is identical to the long-tested whatif/risk simulate
-    # path.
+    # NOTE on the 403 path: the cross-user ownership check is now
+    # centralised in ``_assert_channel_owner`` (src/api/routers/risk.py)
+    # and shared by both ``run_risk_simulation`` and
+    # ``get_risk_simulation_by_job``. End-to-end FastAPI tests via
+    # ``dependency_overrides[optional_auth]`` exhibit flaky behaviour
+    # under the full test suite (the override is correctly registered
+    # but FastAPI's resolver bypasses it for ``optional_auth`` — root
+    # cause appears to be inter-test pollution outside this module's
+    # reach). To get hard regression coverage on the ownership branch
+    # without that flakiness, the helper itself is unit-tested below
+    # (``TestAssertChannelOwner``). Any future endpoint that consumes
+    # a ``job_id`` should call ``_assert_channel_owner`` rather than
+    # re-implement the comparison — that way the helper test covers
+    # all consumers.
+
+
+class TestAssertChannelOwner:
+    """Unit tests for the shared ownership-check helper.
+
+    ``_assert_channel_owner`` is the single 403 gate consumed by every
+    endpoint that takes a ``job_id`` parameter. Testing the helper
+    directly (instead of via FastAPI dependency overrides) avoids the
+    test-suite-pollution issue documented above and gives one
+    regression that protects all consumers.
+    """
+
+    def test_anonymous_no_owner_passes(self) -> None:
+        """No channel registered + no caller → no raise (dev-mode default)."""
+        from src.api.routers.risk import _assert_channel_owner
+
+        _assert_channel_owner("job-no-channel-no-user", None)  # no raise
+
+    def test_authenticated_user_matching_owner_passes(self) -> None:
+        """Owner == caller → no raise (the happy path)."""
+        from src.api import progress
+        from src.api.routers.risk import _assert_channel_owner
+
+        progress.open_channel("job-bob-match", owner_user_id="bob")
+        try:
+            _assert_channel_owner("job-bob-match", {"id": "bob"})  # no raise
+        finally:
+            progress.close_channel("job-bob-match")
+
+    def test_authenticated_user_mismatched_owner_raises_403(self) -> None:
+        """Owner ≠ caller → raises HTTPException(403)."""
+        from fastapi import HTTPException
+
+        from src.api import progress
+        from src.api.routers.risk import _assert_channel_owner
+
+        progress.open_channel("job-alice-mismatch", owner_user_id="alice")
+        try:
+            with pytest.raises(HTTPException) as exc_info:
+                _assert_channel_owner("job-alice-mismatch", {"id": "bob"})
+            assert exc_info.value.status_code == 403
+            assert "bound to another user" in exc_info.value.detail
+        finally:
+            progress.close_channel("job-alice-mismatch")
+
+    def test_anonymous_caller_with_owned_channel_passes(self) -> None:
+        """Owner present + anonymous caller → no raise.
+
+        Matches the existing ``run_risk_simulation`` semantics (Wave 0
+        #7 hardening) where bound channels reject MISMATCHED
+        authenticated users, not anonymous callers.
+        """
+        from src.api import progress
+        from src.api.routers.risk import _assert_channel_owner
+
+        progress.open_channel("job-alice-anon-helper", owner_user_id="alice")
+        try:
+            _assert_channel_owner("job-alice-anon-helper", None)  # no raise
+        finally:
+            progress.close_channel("job-alice-anon-helper")

--- a/tests/test_risk_api.py
+++ b/tests/test_risk_api.py
@@ -243,3 +243,119 @@ class TestGetSCurve:
         """S-curve for missing simulation returns 404."""
         resp = client.get("/api/v1/risk/simulations/nonexistent/s-curve")
         assert resp.status_code == 404
+
+
+class TestRiskStoreBindJob:
+    """Unit tests for RiskStore.bind_job + get_simulation_id_by_job.
+
+    Per ADR-0019 W1 D4. The store maps job_id (progress channel id) to
+    simulation_id so the WS-recovery poller can recover a completed
+    simulation after a transient WebSocket disconnect.
+    """
+
+    def test_bind_job_returns_simulation_id(self) -> None:
+        """get_simulation_id_by_job returns the bound id."""
+        store = RiskStore()
+        store.bind_job("job-abc", "risk-0001")
+        assert store.get_simulation_id_by_job("job-abc") == "risk-0001"
+
+    def test_unbound_job_returns_none(self) -> None:
+        """Lookup for a never-bound job returns None (still running / never started)."""
+        store = RiskStore()
+        assert store.get_simulation_id_by_job("job-never-bound") is None
+
+    def test_clear_resets_jobs(self) -> None:
+        """clear() drops the job index alongside simulations."""
+        store = RiskStore()
+        store.bind_job("job-abc", "risk-0001")
+        store.clear()
+        assert store.get_simulation_id_by_job("job-abc") is None
+
+    def test_rebinding_overwrites(self) -> None:
+        """Last bind wins when the same job_id is bound twice."""
+        store = RiskStore()
+        store.bind_job("job-abc", "risk-0001")
+        store.bind_job("job-abc", "risk-0002")
+        assert store.get_simulation_id_by_job("job-abc") == "risk-0002"
+
+
+class TestRiskByJobEndpoint:
+    """Contract tests for GET /api/v1/risk/simulations/by-job/{job_id}.
+
+    Per ADR-0019 W1 D4. The endpoint always returns 200 (the poller
+    contract distinguishes done vs running via the simulation_id
+    value), except when ownership check fails (403).
+    """
+
+    def test_unbound_job_returns_null_simulation_id(self, client: TestClient) -> None:
+        """Unbound job_id returns 200 with simulation_id=null (poller keeps polling)."""
+        resp = client.get("/api/v1/risk/simulations/by-job/job-never-bound")
+        assert resp.status_code == 200
+        assert resp.json() == {"simulation_id": None}
+
+    def test_bound_job_returns_simulation_id(self, client: TestClient) -> None:
+        """After bind_job, the endpoint returns the simulation_id (poller flips to done)."""
+        # Bind directly via the store fixture (avoids needing the full
+        # simulation flow; the bind_job + lookup path is what we assert).
+        import src.api.deps as deps_module
+
+        deps_module._risk_store.bind_job("job-bound-1", "risk-0042")
+
+        resp = client.get("/api/v1/risk/simulations/by-job/job-bound-1")
+        assert resp.status_code == 200
+        assert resp.json() == {"simulation_id": "risk-0042"}
+
+    def test_simulate_binds_job_id_to_result(
+        self, client: TestClient, uploaded_project: str
+    ) -> None:
+        """End-to-end: a simulate call with job_id binds the job to the simulation_id.
+
+        This is the non-recovery happy-path: the simulation completes
+        synchronously over HTTP, the by-job endpoint resolves to the
+        same simulation_id even though no recovery was needed.
+        """
+        body = {
+            "config": {"iterations": 100, "seed": 42},
+            "duration_risks": [],
+            "risk_events": [],
+        }
+        resp = client.post(
+            f"/api/v1/risk/simulate/{uploaded_project}?job_id=job-flow-1",
+            json=body,
+        )
+        assert resp.status_code == 200
+        sid_from_response = resp.json()["simulation_id"]
+
+        # The by-job endpoint should now resolve job-flow-1 to the same id.
+        resp = client.get("/api/v1/risk/simulations/by-job/job-flow-1")
+        assert resp.status_code == 200
+        assert resp.json() == {"simulation_id": sid_from_response}
+
+    def test_anonymous_caller_with_owned_channel_allowed(self, client: TestClient) -> None:
+        """Owner present, caller anonymous → 200 (the 403 only triggers when
+        an authenticated caller differs from the owner; matches the
+        existing run_risk_simulation ownership semantics)."""
+        from src.api import progress as progress_module
+
+        progress_module.open_channel("job-owned-by-alice-anon", owner_user_id="alice-user-id")
+        try:
+            resp = client.get("/api/v1/risk/simulations/by-job/job-owned-by-alice-anon")
+            assert resp.status_code == 200
+            assert resp.json() == {"simulation_id": None}
+        finally:
+            progress_module.close_channel("job-owned-by-alice-anon")
+
+    # NOTE on the 403 path: the cross-user ownership check in
+    # ``get_risk_simulation_by_job`` is byte-identical to the one in
+    # ``run_risk_simulation`` (same ``get_channel_owner`` lookup, same
+    # ``caller_id`` comparison, same 403 message). A dedicated 403
+    # test here would require FastAPI ``dependency_overrides`` to fake
+    # the authenticated caller. Under this repository's full test
+    # suite the override is correctly registered (verified via debug
+    # logs) but FastAPI's resolver bypasses it for ``optional_auth``,
+    # likely due to an inter-test pollution path that this test cannot
+    # be made robust against in isolation. The contract is exercised
+    # end-to-end by ``test_anonymous_caller_with_owned_channel_allowed``
+    # above (channel-owner lookup is invoked) and the 403 branch
+    # itself is identical to the long-tested whatif/risk simulate
+    # path.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -703,6 +703,21 @@ export async function createRiskSimulation(
 	});
 }
 
+/**
+ * ADR-0019 §"W1 — D4". Look up a completed risk simulation by its
+ * progress channel job_id. Returns `simulation_id: null` while the
+ * simulation is still running OR was never bound — the
+ * `useWebSocketProgress` recovery poller polls until a non-null id
+ * appears or the recovery window times out.
+ */
+export async function getRiskSimulationByJob(
+	jobId: string
+): Promise<{ simulation_id: string | null }> {
+	return request<{ simulation_id: string | null }>(
+		`/api/v1/risk/simulations/by-job/${encodeURIComponent(jobId)}`
+	);
+}
+
 // ── Progress jobs (ADR-0013 server-generated job_id + ownership) ───────
 
 export interface ProgressJobResponse {

--- a/web/src/lib/i18n/en.ts
+++ b/web/src/lib/i18n/en.ts
@@ -404,7 +404,7 @@ export default {
 	'risk.progress.starting': 'Starting job...',
 	'risk.progress.connecting': 'Connecting to progress channel...',
 	'risk.progress.running': 'Running simulation',
-	'risk.progress.recovering': 'Connection dropped — simulation likely still running. Polling for completion...',
+	'risk.progress.recovering': 'Connection lost — checking if the simulation completed...',
 	'risk.progress.connection_lost': 'Connection lost. The simulation may still be running in the background; refresh the list below once it completes.',
 	'risk.progress.failed': 'Simulation failed',
 

--- a/web/src/lib/i18n/en.ts
+++ b/web/src/lib/i18n/en.ts
@@ -404,6 +404,7 @@ export default {
 	'risk.progress.starting': 'Starting job...',
 	'risk.progress.connecting': 'Connecting to progress channel...',
 	'risk.progress.running': 'Running simulation',
+	'risk.progress.recovering': 'Connection dropped — simulation likely still running. Polling for completion...',
 	'risk.progress.connection_lost': 'Connection lost. The simulation may still be running in the background; refresh the list below once it completes.',
 	'risk.progress.failed': 'Simulation failed',
 

--- a/web/src/lib/i18n/es.ts
+++ b/web/src/lib/i18n/es.ts
@@ -404,7 +404,7 @@ export default {
 	'risk.progress.starting': 'Iniciando proceso...',
 	'risk.progress.connecting': 'Conectando al canal de progreso...',
 	'risk.progress.running': 'Ejecutando simulacion',
-	'risk.progress.recovering': 'Conexion caida — la simulacion probablemente sigue en ejecucion. Consultando finalizacion...',
+	'risk.progress.recovering': 'Conexion perdida — comprobando si la simulacion termino...',
 	'risk.progress.connection_lost': 'Conexion perdida. La simulacion puede continuar en segundo plano; actualice la lista abajo cuando termine.',
 	'risk.progress.failed': 'La simulacion fallo',
 

--- a/web/src/lib/i18n/es.ts
+++ b/web/src/lib/i18n/es.ts
@@ -404,6 +404,7 @@ export default {
 	'risk.progress.starting': 'Iniciando proceso...',
 	'risk.progress.connecting': 'Conectando al canal de progreso...',
 	'risk.progress.running': 'Ejecutando simulacion',
+	'risk.progress.recovering': 'Conexion caida — la simulacion probablemente sigue en ejecucion. Consultando finalizacion...',
 	'risk.progress.connection_lost': 'Conexion perdida. La simulacion puede continuar en segundo plano; actualice la lista abajo cuando termine.',
 	'risk.progress.failed': 'La simulacion fallo',
 

--- a/web/src/lib/i18n/pt-BR.ts
+++ b/web/src/lib/i18n/pt-BR.ts
@@ -404,6 +404,7 @@ export default {
 	'risk.progress.starting': 'Iniciando processamento...',
 	'risk.progress.connecting': 'Conectando ao canal de progresso...',
 	'risk.progress.running': 'Executando simulacao',
+	'risk.progress.recovering': 'Conexao caiu — simulacao provavelmente ainda em execucao. Verificando conclusao...',
 	'risk.progress.connection_lost': 'Conexao perdida. A simulacao pode continuar em segundo plano; atualize a lista abaixo quando ela terminar.',
 	'risk.progress.failed': 'Simulacao falhou',
 

--- a/web/src/lib/i18n/pt-BR.ts
+++ b/web/src/lib/i18n/pt-BR.ts
@@ -404,7 +404,7 @@ export default {
 	'risk.progress.starting': 'Iniciando processamento...',
 	'risk.progress.connecting': 'Conectando ao canal de progresso...',
 	'risk.progress.running': 'Executando simulacao',
-	'risk.progress.recovering': 'Conexao caiu — simulacao provavelmente ainda em execucao. Verificando conclusao...',
+	'risk.progress.recovering': 'Conexao perdida — verificando se a simulacao foi concluida...',
 	'risk.progress.connection_lost': 'Conexao perdida. A simulacao pode continuar em segundo plano; atualize a lista abaixo quando ela terminar.',
 	'risk.progress.failed': 'Simulacao falhou',
 

--- a/web/src/routes/risk/+page.svelte
+++ b/web/src/routes/risk/+page.svelte
@@ -2,6 +2,7 @@
 	import {
 		getRiskSimulations,
 		createRiskSimulation,
+		getRiskSimulationByJob,
 		getProjects,
 		type RiskSimulationSummary,
 		type RiskSimulationRunConfig
@@ -34,7 +35,21 @@
 	// `progressState` is the composable's readable store; the template
 	// auto-subscribes via the `$progressState` sigil so every WebSocket
 	// frame triggers a re-render without manual polling.
-	const progress = useWebSocketProgress();
+	//
+	// ADR-0019 §"W1 — D4" recoveryPoller — on transient WS disconnect
+	// (TLS hiccup, Fly.io single-instance restart blip, ~5–15s) the
+	// composable enters `recovering` state and polls this function on
+	// 5s cadence within a 60s window. The poller hits the by-job
+	// endpoint that resolves to `simulation_id` once the backend has
+	// stored the result, OR returns null while still running. A
+	// non-null result flips the composable to `done` without spurious
+	// `error`. Authoritative close codes (4401/4403/4404) bypass the
+	// recovery — those are deliberate server decisions, not blips.
+	async function riskRecoveryPoller(jobId: string): Promise<string | null> {
+		const result = await getRiskSimulationByJob(jobId);
+		return result.simulation_id;
+	}
+	const progress = useWebSocketProgress({ recoveryPoller: riskRecoveryPoller });
 	const progressState = progress.state;
 
 	async function loadSimulations() {
@@ -203,7 +218,9 @@
 								? 'bg-red-500'
 								: $progressState.status === 'done'
 									? 'bg-green-600'
-									: 'bg-blue-600'}"
+									: $progressState.status === 'recovering'
+										? 'bg-amber-500 animate-pulse'
+										: 'bg-blue-600'}"
 							style="width: {$progressState.status === 'done' ? 100 : $progressState.pct}%"
 						></div>
 					</div>
@@ -217,6 +234,8 @@
 							{$t('risk.progress.connecting')}
 						{:else if $progressState.status === 'running'}
 							{$t('risk.progress.running')} — {Math.round($progressState.pct)}% ({$progressState.done.toLocaleString()} / {$progressState.total.toLocaleString()})
+						{:else if $progressState.status === 'recovering'}
+							{$t('risk.progress.recovering')}
 						{:else if $progressState.status === 'done'}
 							{$t('risk.progress.running')} — 100%
 						{:else if $progressState.status === 'error'}


### PR DESCRIPTION
Closes the D4 deferral that Cycle 2 W1 (commit `567a604`) shipped explicitly dormant — the `recoveryPoller` composable contract was in place but the backend `job_id → simulation_id` lookup was missing. With this PR landed, a real risk-page user whose WebSocket drops mid-simulation gets recovery instead of an immediate failure flip.

## What changed

### Backend
- `src/api/storage.py` — `RiskStore` gains a `_jobs: dict[str, str]` index, `bind_job(job_id, simulation_id)`, and `get_simulation_id_by_job(job_id) -> str | None`. `clear()` drops the job index alongside simulations.
- `src/api/routers/risk.py` — `run_risk_simulation` calls `risk_store.bind_job(job_id, sid)` after `add()` when `job_id` present. New endpoint `GET /api/v1/risk/simulations/by-job/{job_id}` returns `RiskSimulationByJobResponse` (200 in both states; `simulation_id` string → done, null → running/never-bound). Ownership check mirrors `run_risk_simulation`: `get_channel_owner` vs authenticated `caller_id`, 403 on cross-user.
- `src/api/schemas.py` — new `RiskSimulationByJobResponse` Pydantic v2 model with full contract docstring.

### Frontend
- `web/src/lib/api.ts` — new `getRiskSimulationByJob(jobId)` helper.
- `web/src/routes/risk/+page.svelte` — defines `riskRecoveryPoller(jobId)` calling the new endpoint, passes to `useWebSocketProgress({ recoveryPoller })`. UI: new `status === 'recovering'` branch with amber `animate-pulse` bar and `risk.progress.recovering` i18n string. Authoritative WS close codes (4401/4403/4404) still bypass recovery — only `connection_lost` triggers it.
- `web/src/lib/i18n/{en,pt-BR,es}.ts` — new `risk.progress.recovering` key × 3 locales.

## Tests

- **4 unit tests** in `TestRiskStoreBindJob`: bind/lookup/clear/rebinding-overwrites.
- **4 contract tests** in `TestRiskByJobEndpoint`: unbound→null, bound→sid, simulate-then-lookup, anonymous-with-owned-channel.
- **1399 backend tests pass** (+8 net from baseline). Ruff lint + format clean. `npm run check` 0 errors 0 warnings on 637 files.

### Honest disclosure on the 403 path

The cross-user 403 path was originally tested as a 2-test pair using FastAPI `dependency_overrides[optional_auth]`. Under the full test suite the override was correctly registered (verified via debug logs — the function reference matched, `dependency_overrides` had the entry) but FastAPI's resolver bypassed it for `optional_auth`. Likely an inter-test pollution path outside this module's reach. Removed the flaky tests; left an in-file `# NOTE` block documenting the decision and citing that the 403 branch is byte-identical to the long-tested `run_risk_simulation` ownership check (which has been in production since v3.x). Future work could re-introduce these tests once the pollution source is identified.

## Refs

- [ADR-0019 §"W1 — D4"](../blob/main/docs/adr/0019-cycle-2-entry-consolidation-primitive.md)
- [ADR-0013 — WebSocket progress hardening](../blob/main/docs/adr/0013-websocket-progress-hardening.md)
- `docs/ROADMAP.md` §"Pre-Cycle-3 hygiene (Claude-doable, queued)"
- `docs/LESSONS_LEARNED.md` Cycle 2 §"Half-shipped features need explicit 'dormant' framing"

## Test plan

- [ ] CI 9/9 green: CI · Doc sync check · Secret scan · Verify catalogs · CodeQL · 3× Analyze · Backend · Frontend · E2E · gitleaks
- [ ] Manual: simulate Monte Carlo on the risk page with browser DevTools throttling the WS to drop after `running` is reached; verify `recovering` chip appears and resolves to `done` once the simulation completes server-side.