### PR TITLE
feat(observability): D-tier runtime instrumentation + SuperAdmin gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,25 @@ ENVIRONMENT=development
 # RATE_LIMIT_ENABLED=true
 
 # ──────────────────────────────────────────────────────────────
+# SuperAdmin tier (env-gated allowlist) — top of the 5-tier role
+# model (SuperAdmin → Enterprise → Program → Project → Contract).
+# Today: env vars only.  Future: DB-backed users.tier column once
+# the Tier-model migration ships.  Both lists are comma-separated;
+# matching is OR (either list matching is sufficient).  Email
+# matching is case-insensitive.  API-key role is NEVER promoted to
+# SuperAdmin even on user_id match — JWT-only by design.  Required
+# to access GET /api/v1/superadmin/runtime.
+# Fail-closed: if neither is set, no caller is SuperAdmin.
+# SUPERADMIN_USER_IDS=00000000-0000-0000-0000-000000000000
+# SUPERADMIN_EMAILS=ops@example.com
+
+# Runtime breadcrumb throttle — interval in seconds between Sentry
+# breadcrumb emissions from /health.  Bounds at 5s minimum; values
+# below or non-numeric fall back to the default safely.
+# Default: 300 (5 min — matches Fly's per-machine OOM signal cadence).
+# RUNTIME_BREADCRUMB_INTERVAL_SECONDS=300
+
+# ──────────────────────────────────────────────────────────────
 # Optional features
 # ──────────────────────────────────────────────────────────────
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ mypy src/ --strict              # type check
 ## Architecture
 
 - **47 analysis engines** in `src/analytics/` + 1 export module in `src/export/` — each standalone, no cross-dependencies
-- **API**: FastAPI with 122 endpoints under `/api/v1/` across 23 routers, rate-limited critical endpoints
+- **API**: FastAPI with 123 endpoints under `/api/v1/` across 24 routers, rate-limited critical endpoints
 - **Frontend**: SvelteKit + Tailwind v4, 54 pages, Svelte 5 runes ($state, $derived, $effect), dark mode, i18n (en/pt-BR/es), keyboard shortcuts (?)
 - **Database**: Supabase PostgreSQL with RLS, 27 migrations in `supabase/migrations/`
 - **Auth**: Supabase Auth (Google + LinkedIn + Microsoft OAuth), ES256 JWT

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Every methodology is traceable to published standards: AACE Recommended Practice
 | Schedule formats | 2 (Primavera P6 XER + Microsoft Project XML) |
 | Tests passing | 1490 backend + 26 Vitest composables + Playwright E2E |
 | Frontend pages | 54 (Schedule Viewer, EVM S-Curve, Cost Integration, Health Score, NLP Query, Early Warning, Lifecycle Phase, …) |
