### PR TITLE
fix(ops): BUG-007 — fly min_machines_running = 1 (kill cold-start 502s)

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -11,9 +11,17 @@ primary_region = "iad"
 [http_service]
   internal_port = 8080
   force_https = true
+  # Cold-start mitigation (BUG-007): keep at least 1 machine always running.
+  # `auto_stop_machines = "stop"` still scales DOWN excess machines (e.g.,
+  # under load Fly may add 2-3 machines, idle scales back to 1).
+  # `min_machines_running = 1` is the floor — guarantees one warm worker so
+  # the first request after idle doesn't return 502 (HTTP/2 connection drop
+  # in the browser → false-CORS error). Cost delta ~$5-8/month for the 1
+  # always-on machine. Pairs with PR #65 (frontend surface-errors fix);
+  # this is the BACKEND half of the same root cause.
   auto_stop_machines = "stop"
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ["app"]
 
   [http_service.concurrency]


### PR DESCRIPTION
## Summary

Backend half of the cold-start mitigation. **PR #65** (frontend) made the errors visible; this PR removes the cause.

## Root cause (confirmed via HAR 2026-04-28)

User reported "Failed to fetch" on Gantt + 3 menus not listing projects. Production HAR showed:
- `GET /api/v1/projects/{id}/schedule-view → 502 Bad Gateway`
- `net::ERR_FAILED` + missing CORS headers (Chrome shows misleading "CORS blocked" message because 502 responses from Fly's edge don't include the configured CORS headers)
- Pattern: first request after idle period fails; subsequent requests on the warm machine succeed

`min_machines_running = 0` lets Fly scale to zero. After ~5min idle the machine sleeps. The browser's HTTP/2 connection becomes stale; the next request returns 502 from Fly's edge while the upstream worker boots (cold start ~10-15s).

## Fix

```toml
- min_machines_running = 0
+ min_machines_running = 1
```

Cost delta ~$5-8/month for the 1 always-on shared-CPU 1024mb machine in iad. `auto_stop_machines = "stop"` is preserved — Fly still scales DOWN excess machines under load. `min_machines_running = 1` is the floor, not the ceiling.

Documented inline so future tuning is informed.

## Test plan

- [ ] **Operator action required**: `flyctl deploy` from this branch / after merge
- [ ] Post-deploy: `flyctl status` shows 1 machine in `started` state
- [ ] Idle for 10+ min, then confirm machine STAYS started (not scaled to zero)
- [ ] Prod smoke test: navigate to `/schedule` with stale session, confirm no 502

## CLAUDE.md update

Once deploy is verified, the BUG-007 entry in `CLAUDE.md §"Known Gotchas"` can be marked resolved (separate doc PR).

## DA review

Skipped per ADR-0018 Amendment 1 §"Skip protocol" — single-line ops config change. Verifiable empirically post-deploy.

Closes BUG-007 root cause.

Assisted-By: Claude (Anthropic) <noreply@anthropic.com>