### PR TITLE
fix(e2e): #61 — replace over-matching 'Intelligence' locator in pages.spec.ts

### DIFF
--- a/web/tests/pages.spec.ts
+++ b/web/tests/pages.spec.ts
@@ -177,9 +177,20 @@ test.describe('Docs page sections', () => {
 });
 
 test.describe('Sidebar navigation', () => {
-  test('Intelligence section hidden when unauthenticated', async ({ page }) => {
+  test('Auth-gated sections hidden when unauthenticated', async ({ page }) => {
     await page.goto('/');
-    // Auth-required sections are hidden for unauthenticated users
-    await expect(page.locator('aside').getByText('Intelligence')).not.toBeVisible();
+    // Sections marked `auth: true` in `web/src/routes/+layout.svelte:navSections`
+    // must NOT render for anonymous visitors. Each title below is a real
+    // auth-gated section header (i18n keys nav.section.*) — they are
+    // chosen specifically because they don't substring-collide with
+    // always-visible chrome (the `Schedule Intelligence Platform` tagline
+    // at +layout.svelte:206 contains both "Schedule" and "Intelligence",
+    // so neither word is a safe locator on its own).
+    await expect(page.locator('aside').getByText('AI Insights')).not.toBeVisible();
+    await expect(page.locator('aside').getByText('Claims & Forensic')).not.toBeVisible();
+    await expect(page.locator('aside').getByText('Risk & Controls')).not.toBeVisible();
+    await expect(page.locator('aside').getByText('Cost & Earned Value')).not.toBeVisible();
+    await expect(page.locator('aside').getByText('Planning & Optimization')).not.toBeVisible();
+    await expect(page.locator('aside').getByText('Enterprise')).not.toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

- Closes #61. The Playwright test `'Intelligence section hidden when unauthenticated'` was using `getByText('Intelligence')` which substring-matched the always-visible platform tagline `Schedule Intelligence Platform` (`web/src/routes/+layout.svelte:206`, added 2026-04-17 via i18n key `sidebar.platform_subtitle`).
- The test passed only when Playwright's i18n hydration didn't complete before the 5000ms assertion timeout — a flake that hit PR #60 retry-loop. There IS no "Intelligence" section in the sidebar (the actual section is "AI Insights").

## Fix

Renamed the test to `'Auth-gated sections hidden when unauthenticated'` (the original name was misleading) and asserted each of 6 real auth-gated section titles is hidden when unauthenticated. Excluded `'Schedule'` deliberately — substring of the platform tagline.

| Title | i18n key | auth gate |
|---|---|---|
| AI Insights | `nav.section.ai_insights` | yes |
| Claims & Forensic | `nav.section.forensic` | yes |
| Risk & Controls | `nav.section.risk` | yes |
| Cost & Earned Value | `nav.section.cost` | yes |
| Planning & Optimization | `nav.section.planning` | yes |
| Enterprise | `nav.section.enterprise` | yes |

## Test plan

- [x] `npm run check` (web) — 0 errors, 0 warnings
- [ ] CI E2E (Playwright) — should pass deterministically now

## DA review

Skipped per ADR-0018 Amendment 1 §"Skip protocol APENAS para" — falls under the "1-line typo fixes / mechanical PR" class (1 broken locator → 6 specific locators in a single test file; doesn't change frontend behavior, only test assertion targets).

Closes #61.

Assisted-By: Claude (Anthropic) <noreply@anthropic.com>