-| API endpoints | 122 across 23 routers |
+| API endpoints | 123 across 24 routers |
 | SVG chart components | 11 (incl. EVM S-Curve) + ScheduleViewer (hand-crafted, no chart.js) |
 | Released versions | v0.1.0 → v4.1.0 |
 | Live platform | [meridianiq.vitormr.dev](https://meridianiq.vitormr.dev) |
@@ -120,7 +120,7 @@ graph TB
     end
 
     subgraph "Compute Layer — Fly.io"
-        FASTAPI["FastAPI Container<br/>Analysis Engines (47)<br/>122 endpoints"]
+        FASTAPI["FastAPI Container<br/>Analysis Engines (47)<br/>123 endpoints"]
     end
 
     subgraph "Platform Layer — Supabase"
@@ -324,7 +324,7 @@ meridianiq/
 │   ├── database/         # Supabase client, config, store abstraction
 │   └── api/
 │       ├── app.py        # FastAPI entry point
-│       ├── routers/      # 122 endpoints across modular routers
+│       ├── routers/      # 123 endpoints across modular routers
 │       └── schemas.py    # Request/response models
 ├── web/                  # SvelteKit + Tailwind (54 pages)
 ├── tests/                # 1490+ backend tests

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,6 +1,6 @@
 # API Reference
 
-Generated from `src/api/app.py` — **122 endpoints** across **23 routers**. Interactive Swagger UI is served at `/docs` when the API is running; this document is a static browseable index.
+Generated from `src/api/app.py` — **123 endpoints** across **24 routers**. Interactive Swagger UI is served at `/docs` when the API is running; this document is a static browseable index.
 
 All paths are prefixed with the deployment base URL (e.g. `https://meridianiq.fly.dev`). Auth column: `none` (public), `optional` (degrades gracefully), `required` (returns 401 without bearer token).
 
@@ -28,6 +28,7 @@ Regenerate with: `python3 scripts/generate_api_reference.py`
 - [Health](#health) — 2 endpoints
 - [Bi](#bi) — 3 endpoints
 - [Lifecycle](#lifecycle) — 4 endpoints
+- [Observability](#observability) — 1 endpoints
 - [Organizations](#organizations) — 11 endpoints
 - [Plugins](#plugins) — 2 endpoints
 - [Ws](#ws) — 1 endpoints
@@ -257,7 +258,7 @@ _Readiness and liveness_
 | Method | Path | Summary | Response | Auth |
 |---|---|---|---|---|
 | `GET` | `/api/v1/health` | Health check endpoint. | `HealthResponse` | none |
-| `GET` | `/health` | — | `—` | none |
+| `GET` | `/health` | — | `dict` | none |
 
 ## Bi
 
@@ -275,6 +276,12 @@ _Readiness and liveness_
 | `DELETE` | `/api/v1/projects/{project_id}/lifecycle/override` | Revert to the inferred phase (keeps override history). | `—` | optional |
 | `POST` | `/api/v1/projects/{project_id}/lifecycle/override` | Write a manual lifecycle phase override + flip the lock. | `LifecycleOverrideSchema` | optional |
 | `GET` | `/api/v1/projects/{project_id}/lifecycle/overrides` | Return the override history for a project (newest first). | `LifecycleOverrideListResponse` | optional |
+
+## Observability
+
+| Method | Path | Summary | Response | Auth |
+|---|---|---|---|---|
+| `GET` | `/api/v1/admin/runtime` | Return a snapshot of process runtime state (SuperAdmin only). | `RuntimeSnapshot` | none |
 
 ## Organizations
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -281,7 +281,7 @@ _Readiness and liveness_
 
 | Method | Path | Summary | Response | Auth |
 |---|---|---|---|---|
-| `GET` | `/api/v1/admin/runtime` | Return a snapshot of process runtime state (SuperAdmin only). | `RuntimeSnapshot` | none |
+| `GET` | `/api/v1/superadmin/runtime` | Return a snapshot of process runtime state (SuperAdmin only). | `RuntimeSnapshot` | none |
 
 ## Organizations
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@
 
 MeridianIQ is a **modular monolith**: a single FastAPI application with clearly separated analysis engines, each implementing a specific published methodology and written to stay independent of every other engine. The frontend is a SvelteKit SPA served from Cloudflare Pages and talks to the backend via REST.
 
-As of **v4.1.0** + Cycle 3 in-flight: 47 analysis engines + 1 export module, 122 API endpoints across 23 routers, 54 SvelteKit pages, 11 hand-crafted SVG chart components, 27 Supabase migrations, 22 MCP tools, 15 PDF report types, 1490 tests.
+As of **v4.1.0** + Cycle 3 in-flight + post-Cycle-3 follow-ups: 47 analysis engines + 1 export module, 123 API endpoints across 24 routers, 54 SvelteKit pages, 11 hand-crafted SVG chart components, 27 Supabase migrations, 22 MCP tools, 15 PDF report types, 1490 tests.
 
 ```mermaid
 graph TB
@@ -14,7 +14,7 @@ graph TB
     end
 
     subgraph "Compute — Fly.io"
-        API[FastAPI application<br/>121 endpoints · 23 routers<br/>Rate-limited · CORS whitelist<br/>Sentry telemetry]
+        API[FastAPI application<br/>123 endpoints · 24 routers<br/>Rate-limited · CORS whitelist<br/>Sentry telemetry]
         ENGINES[47 analysis engines<br/>+ 1 export module<br/>src/analytics/ + src/export/]
         MATERIALIZER[Async materializer<br/>asyncio.Task · Semaphore(1)<br/>ProcessPoolExecutor spawn<br/>src/materializer/]
         MCP[MCP server<br/>22 tools · stdio + http + sse<br/>src/mcp_server.py]
@@ -296,7 +296,7 @@ Supports universal ERP fields per AACE RP 10S-90, ANSI/EIA-748, ISO 21511, with 
 
 ## Catalogs & references
 
-- [API Reference](api-reference.md) — auto-generated from FastAPI app (121 endpoints × 23 routers)
+- [API Reference](api-reference.md) — auto-generated from FastAPI app (123 endpoints × 24 routers)
 - [Methodologies](methodologies.md) — auto-generated from engine docstrings (47 engines + citations)
 - [MCP Tools](mcp-tools.md) — auto-generated from `@mcp.tool()` decorators (22 tools)
 - [Deploy Checklist](DEPLOY_CHECKLIST.md) — 5-phase procedure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,13 +41,13 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-api = ["fastapi>=0.136", "uvicorn[standard]>=0.46", "slowapi>=0.1.9"]
+api = ["fastapi>=0.136", "uvicorn[standard]>=0.46", "slowapi>=0.1.9", "psutil>=5.9"]
 export = ["pandas>=2.2", "openpyxl>=3.1"]
 reports = ["weasyprint>=62.0"]
 ai = ["anthropic>=0.97"]
 ml = ["scikit-learn>=1.8"]
 mcp = ["mcp>=1.20"]
-dev = ["pytest>=9.0.3", "pytest-cov>=7.1", "ruff>=0.15.12", "mypy>=1.20", "httpx>=0.27", "slowapi>=0.1.9"]
+dev = ["pytest>=9.0.3", "pytest-cov>=7.1", "ruff>=0.15.12", "mypy>=1.20", "httpx>=0.27", "slowapi>=0.1.9", "psutil>=5.9"]
 all = ["meridianiq[api,export,reports,ai,ml,mcp,dev]"]
 
 [tool.hatch.build.targets.wheel]

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -126,6 +126,7 @@ from .routers.bi import router as bi_router  # noqa: E402
 from .routers.plugins import router as plugins_router  # noqa: E402
 from .routers.ws import router as ws_router  # noqa: E402
 from .routers.lifecycle import router as lifecycle_router  # noqa: E402
+from .routers.observability import router as observability_router  # noqa: E402
 
 # Discover third-party analysis-engine plugins at startup so the registry
 # is populated by the time the first request hits /api/v1/plugins.
@@ -156,6 +157,7 @@ app.include_router(bi_router)
 app.include_router(plugins_router)
 app.include_router(ws_router)
 app.include_router(lifecycle_router)
+app.include_router(observability_router)
 
 
 @app.exception_handler(Exception)

--- a/src/api/auth.py
+++ b/src/api/auth.py
@@ -15,7 +15,7 @@ import hashlib
 import logging
 import secrets
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
 
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -119,7 +119,7 @@ def require_auth(user: Optional[dict] = Depends(get_current_user)) -> dict:
     return user
 
 
-def _is_superadmin(user: dict) -> bool:
+def _is_superadmin(user: dict[str, Any]) -> bool:
     """Return True if the authenticated user is a SuperAdmin.
 
     SuperAdmin is the top of the 5-tier role hierarchy
@@ -161,7 +161,7 @@ def _is_superadmin(user: dict) -> bool:
     return False
 
 
-def require_superadmin(user: dict = Depends(require_auth)) -> dict:
+def require_superadmin(user: dict[str, Any] = Depends(require_auth)) -> dict[str, Any]:
     """Dependency that requires the caller to be a SuperAdmin.
 
     Layered on top of ``require_auth`` — first proves authentication

--- a/src/api/auth.py
+++ b/src/api/auth.py
@@ -119,6 +119,65 @@ def require_auth(user: Optional[dict] = Depends(get_current_user)) -> dict:
     return user
 
 
+def _is_superadmin(user: dict) -> bool:
+    """Return True if the authenticated user is a SuperAdmin.
+
+    SuperAdmin is the top of the 5-tier role hierarchy
+    (SuperAdmin → Enterprise → Program → Project → Contract).  Today
+    it is env-gated via ``SUPERADMIN_USER_IDS`` (comma-separated
+    Supabase user UUIDs) and/or ``SUPERADMIN_EMAILS`` (comma-separated
+    case-insensitive emails).  A future Tier-model migration will
+    replace this primitive with a DB-backed ``users.tier`` column.
+
+    Fail-closed: if neither env var is set, no user is SuperAdmin.
+
+    API-key callers are NEVER SuperAdmin in this primitive — even if
+    their ``user_id`` matches.  SuperAdmin actions must originate from
+    a session JWT (proves recent human auth via OAuth) so an exfil-
+    trated long-lived API key cannot be used to e.g. force a Fly
+    restart or read runtime memory of arbitrary other users' sessions.
+    """
+    import os
+
+    if user.get("role") == "api_key":
+        return False
+
+    ids_env = os.environ.get("SUPERADMIN_USER_IDS", "").strip()
+    emails_env = os.environ.get("SUPERADMIN_EMAILS", "").strip()
+    if not ids_env and not emails_env:
+        return False
+
+    if ids_env:
+        allowed_ids = {s.strip() for s in ids_env.split(",") if s.strip()}
+        if user.get("id") in allowed_ids:
+            return True
+
+    if emails_env:
+        allowed_emails = {s.strip().lower() for s in emails_env.split(",") if s.strip()}
+        user_email = (user.get("email") or "").strip().lower()
+        if user_email and user_email in allowed_emails:
+            return True
+
+    return False
+
+
+def require_superadmin(user: dict = Depends(require_auth)) -> dict:
+    """Dependency that requires the caller to be a SuperAdmin.
+
+    Layered on top of ``require_auth`` — first proves authentication
+    (raises 401 if no valid token), then proves SuperAdmin tier
+    (raises 403 if authenticated but not SuperAdmin).
+
+    See ``_is_superadmin`` for the env-gated allowlist contract.
+    """
+    if not _is_superadmin(user):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="SuperAdmin access required",
+        )
+    return user
+
+
 def optional_auth(
     request: Request,
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),

--- a/src/api/observability.py
+++ b/src/api/observability.py
@@ -1,0 +1,218 @@
+# MIT License
+# Copyright (c) 2026 Vitor Maia Rodovalho
+"""Runtime observability — process memory, CPU, GC, and uptime snapshot.
+
+Single source of truth for the ``/api/v1/admin/runtime`` endpoint and a
+throttled Sentry breadcrumb emitter wired into ``/health``.
+
+Designed to diagnose slow native-allocation leaks (numpy / scipy /
+Cairo / Pango) that accumulate across long-uptime Fly.io machines.
+The 2026-05-06 OOM incident on instance ``0800d09a69e258`` (idle Fly
+machine, ~40 days uptime, no user traffic) is the motivating event:
+without runtime telemetry, post-mortem of an OOM-killed Python process
+is opaque — the curve up to the kill is the only diagnostic, and it
+must be captured proactively because the dead process cannot tell you.
+"""
+
+from __future__ import annotations
+
+import gc
+import logging
+import os
+import sys
+import time
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# psutil is in the [api] extras (pyproject.toml).  Imported lazily so
+# this module loads even when [api] is not installed (test envs).
+# Stubs not shipped with psutil — types-psutil is unmaintained, so we
+# accept the import-untyped at this single boundary.
+try:
+    import psutil  # type: ignore[import-untyped]
+
+    _PSUTIL_AVAILABLE = True
+    _PROCESS: "psutil.Process | None" = psutil.Process()
+except ImportError:  # pragma: no cover — exercised via monkeypatch in tests
+    psutil = None
+    _PSUTIL_AVAILABLE = False
+    _PROCESS = None
+
+
+# Process start time captured at module import — i.e., when uvicorn
+# imports the FastAPI app.  Wall-clock for the boot timestamp,
+# monotonic for uptime accounting (immune to NTP / clock drift).
+_BOOT_TS_WALL = time.time()
+_BOOT_TS_MONO = time.monotonic()
+
+# Throttle for Sentry breadcrumb emission from /health.  Module-level
+# state — process-local, NOT shared across Fly machines.  That is
+# intentional: each machine has its own memory leak curve to track.
+_BREADCRUMB_INTERVAL_SECONDS = float(os.environ.get("RUNTIME_BREADCRUMB_INTERVAL_SECONDS", "300"))
+_last_breadcrumb_mono: float = 0.0
+
+
+def _read_version() -> str:
+    """Best-effort meridianiq version string.
+
+    Falls back through env → importlib.metadata → ``"unknown"`` so the
+    snapshot ALWAYS returns a usable value.  Mirrors the
+    ``src.api.app._RELEASE`` resolution chain.
+    """
+    if version := os.environ.get("FLY_RELEASE_VERSION"):
+        return str(version)
+    try:
+        import importlib.metadata as md
+
+        return md.version("meridianiq")
+    except Exception:  # noqa: BLE001 — best-effort
+        return "unknown"
+
+
+def _active_ws_channels() -> int:
+    """Count of currently-open WebSocket progress channels.
+
+    Returns 0 if the progress module is unimportable (defensive — a
+    diagnostic helper must NEVER raise, otherwise the snapshot
+    endpoint becomes unreliable as a leak-curve probe).
+    """
+    try:
+        from src.api.progress import channel_count
+
+        return channel_count()
+    except Exception:  # noqa: BLE001 — diagnostic must not raise
+        return 0
+
+
+def _rate_limit_buckets() -> int:
+    """Best-effort bucket count of slowapi's MemoryStorage.
+
+    ``limits.storage.memory.MemoryStorage`` exposes a public
+    ``.storage`` attribute (a ``collections.Counter``).  This count
+    is a coarse leak indicator — under normal load it stays low; a
+    runaway IP allowlist would show as continuous growth here.
+    """
+    try:
+        from src.api.deps import limiter
+
+        storage = getattr(limiter, "_storage", None)
+        if storage is None:
+            return 0
+        backing = getattr(storage, "storage", None)
+        if backing is None:
+            return 0
+        return len(backing)
+    except Exception:  # noqa: BLE001 — diagnostic must not raise
+        return 0
+
+
+def get_runtime_snapshot() -> dict[str, Any]:
+    """Return a JSON-serialisable snapshot of process runtime state.
+
+    Fields (all numeric defaults to 0 on introspection failure):
+
+    - ``memory_rss_mb``  Resident set size — load-bearing leak metric
+    - ``memory_vms_mb``  Virtual memory — diverges from RSS on fork
+                         (signals subprocess presence; e.g.
+                         materializer ProcessPoolExecutor spawn)
+    - ``cpu_percent``    CPU % since the previous probe (first call
+                         always reads 0 by psutil contract)
+    - ``cpu_count``      Number of vCPUs visible to the process
+    - ``process_uptime_seconds``  Monotonic seconds since module import
+    - ``boot_time_iso``  ISO-8601 wall-clock at module import (UTC)
+    - ``gc_counts``      Python GC generation counts ``[g0, g1, g2]``
+    - ``version``        meridianiq version string
+    - ``environment``    ``ENVIRONMENT`` env (production / development)
+    - ``python_version`` ``major.minor.micro``
+    - ``active_ws_channels``  Open WebSocket progress channels
+    - ``rate_limit_buckets``  Estimate of slowapi MemoryStorage size
+    - ``psutil_available``    True if psutil is importable
+    """
+    snapshot: dict[str, Any] = {
+        "memory_rss_mb": 0.0,
+        "memory_vms_mb": 0.0,
+        "cpu_percent": 0.0,
+        "cpu_count": os.cpu_count() or 1,
+        "process_uptime_seconds": time.monotonic() - _BOOT_TS_MONO,
+        "boot_time_iso": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(_BOOT_TS_WALL)),
+        "gc_counts": list(gc.get_count()),
+        "version": _read_version(),
+        "environment": os.environ.get("ENVIRONMENT", "development"),
+        "python_version": (
+            f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+        ),
+        "active_ws_channels": _active_ws_channels(),
+        "rate_limit_buckets": _rate_limit_buckets(),
+        "psutil_available": _PSUTIL_AVAILABLE,
+    }
+
+    if _PSUTIL_AVAILABLE and _PROCESS is not None:
+        try:
+            mem = _PROCESS.memory_info()
+            snapshot["memory_rss_mb"] = round(mem.rss / (1024 * 1024), 1)
+            snapshot["memory_vms_mb"] = round(mem.vms / (1024 * 1024), 1)
+            # ``cpu_percent(interval=None)`` returns % since last call;
+            # first invocation per process always reads 0.0 (psutil
+            # contract), which is fine — subsequent calls give signal.
+            snapshot["cpu_percent"] = _PROCESS.cpu_percent(interval=None)
+        except Exception as exc:  # noqa: BLE001 — diagnostic must not raise
+            logger.warning("psutil snapshot failed: %s", exc)
+
+    return snapshot
+
+
+def maybe_emit_breadcrumb() -> bool:
+    """Throttled Sentry breadcrumb + INFO log of the runtime snapshot.
+
+    Designed to be called from the ``/health`` endpoint on every probe.
+    Emits at most once per ``RUNTIME_BREADCRUMB_INTERVAL_SECONDS``
+    (default 300s) per process.  Returns True iff a breadcrumb was
+    emitted on this call (used by tests).
+
+    Defensive: any failure during emission is swallowed.  Health
+    endpoint correctness is more important than breadcrumb correctness.
+    """
+    global _last_breadcrumb_mono
+    now = time.monotonic()
+    if now - _last_breadcrumb_mono < _BREADCRUMB_INTERVAL_SECONDS:
+        return False
+    _last_breadcrumb_mono = now
+
+    try:
+        snapshot = get_runtime_snapshot()
+        # INFO log preserves a trail in Fly logs even when Sentry is
+        # disabled (e.g., dev) — independently of breadcrumb capture.
+        logger.info(
+            "runtime_snapshot rss_mb=%s vms_mb=%s uptime_s=%s ws=%s rl_buckets=%s",
+            snapshot["memory_rss_mb"],
+            snapshot["memory_vms_mb"],
+            int(snapshot["process_uptime_seconds"]),
+            snapshot["active_ws_channels"],
+            snapshot["rate_limit_buckets"],
+        )
+        try:
+            import sentry_sdk
+
+            sentry_sdk.add_breadcrumb(
+                category="runtime",
+                message="memory snapshot",
+                data=snapshot,
+                level="info",
+            )
+        except ImportError:
+            pass
+    except Exception as exc:  # noqa: BLE001 — must not break /health
+        logger.warning("breadcrumb emission failed: %s", exc)
+
+    return True
+
+
+def _reset_throttle_for_tests() -> None:
+    """Test-only helper to reset the breadcrumb throttle.
+
+    Lets a test trigger a fresh emission without sleeping for 5 minutes.
+    NOT exported in ``__all__``; tests reach in via the leading underscore.
+    """
+    global _last_breadcrumb_mono
+    _last_breadcrumb_mono = 0.0

--- a/src/api/observability.py
+++ b/src/api/observability.py
@@ -29,15 +29,22 @@ logger = logging.getLogger(__name__)
 # this module loads even when [api] is not installed (test envs).
 # Stubs not shipped with psutil — types-psutil is unmaintained, so we
 # accept the import-untyped at this single boundary.
+#
+# DA fix-up #P2 (PR #71): the inner ``Process()`` call can raise
+# ``psutil.AccessDenied`` on hardened containers (rare but documented),
+# which is NOT an ImportError.  Catch broadly at module-init only —
+# correctness of /health and /api/v1/superadmin/runtime must not depend
+# on psutil being usable, only on the FastAPI app booting cleanly.
+psutil: Any = None
+_PSUTIL_AVAILABLE = False
+_PROCESS: Any = None
 try:
-    import psutil  # type: ignore[import-untyped]
+    import psutil  # type: ignore[import-untyped,no-redef]  # noqa: F811
 
+    _PROCESS = psutil.Process()
     _PSUTIL_AVAILABLE = True
-    _PROCESS: "psutil.Process | None" = psutil.Process()
-except ImportError:  # pragma: no cover — exercised via monkeypatch in tests
-    psutil = None
-    _PSUTIL_AVAILABLE = False
-    _PROCESS = None
+except Exception:  # noqa: BLE001 — module-init MUST NOT brick startup
+    pass
 
 
 # Process start time captured at module import — i.e., when uvicorn
@@ -46,10 +53,40 @@ except ImportError:  # pragma: no cover — exercised via monkeypatch in tests
 _BOOT_TS_WALL = time.time()
 _BOOT_TS_MONO = time.monotonic()
 
+
+def _read_breadcrumb_interval_env() -> float:
+    """Parse ``RUNTIME_BREADCRUMB_INTERVAL_SECONDS`` env safely.
+
+    DA fix-up #P1 (PR #71): the original implementation called
+    ``float(os.environ.get(..., "300"))`` directly at module-import.
+    A non-numeric env value (operator typo, shell expansion artifact,
+    stray ``=`` line in a ``.env``) would raise ``ValueError`` during
+    FastAPI app boot — bricking the entire deploy at the worst possible
+    time (the next OOM-class incident this primitive exists to diagnose).
+
+    Fail-safe contract: bad input → default 300s + WARNING log.
+    Below-minimum input → clamp to 5s + WARNING log.  Valid input → as-is.
+    """
+    raw = os.environ.get("RUNTIME_BREADCRUMB_INTERVAL_SECONDS", "300")
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "RUNTIME_BREADCRUMB_INTERVAL_SECONDS=%r non-numeric; using default 300s", raw
+        )
+        return 300.0
+    if value < 5.0:
+        logger.warning(
+            "RUNTIME_BREADCRUMB_INTERVAL_SECONDS=%s below 5s minimum; clamping to 5s", value
+        )
+        return 5.0
+    return value
+
+
 # Throttle for Sentry breadcrumb emission from /health.  Module-level
 # state — process-local, NOT shared across Fly machines.  That is
 # intentional: each machine has its own memory leak curve to track.
-_BREADCRUMB_INTERVAL_SECONDS = float(os.environ.get("RUNTIME_BREADCRUMB_INTERVAL_SECONDS", "300"))
+_BREADCRUMB_INTERVAL_SECONDS = _read_breadcrumb_interval_env()
 _last_breadcrumb_mono: float = 0.0
 
 
@@ -112,12 +149,14 @@ def get_runtime_snapshot() -> dict[str, Any]:
 
     Fields (all numeric defaults to 0 on introspection failure):
 
+    - ``pid``            ``os.getpid()`` of the snapshotting process
     - ``memory_rss_mb``  Resident set size — load-bearing leak metric
     - ``memory_vms_mb``  Virtual memory — diverges from RSS on fork
                          (signals subprocess presence; e.g.
                          materializer ProcessPoolExecutor spawn)
     - ``cpu_percent``    CPU % since the previous probe (first call
-                         always reads 0 by psutil contract)
+                         always reads 0 by psutil contract — second
+                         and later calls give meaningful signal)
     - ``cpu_count``      Number of vCPUs visible to the process
     - ``process_uptime_seconds``  Monotonic seconds since module import
     - ``boot_time_iso``  ISO-8601 wall-clock at module import (UTC)
@@ -128,8 +167,21 @@ def get_runtime_snapshot() -> dict[str, Any]:
     - ``active_ws_channels``  Open WebSocket progress channels
     - ``rate_limit_buckets``  Estimate of slowapi MemoryStorage size
     - ``psutil_available``    True if psutil is importable
+
+    DA fix-up #P2 (PR #71): the module-level ``_PROCESS`` handle is
+    captured at import time and points at the importing process's PID.
+    If a future caller imports this module inside a ``ProcessPoolExecutor
+    spawn`` worker (e.g., calibration harness, materializer subprocess),
+    a stale ``_PROCESS`` would silently report subprocess RSS while the
+    operator believed it was parent RSS.  The PID self-correct below
+    re-acquires ``_PROCESS`` if it drifts, making subprocess use both
+    visible (via the ``pid`` field) and self-healing.
     """
+    global _PROCESS
+
+    current_pid = os.getpid()
     snapshot: dict[str, Any] = {
+        "pid": current_pid,
         "memory_rss_mb": 0.0,
         "memory_vms_mb": 0.0,
         "cpu_percent": 0.0,
@@ -147,14 +199,16 @@ def get_runtime_snapshot() -> dict[str, Any]:
         "psutil_available": _PSUTIL_AVAILABLE,
     }
 
-    if _PSUTIL_AVAILABLE and _PROCESS is not None:
+    if _PSUTIL_AVAILABLE and _PROCESS is not None and psutil is not None:
         try:
+            # Self-correct after fork / spawn — if the captured handle's
+            # PID drifted from the running process, re-acquire so the
+            # snapshot reports THIS process, not the parent that imported.
+            if _PROCESS.pid != current_pid:
+                _PROCESS = psutil.Process(current_pid)
             mem = _PROCESS.memory_info()
             snapshot["memory_rss_mb"] = round(mem.rss / (1024 * 1024), 1)
             snapshot["memory_vms_mb"] = round(mem.vms / (1024 * 1024), 1)
-            # ``cpu_percent(interval=None)`` returns % since last call;
-            # first invocation per process always reads 0.0 (psutil
-            # contract), which is fine — subsequent calls give signal.
             snapshot["cpu_percent"] = _PROCESS.cpu_percent(interval=None)
         except Exception as exc:  # noqa: BLE001 — diagnostic must not raise
             logger.warning("psutil snapshot failed: %s", exc)
@@ -213,6 +267,13 @@ def _reset_throttle_for_tests() -> None:
 
     Lets a test trigger a fresh emission without sleeping for 5 minutes.
     NOT exported in ``__all__``; tests reach in via the leading underscore.
+
+    DA fix-up #P1 (PR #71) follow-up: setting to ``0.0`` is unsafe because
+    ``time.monotonic()`` is "seconds since some unspecified start" — in a
+    freshly-booted Python process (e.g., CI runner) the value can be < 300s,
+    so ``now - 0.0 < _BREADCRUMB_INTERVAL_SECONDS`` and the next call would
+    NOT fire.  Setting to ``float("-inf")`` makes the next call fire
+    deterministically regardless of monotonic baseline.
     """
     global _last_breadcrumb_mono
-    _last_breadcrumb_mono = 0.0
+    _last_breadcrumb_mono = float("-inf")

--- a/src/api/routers/health.py
+++ b/src/api/routers/health.py
@@ -6,13 +6,18 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
+from ..observability import maybe_emit_breadcrumb
 from ..schemas import HealthResponse
 
 router = APIRouter()
 
 
 @router.get("/health")
-async def root_health():
+async def root_health() -> dict[str, str]:
+    # Throttled at 5 min by default — see ``observability.maybe_emit_breadcrumb``.
+    # Captures the runtime snapshot into Sentry breadcrumbs + INFO log so the
+    # leak curve is observable without a separate background task pattern.
+    maybe_emit_breadcrumb()
     return {"status": "ok", "version": "1.0.0-dev"}
 
 

--- a/src/api/routers/observability.py
+++ b/src/api/routers/observability.py
@@ -1,0 +1,53 @@
+# MIT License
+# Copyright (c) 2026 Vitor Maia Rodovalho
+"""Runtime observability router — SuperAdmin-gated diagnostic endpoint.
+
+Exposes the on-demand snapshot returned by
+``src.api.observability.get_runtime_snapshot`` so an operator can probe
+the live process state during a leak investigation, an OOM post-mortem
+follow-up, or routine health checks.
+
+The endpoint is intentionally separate from ``src/api/routers/admin.py``
+(which is user-self-service: API keys, GDPR deletion, IPS reconciliation)
+because this surface is gated by a **different role tier** — SuperAdmin
+only — and conflating the two would tempt a future refactor to relax
+the gate.
+
+See ``project_role_hierarchy.md`` (memory) for the 5-tier model
+(SuperAdmin → Enterprise → Program → Project → Contract) this endpoint
+participates in. Today the model is env-gated; a future Tier-model
+migration will replace the env primitive with a DB-backed contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, Request
+
+from ..auth import require_superadmin
+from ..deps import RATE_LIMIT_LIGHT, limiter
+from ..observability import get_runtime_snapshot
+from ..schemas import RuntimeSnapshot
+
+router = APIRouter()
+
+
+@router.get("/api/v1/admin/runtime", response_model=RuntimeSnapshot)
+@limiter.limit(RATE_LIMIT_LIGHT)
+def runtime_snapshot_endpoint(
+    request: Request,
+    _user: dict[str, Any] = Depends(require_superadmin),
+) -> RuntimeSnapshot:
+    """Return a snapshot of process runtime state (SuperAdmin only).
+
+    Use cases:
+    - Live probe during a leak investigation
+    - OOM post-mortem context (curve up to the kill is on Sentry / logs)
+    - Routine ops check before an operator action (e.g., re-mat job)
+
+    Rate-limited under ``RATE_LIMIT_LIGHT`` to match other read endpoints
+    — diagnostic value falls off rapidly past once-per-second polling.
+    """
+    snapshot = get_runtime_snapshot()
+    return RuntimeSnapshot(**snapshot)

--- a/src/api/routers/observability.py
+++ b/src/api/routers/observability.py
@@ -7,16 +7,33 @@ Exposes the on-demand snapshot returned by
 the live process state during a leak investigation, an OOM post-mortem
 follow-up, or routine health checks.
 
-The endpoint is intentionally separate from ``src/api/routers/admin.py``
-(which is user-self-service: API keys, GDPR deletion, IPS reconciliation)
-because this surface is gated by a **different role tier** — SuperAdmin
-only — and conflating the two would tempt a future refactor to relax
-the gate.
+## Path namespace
 
-See ``project_role_hierarchy.md`` (memory) for the 5-tier model
-(SuperAdmin → Enterprise → Program → Project → Contract) this endpoint
-participates in. Today the model is env-gated; a future Tier-model
-migration will replace the env primitive with a DB-backed contract.
+The endpoint lives at ``/api/v1/superadmin/runtime`` — NOT under
+``/api/v1/admin/*`` — because the existing admin router contains
+user-self-service endpoints (API keys, GDPR data deletion, IPS
+reconciliation) that are NOT SuperAdmin-gated. Conflating tiers under
+the same prefix would tempt a future refactor to relax this gate.
+The path itself is the load-bearing security signal, not just the
+docstring.
+
+## 5-tier role model (destination architecture)
+
+MeridianIQ's auth model targets a 5-level hierarchy, top-down:
+
+```
+SuperAdmin                 (single — maintainer)
+   └── Enterprise          (organization / company / GC firm)
+          └── Program      (portfolio of projects)
+                 └── Project    (single construction project)
+                        └── Contract   (subcontract / scope-of-work)
+```
+
+Today the codebase is single-tenant Project-scoped with flat
+``project_owners``; the Tier-model migration is a Cycle 4+ deliverable.
+SuperAdmin is currently env-gated (``SUPERADMIN_USER_IDS`` /
+``SUPERADMIN_EMAILS``) — the smallest committable surface that gates
+this endpoint TODAY without prejudging the destination contract.
 """
 
 from __future__ import annotations
@@ -33,7 +50,7 @@ from ..schemas import RuntimeSnapshot
 router = APIRouter()
 
 
-@router.get("/api/v1/admin/runtime", response_model=RuntimeSnapshot)
+@router.get("/api/v1/superadmin/runtime", response_model=RuntimeSnapshot)
 @limiter.limit(RATE_LIMIT_LIGHT)
 def runtime_snapshot_endpoint(
     request: Request,
@@ -46,8 +63,15 @@ def runtime_snapshot_endpoint(
     - OOM post-mortem context (curve up to the kill is on Sentry / logs)
     - Routine ops check before an operator action (e.g., re-mat job)
 
-    Rate-limited under ``RATE_LIMIT_LIGHT`` to match other read endpoints
-    — diagnostic value falls off rapidly past once-per-second polling.
+    Rate-limited under ``RATE_LIMIT_LIGHT`` (60/min) — sufficient for
+    once-per-second polling during an active incident.  Diagnostic value
+    falls off rapidly past 1Hz; if more aggressive sampling is ever
+    required, prefer Sentry profiling over endpoint polling.
+
+    Note on ``cpu_percent``: psutil's contract is that the FIRST call
+    per process always returns 0.0 (it baselines off the previous call).
+    Operators interpreting an active incident should call twice with a
+    short delay; the second value is meaningful.
     """
     snapshot = get_runtime_snapshot()
     return RuntimeSnapshot(**snapshot)

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -1819,3 +1819,35 @@ class PendingStatusesResponse(BaseModel):
 
     items: list[PendingStatusItem] = Field(default_factory=list)
     polled_at: Optional[str] = None
+
+
+# ── Runtime observability (D-tier ops instrumentation) ───
+
+
+class RuntimeSnapshot(BaseModel):
+    """Response for GET /api/v1/admin/runtime — process runtime state.
+
+    SuperAdmin-gated diagnostic. Captures the leak-curve metrics that
+    were missing during the 2026-05-06 OOM post-mortem (idle 40-day
+    Fly machine, no user traffic, 1024mb cgroup limit). Pairs with
+    the throttled Sentry breadcrumb emitter wired into ``/health``.
+
+    See ``src.api.observability.get_runtime_snapshot`` for the field
+    contract — all numeric fields default to 0 if introspection fails
+    (the diagnostic must NEVER raise, as that would mask the very
+    OOM-class issues it is meant to surface).
+    """
+
+    memory_rss_mb: float = 0.0
+    memory_vms_mb: float = 0.0
+    cpu_percent: float = 0.0
+    cpu_count: int = 1
+    process_uptime_seconds: float = 0.0
+    boot_time_iso: str = ""
+    gc_counts: list[int] = Field(default_factory=list)
+    version: str = "unknown"
+    environment: str = "development"
+    python_version: str = ""
+    active_ws_channels: int = 0
+    rate_limit_buckets: int = 0
+    psutil_available: bool = False

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 # ── Health ───────────────────────────────────────────────
@@ -1825,7 +1825,7 @@ class PendingStatusesResponse(BaseModel):
 
 
 class RuntimeSnapshot(BaseModel):
-    """Response for GET /api/v1/admin/runtime — process runtime state.
+    """Response for GET /api/v1/superadmin/runtime — process runtime state.
 
     SuperAdmin-gated diagnostic. Captures the leak-curve metrics that
     were missing during the 2026-05-06 OOM post-mortem (idle 40-day
@@ -1836,11 +1836,34 @@ class RuntimeSnapshot(BaseModel):
     contract — all numeric fields default to 0 if introspection fails
     (the diagnostic must NEVER raise, as that would mask the very
     OOM-class issues it is meant to surface).
+
+    DA fix-up #P5 (PR #71): the model validator below asserts that
+    ``psutil_available=True`` AND ``memory_rss_mb=0.0`` is an impossible
+    state — psutil's contract says a live Python process's RSS is
+    always > 0. If both hold, the defensive try/except in the
+    snapshot helper silently swallowed a real failure; surfacing as
+    HTTP 500 lets the operator catch it.
     """
 
-    memory_rss_mb: float = 0.0
+    pid: int = 0
+    memory_rss_mb: float = Field(
+        default=0.0,
+        description=(
+            "Resident set size in MB. Load-bearing leak metric. "
+            "0.0 with psutil_available=True is an impossible state and "
+            "raises a model-validation error."
+        ),
+    )
     memory_vms_mb: float = 0.0
-    cpu_percent: float = 0.0
+    cpu_percent: float = Field(
+        default=0.0,
+        description=(
+            "CPU %% since the previous probe. By psutil contract the "
+            "FIRST invocation per process always reads 0.0; subsequent "
+            "calls give meaningful signal. Operators should call twice "
+            "with a delay between them when interpreting CPU pressure."
+        ),
+    )
     cpu_count: int = 1
     process_uptime_seconds: float = 0.0
     boot_time_iso: str = ""
@@ -1851,3 +1874,13 @@ class RuntimeSnapshot(BaseModel):
     active_ws_channels: int = 0
     rate_limit_buckets: int = 0
     psutil_available: bool = False
+
+    @model_validator(mode="after")
+    def _check_psutil_coherence(self) -> "RuntimeSnapshot":
+        if self.psutil_available and self.memory_rss_mb <= 0:
+            raise ValueError(
+                "psutil_available=True but memory_rss_mb<=0 — impossible state, "
+                "psutil snapshot path failed silently. Inspect WARNING logs "
+                "for the underlying psutil exception."
+            )
+        return self

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -116,3 +116,102 @@ def test_invalid_token_raises_401():
     with pytest.raises(HTTPException) as exc_info:
         get_current_user(creds)
     assert exc_info.value.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# SuperAdmin tier (env-gated allowlist) — the 5-tier role model primitive.
+# Today: SUPERADMIN_USER_IDS / SUPERADMIN_EMAILS env vars.
+# Future: replaced by a DB-backed users.tier column once the Tier-model
+# migration ships.  See project_role_hierarchy.md (memory).
+# ---------------------------------------------------------------------------
+
+
+def test_is_superadmin_fail_closed_when_no_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SUPERADMIN_USER_IDS", raising=False)
+    monkeypatch.delenv("SUPERADMIN_EMAILS", raising=False)
+    from src.api.auth import _is_superadmin
+
+    assert (
+        _is_superadmin({"id": "any-id", "email": "any@example.com", "role": "authenticated"})
+        is False
+    )
+
+
+def test_is_superadmin_id_match(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SUPERADMIN_USER_IDS", "alice-id,bob-id")
+    monkeypatch.delenv("SUPERADMIN_EMAILS", raising=False)
+    from src.api.auth import _is_superadmin
+
+    assert _is_superadmin({"id": "alice-id", "email": "x@y.com", "role": "authenticated"}) is True
+    assert _is_superadmin({"id": "carol-id", "email": "x@y.com", "role": "authenticated"}) is False
+
+
+def test_is_superadmin_email_match_case_insensitive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SUPERADMIN_EMAILS", "Alice@Example.com")
+    monkeypatch.delenv("SUPERADMIN_USER_IDS", raising=False)
+    from src.api.auth import _is_superadmin
+
+    assert (
+        _is_superadmin({"id": "x", "email": "alice@example.com", "role": "authenticated"}) is True
+    )
+    assert (
+        _is_superadmin({"id": "x", "email": "ALICE@EXAMPLE.COM", "role": "authenticated"}) is True
+    )
+    assert _is_superadmin({"id": "x", "email": "bob@example.com", "role": "authenticated"}) is False
+
+
+def test_is_superadmin_api_key_role_denied_even_if_id_matches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Security: API-key callers MUST NOT be SuperAdmin.
+
+    Long-lived programmatic credentials are higher-risk and an exfiltrated
+    key would otherwise grant SuperAdmin access.  The role check is the
+    structural guard.
+    """
+    monkeypatch.setenv("SUPERADMIN_USER_IDS", "alice-id")
+    from src.api.auth import _is_superadmin
+
+    assert (
+        _is_superadmin({"id": "alice-id", "email": "alice@example.com", "role": "api_key"}) is False
+    )
+    # Same user, session-class JWT — DOES pass.
+    assert (
+        _is_superadmin({"id": "alice-id", "email": "alice@example.com", "role": "authenticated"})
+        is True
+    )
+
+
+def test_is_superadmin_handles_empty_env_strings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty strings (deliberate ops misconfig) must NOT promote anyone."""
+    monkeypatch.setenv("SUPERADMIN_USER_IDS", "  ")
+    monkeypatch.setenv("SUPERADMIN_EMAILS", "")
+    from src.api.auth import _is_superadmin
+
+    assert _is_superadmin({"id": "any", "email": "any@x.com", "role": "authenticated"}) is False
+
+
+def test_require_superadmin_raises_403_when_not_super(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SUPERADMIN_USER_IDS", raising=False)
+    monkeypatch.delenv("SUPERADMIN_EMAILS", raising=False)
+    from src.api.auth import require_superadmin
+
+    user = {"id": "alice-id", "email": "alice@example.com", "role": "authenticated"}
+    with pytest.raises(HTTPException) as exc_info:
+        require_superadmin(user=user)
+    assert exc_info.value.status_code == 403
+
+
+def test_require_superadmin_passes_when_super(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SUPERADMIN_USER_IDS", "alice-id")
+    from src.api.auth import require_superadmin
+
+    user = {"id": "alice-id", "email": "alice@example.com", "role": "authenticated"}
+    result = require_superadmin(user=user)
+    assert result == user

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -10,6 +10,8 @@ tests pin that invariant.
 
 from __future__ import annotations
 
+import logging
+import os
 import time
 
 import pytest
@@ -20,6 +22,7 @@ from src.api import observability
 def test_get_runtime_snapshot_returns_dict_with_expected_keys() -> None:
     snapshot = observability.get_runtime_snapshot()
     expected_keys = {
+        "pid",
         "memory_rss_mb",
         "memory_vms_mb",
         "cpu_percent",
@@ -39,6 +42,8 @@ def test_get_runtime_snapshot_returns_dict_with_expected_keys() -> None:
 
 def test_get_runtime_snapshot_field_types() -> None:
     snapshot = observability.get_runtime_snapshot()
+    assert isinstance(snapshot["pid"], int)
+    assert snapshot["pid"] > 0
     assert isinstance(snapshot["memory_rss_mb"], float)
     assert isinstance(snapshot["memory_vms_mb"], float)
     assert isinstance(snapshot["cpu_percent"], float)
@@ -53,6 +58,12 @@ def test_get_runtime_snapshot_field_types() -> None:
     assert isinstance(snapshot["active_ws_channels"], int)
     assert isinstance(snapshot["rate_limit_buckets"], int)
     assert isinstance(snapshot["psutil_available"], bool)
+
+
+def test_pid_matches_current_process() -> None:
+    """The reported PID is the process running this test, not the import-time PID."""
+    snapshot = observability.get_runtime_snapshot()
+    assert snapshot["pid"] == os.getpid()
 
 
 def test_psutil_fields_populated_when_available() -> None:
@@ -127,10 +138,16 @@ def test_maybe_emit_breadcrumb_after_reset_unblocks() -> None:
 
 def test_maybe_emit_breadcrumb_swallows_snapshot_failure(
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """If get_runtime_snapshot raises, breadcrumb emission must NOT propagate.
+    """If get_runtime_snapshot raises, breadcrumb emission must NOT propagate
+    — but the WARNING log MUST fire, otherwise the leak-class failure that
+    the diagnostic exists to surface would be silently swallowed forever.
 
-    /health endpoint correctness is the load-bearing invariant.
+    DA fix-up #P2 (PR #71): the original test only asserted ``result is True``,
+    pinning the wrong invariant. The asserted logger.warning call is what
+    keeps the next OOM investigation from finding the same diagnostic
+    darkness as the 2026-05-06 incident.
     """
     observability._reset_throttle_for_tests()
 
@@ -138,12 +155,92 @@ def test_maybe_emit_breadcrumb_swallows_snapshot_failure(
         raise RuntimeError("simulated psutil meltdown")
 
     monkeypatch.setattr(observability, "get_runtime_snapshot", _boom)
-    # Returns True (throttle was advanced) but did NOT raise.
-    result = observability.maybe_emit_breadcrumb()
+    with caplog.at_level(logging.WARNING, logger="src.api.observability"):
+        result = observability.maybe_emit_breadcrumb()
+
+    # Throttle advanced (the contract; tests would otherwise tight-loop).
     assert result is True
+    # The failure path MUST log a WARNING with the underlying exception.
+    matching = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING
+        and "breadcrumb emission failed" in r.getMessage()
+        and "simulated psutil meltdown" in r.getMessage()
+    ]
+    assert matching, (
+        "expected logger.warning('breadcrumb emission failed: ...') with the "
+        "underlying exception text — defensive code must remain VISIBLE in logs"
+    )
 
 
 def test_get_runtime_snapshot_version_is_non_empty() -> None:
     snapshot = observability.get_runtime_snapshot()
     assert snapshot["version"]
     assert snapshot["version"] != ""
+
+
+def test_read_breadcrumb_interval_env_default() -> None:
+    """Unset env returns the documented default 300s."""
+    import os
+
+    os.environ.pop("RUNTIME_BREADCRUMB_INTERVAL_SECONDS", None)
+    assert observability._read_breadcrumb_interval_env() == 300.0
+
+
+def test_read_breadcrumb_interval_env_non_numeric_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """DA fix-up #P1 (PR #71): non-numeric env must not brick startup."""
+    monkeypatch.setenv("RUNTIME_BREADCRUMB_INTERVAL_SECONDS", "5min")
+    with caplog.at_level(logging.WARNING, logger="src.api.observability"):
+        value = observability._read_breadcrumb_interval_env()
+    assert value == 300.0
+    assert any("non-numeric" in r.getMessage() for r in caplog.records)
+
+
+def test_read_breadcrumb_interval_env_clamps_below_minimum(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Below-5s values clamp to 5s with a warning — guards the Fly log /
+    Sentry quota during an active incident."""
+    monkeypatch.setenv("RUNTIME_BREADCRUMB_INTERVAL_SECONDS", "0")
+    with caplog.at_level(logging.WARNING, logger="src.api.observability"):
+        value = observability._read_breadcrumb_interval_env()
+    assert value == 5.0
+    assert any("below 5s minimum" in r.getMessage() for r in caplog.records)
+
+
+def test_read_breadcrumb_interval_env_negative_clamps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("RUNTIME_BREADCRUMB_INTERVAL_SECONDS", "-100")
+    assert observability._read_breadcrumb_interval_env() == 5.0
+
+
+def test_read_breadcrumb_interval_env_valid_passes_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("RUNTIME_BREADCRUMB_INTERVAL_SECONDS", "60")
+    assert observability._read_breadcrumb_interval_env() == 60.0
+
+
+def test_rate_limit_buckets_contract_pin() -> None:
+    """DA fix-up #P3 (PR #71): pin the slowapi private-internals contract.
+
+    ``_rate_limit_buckets`` reaches into ``limiter._storage.storage``.
+    A future slowapi bump that renames either layer would silently turn
+    this into 0 forever.  This test asserts the structure exists at the
+    expected path so a contract regression fails LOUDLY.
+    """
+    from src.api.deps import limiter
+
+    storage = getattr(limiter, "_storage", None)
+    assert storage is not None, "slowapi Limiter._storage missing — contract drift"
+    backing = getattr(storage, "storage", None)
+    assert backing is not None, "MemoryStorage.storage missing — contract drift"
+    assert hasattr(backing, "__len__"), (
+        "Expected dict-like backing (Counter); got something with no __len__"
+    )

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,149 @@
+# MIT License
+# Copyright (c) 2026 Vitor Maia Rodovalho
+"""Tests for src/api/observability.py — runtime snapshot + breadcrumb throttle.
+
+Covers the diagnostic primitive that pairs with the 2026-05-06 OOM
+incident response (Fly memory bump + admin/runtime endpoint).  The
+module's contract is "diagnostic helpers must NEVER raise" — these
+tests pin that invariant.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from src.api import observability
+
+
+def test_get_runtime_snapshot_returns_dict_with_expected_keys() -> None:
+    snapshot = observability.get_runtime_snapshot()
+    expected_keys = {
+        "memory_rss_mb",
+        "memory_vms_mb",
+        "cpu_percent",
+        "cpu_count",
+        "process_uptime_seconds",
+        "boot_time_iso",
+        "gc_counts",
+        "version",
+        "environment",
+        "python_version",
+        "active_ws_channels",
+        "rate_limit_buckets",
+        "psutil_available",
+    }
+    assert set(snapshot.keys()) == expected_keys
+
+
+def test_get_runtime_snapshot_field_types() -> None:
+    snapshot = observability.get_runtime_snapshot()
+    assert isinstance(snapshot["memory_rss_mb"], float)
+    assert isinstance(snapshot["memory_vms_mb"], float)
+    assert isinstance(snapshot["cpu_percent"], float)
+    assert isinstance(snapshot["cpu_count"], int)
+    assert isinstance(snapshot["process_uptime_seconds"], float)
+    assert isinstance(snapshot["boot_time_iso"], str)
+    assert isinstance(snapshot["gc_counts"], list)
+    assert all(isinstance(c, int) for c in snapshot["gc_counts"])
+    assert isinstance(snapshot["version"], str)
+    assert isinstance(snapshot["environment"], str)
+    assert isinstance(snapshot["python_version"], str)
+    assert isinstance(snapshot["active_ws_channels"], int)
+    assert isinstance(snapshot["rate_limit_buckets"], int)
+    assert isinstance(snapshot["psutil_available"], bool)
+
+
+def test_psutil_fields_populated_when_available() -> None:
+    """psutil is in the [api] / [dev] extras so this test env has it."""
+    snapshot = observability.get_runtime_snapshot()
+    assert snapshot["psutil_available"] is True
+    # RSS must be > 0 in any live Python process; 0 would indicate that
+    # the psutil branch failed silently (defensive try/except hid the bug).
+    assert snapshot["memory_rss_mb"] > 0
+    assert snapshot["memory_vms_mb"] > 0
+
+
+def test_uptime_monotonically_increases() -> None:
+    s1 = observability.get_runtime_snapshot()
+    time.sleep(0.01)
+    s2 = observability.get_runtime_snapshot()
+    assert s2["process_uptime_seconds"] > s1["process_uptime_seconds"]
+
+
+def test_python_version_format() -> None:
+    snapshot = observability.get_runtime_snapshot()
+    parts = snapshot["python_version"].split(".")
+    assert len(parts) == 3
+    assert all(p.isdigit() for p in parts)
+
+
+def test_boot_time_iso_format() -> None:
+    snapshot = observability.get_runtime_snapshot()
+    # ISO-8601 UTC "YYYY-MM-DDTHH:MM:SSZ"
+    boot = snapshot["boot_time_iso"]
+    assert len(boot) == 20
+    assert boot[4] == "-" and boot[7] == "-"
+    assert boot[10] == "T"
+    assert boot[-1] == "Z"
+
+
+def test_active_ws_channels_returns_non_negative_int() -> None:
+    """Defensive helper must NEVER raise — 0 on import failure is acceptable."""
+    n = observability._active_ws_channels()
+    assert isinstance(n, int)
+    assert n >= 0
+
+
+def test_rate_limit_buckets_returns_non_negative_int() -> None:
+    n = observability._rate_limit_buckets()
+    assert isinstance(n, int)
+    assert n >= 0
+
+
+def test_maybe_emit_breadcrumb_first_call_after_reset_returns_true() -> None:
+    observability._reset_throttle_for_tests()
+    assert observability.maybe_emit_breadcrumb() is True
+
+
+def test_maybe_emit_breadcrumb_throttle_blocks_within_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observability._reset_throttle_for_tests()
+    observability.maybe_emit_breadcrumb()
+    # Second call immediately after — must be blocked by throttle.
+    assert observability.maybe_emit_breadcrumb() is False
+    assert observability.maybe_emit_breadcrumb() is False
+
+
+def test_maybe_emit_breadcrumb_after_reset_unblocks() -> None:
+    observability._reset_throttle_for_tests()
+    observability.maybe_emit_breadcrumb()
+    assert observability.maybe_emit_breadcrumb() is False
+    observability._reset_throttle_for_tests()
+    assert observability.maybe_emit_breadcrumb() is True
+
+
+def test_maybe_emit_breadcrumb_swallows_snapshot_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If get_runtime_snapshot raises, breadcrumb emission must NOT propagate.
+
+    /health endpoint correctness is the load-bearing invariant.
+    """
+    observability._reset_throttle_for_tests()
+
+    def _boom() -> dict:
+        raise RuntimeError("simulated psutil meltdown")
+
+    monkeypatch.setattr(observability, "get_runtime_snapshot", _boom)
+    # Returns True (throttle was advanced) but did NOT raise.
+    result = observability.maybe_emit_breadcrumb()
+    assert result is True
+
+
+def test_get_runtime_snapshot_version_is_non_empty() -> None:
+    snapshot = observability.get_runtime_snapshot()
+    assert snapshot["version"]
+    assert snapshot["version"] != ""

--- a/tests/test_observability_router.py
+++ b/tests/test_observability_router.py
@@ -1,0 +1,176 @@
+# MIT License
+# Copyright (c) 2026 Vitor Maia Rodovalho
+"""Tests for src/api/routers/observability.py — /api/v1/admin/runtime endpoint.
+
+Covers:
+- Unauthenticated → 401
+- Authenticated but not SuperAdmin → 403
+- Authenticated SuperAdmin (env-allowlisted by user_id) → 200 + valid schema
+- Authenticated SuperAdmin (env-allowlisted by email) → 200
+- API-key role rejected even if user_id matches the env allowlist (security)
+- Response shape matches the RuntimeSnapshot Pydantic schema
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api.app import app
+
+_SECRET = "test-secret"
+_ALGORITHM = "HS256"
+
+
+def _make_token(
+    user_id: str = "user-uuid-1234",
+    email: str = "test@example.com",
+    role: str = "authenticated",
+) -> str:
+    payload: dict[str, Any] = {
+        "sub": user_id,
+        "email": email,
+        "role": role,
+        "aud": "authenticated",
+        "iat": int(time.time()) - 60,
+        "exp": int(time.time()) + 3600,
+    }
+    return jwt.encode(payload, _SECRET, algorithm=_ALGORITHM)
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _clear_superadmin_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default: no SuperAdmin envs.  Tests that need them set them explicitly."""
+    monkeypatch.delenv("SUPERADMIN_USER_IDS", raising=False)
+    monkeypatch.delenv("SUPERADMIN_EMAILS", raising=False)
+
+
+def test_runtime_endpoint_no_auth_returns_401(client: TestClient) -> None:
+    """No Authorization header in production-mode would 401 — but we test
+    the SuperAdmin gate which hits ``require_auth`` first.
+    """
+    resp = client.get("/api/v1/admin/runtime")
+    assert resp.status_code == 401
+
+
+def test_runtime_endpoint_authed_but_no_envs_returns_403(
+    client: TestClient,
+) -> None:
+    """Fail-closed: env vars unset → no user is SuperAdmin → 403."""
+    token = _make_token()
+    resp = client.get(
+        "/api/v1/admin/runtime",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 403
+    assert "superadmin" in resp.json()["detail"].lower()
+
+
+def test_runtime_endpoint_authed_id_mismatch_returns_403(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SUPERADMIN_USER_IDS", "different-id")
+    token = _make_token(user_id="user-uuid-1234")
+    resp = client.get(
+        "/api/v1/admin/runtime",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 403
+
+
+def test_runtime_endpoint_superadmin_via_user_id_returns_200(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SUPERADMIN_USER_IDS", "user-uuid-1234")
+    token = _make_token(user_id="user-uuid-1234")
+    resp = client.get(
+        "/api/v1/admin/runtime",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+
+
+def test_runtime_endpoint_superadmin_via_email_returns_200(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SUPERADMIN_EMAILS", "admin@example.com,test@example.com")
+    token = _make_token(email="test@example.com")
+    resp = client.get(
+        "/api/v1/admin/runtime",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+
+
+def test_runtime_endpoint_email_match_is_case_insensitive(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SUPERADMIN_EMAILS", "TEST@EXAMPLE.COM")
+    token = _make_token(email="test@example.com")
+    resp = client.get(
+        "/api/v1/admin/runtime",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+
+
+def test_runtime_endpoint_id_match_with_extra_emails_envset(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both envs set: ID-match alone is sufficient (OR semantics)."""
+    monkeypatch.setenv("SUPERADMIN_USER_IDS", "user-uuid-1234")
+    monkeypatch.setenv("SUPERADMIN_EMAILS", "different@example.com")
+    token = _make_token(user_id="user-uuid-1234", email="test@example.com")
+    resp = client.get(
+        "/api/v1/admin/runtime",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+
+
+def test_runtime_endpoint_response_shape(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SUPERADMIN_USER_IDS", "user-uuid-1234")
+    token = _make_token(user_id="user-uuid-1234")
+    resp = client.get(
+        "/api/v1/admin/runtime",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    expected_keys = {
+        "memory_rss_mb",
+        "memory_vms_mb",
+        "cpu_percent",
+        "cpu_count",
+        "process_uptime_seconds",
+        "boot_time_iso",
+        "gc_counts",
+        "version",
+        "environment",
+        "python_version",
+        "active_ws_channels",
+        "rate_limit_buckets",
+        "psutil_available",
+    }
+    assert set(body.keys()) == expected_keys
+    assert isinstance(body["memory_rss_mb"], float)
+    # In a live test process psutil should report > 0 RSS.
+    assert body["memory_rss_mb"] > 0
+    assert body["psutil_available"] is True

--- a/tests/test_observability_router.py
+++ b/tests/test_observability_router.py
@@ -1,6 +1,6 @@
 # MIT License
 # Copyright (c) 2026 Vitor Maia Rodovalho
-"""Tests for src/api/routers/observability.py — /api/v1/admin/runtime endpoint.
+"""Tests for src/api/routers/observability.py — /api/v1/superadmin/runtime endpoint.
 
 Covers:
 - Unauthenticated → 401
@@ -58,7 +58,7 @@ def test_runtime_endpoint_no_auth_returns_401(client: TestClient) -> None:
     """No Authorization header in production-mode would 401 — but we test
     the SuperAdmin gate which hits ``require_auth`` first.
     """
-    resp = client.get("/api/v1/admin/runtime")
+    resp = client.get("/api/v1/superadmin/runtime")
     assert resp.status_code == 401
 
 
@@ -68,7 +68,7 @@ def test_runtime_endpoint_authed_but_no_envs_returns_403(
     """Fail-closed: env vars unset → no user is SuperAdmin → 403."""
     token = _make_token()
     resp = client.get(
-        "/api/v1/admin/runtime",
+        "/api/v1/superadmin/runtime",
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 403
@@ -82,7 +82,7 @@ def test_runtime_endpoint_authed_id_mismatch_returns_403(
     monkeypatch.setenv("SUPERADMIN_USER_IDS", "different-id")
     token = _make_token(user_id="user-uuid-1234")
     resp = client.get(
-        "/api/v1/admin/runtime",
+        "/api/v1/superadmin/runtime",
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 403
@@ -95,7 +95,7 @@ def test_runtime_endpoint_superadmin_via_user_id_returns_200(
     monkeypatch.setenv("SUPERADMIN_USER_IDS", "user-uuid-1234")
     token = _make_token(user_id="user-uuid-1234")
     resp = client.get(
-        "/api/v1/admin/runtime",
+        "/api/v1/superadmin/runtime",
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 200
@@ -108,7 +108,7 @@ def test_runtime_endpoint_superadmin_via_email_returns_200(
     monkeypatch.setenv("SUPERADMIN_EMAILS", "admin@example.com,test@example.com")
     token = _make_token(email="test@example.com")
     resp = client.get(
-        "/api/v1/admin/runtime",
+        "/api/v1/superadmin/runtime",
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 200
@@ -121,7 +121,7 @@ def test_runtime_endpoint_email_match_is_case_insensitive(
     monkeypatch.setenv("SUPERADMIN_EMAILS", "TEST@EXAMPLE.COM")
     token = _make_token(email="test@example.com")
     resp = client.get(
-        "/api/v1/admin/runtime",
+        "/api/v1/superadmin/runtime",
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 200
@@ -136,7 +136,7 @@ def test_runtime_endpoint_id_match_with_extra_emails_envset(
     monkeypatch.setenv("SUPERADMIN_EMAILS", "different@example.com")
     token = _make_token(user_id="user-uuid-1234", email="test@example.com")
     resp = client.get(
-        "/api/v1/admin/runtime",
+        "/api/v1/superadmin/runtime",
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 200
@@ -149,12 +149,13 @@ def test_runtime_endpoint_response_shape(
     monkeypatch.setenv("SUPERADMIN_USER_IDS", "user-uuid-1234")
     token = _make_token(user_id="user-uuid-1234")
     resp = client.get(
-        "/api/v1/admin/runtime",
+        "/api/v1/superadmin/runtime",
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 200
     body = resp.json()
     expected_keys = {
+        "pid",
         "memory_rss_mb",
         "memory_vms_mb",
         "cpu_percent",
@@ -174,3 +175,4 @@ def test_runtime_endpoint_response_shape(
     # In a live test process psutil should report > 0 RSS.
     assert body["memory_rss_mb"] > 0
     assert body["psutil_available"] is True
+    assert body["pid"] > 0


### PR DESCRIPTION
## Summary

Pairs with [commit 73c8e48](https://github.com/VitorMRodovalho/meridianiq/commit/73c8e48) (Fly RAM 1024→2048mb after the 2026-05-06 OOM incident) to give the leak-curve telemetry we lacked.

- **`GET /api/v1/admin/runtime`** — SuperAdmin-gated snapshot endpoint returning RSS/VMS/CPU/GC/uptime/version/WS/rate-limit metrics
- **Throttled Sentry breadcrumb** wired into `/health` — leak curve goes to Sentry + INFO logs without a new background-task pattern
- **`require_superadmin` + `_is_superadmin`** in `src/api/auth.py` — env-gated allowlist (`SUPERADMIN_USER_IDS`/`SUPERADMIN_EMAILS`), fail-closed, API-key role explicitly denied
- **`RuntimeSnapshot`** Pydantic v2 schema

## Why env-gated SuperAdmin (not full Tier model)

Destination architecture is the 5-tier role model `SuperAdmin → Enterprise → Program → Project → Contract` (see project memory `project_role_hierarchy.md`).  Today the codebase is single-tenant Project-scoped with flat `project_owners` — the Tier-model migration is a Cycle 4+ deliverable.  The env primitive is the smallest committable surface that gates this endpoint **today** without prejudging the destination.

## Test plan

- [x] 13 new module tests in `tests/test_observability.py` (snapshot keys/types, throttle behaviour, defensive invariants, swallow-on-snapshot-failure)
- [x] 8 new router tests in `tests/test_observability_router.py` (401 unauth, 403 envs-unset, 403 ID mismatch, 200 ID match, 200 email match, case-insensitivity, OR-semantics, shape)
- [x] 8 new SuperAdmin auth-unit tests (fail-closed, ID/email match, API-key role denial, empty-string env handling, 403/200 dependency wiring)
- [x] Full suite: **1512 passed, 6 skipped, 0 failed** (1490 → 1512 = +22)
- [x] Mypy strict: **0 errors** in modified files (`observability.py`, `routers/observability.py`, `auth.py`, `routers/health.py`)
- [x] Ruff format + lint: clean
- [x] Catalog regen: 123 endpoints × 24 routers (was 122 × 23) — CLAUDE.md / README.md / architecture.md / api-reference.md all consistent
- [ ] Devils-advocate review (next step before self-merge per ADR-0018 Amendment 1)
- [ ] Smoke test on Fly post-deploy

## Operator action required (post-merge)

Set the SuperAdmin allowlist env on Fly:

```bash
flyctl secrets set SUPERADMIN_USER_IDS=<your-supabase-uuid> -a meridianiq-api
# OR
flyctl secrets set SUPERADMIN_EMAILS=vitor.rodovalho@outlook.com -a meridianiq-api
```

Then probe the endpoint with a current Supabase session JWT:

```bash
curl -H "Authorization: Bearer <jwt>" https://meridianiq-api.fly.dev/api/v1/admin/runtime
```

## Cost

- $0 dev cost (psutil added to `[api]`/`[dev]` extras)
- Sentry breadcrumb stays under free-tier budget (5-min throttle = 288 breadcrumbs/day per machine)
- Pairs with the +$5-8/mo RAM bump in 73c8e48