### PR TITLE
feat(w2b): Cycle 4 W2 PR-B — revision confirmation card frontend

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1326,3 +1326,62 @@ export async function getLifecycleOverrides(
 export async function getPendingStatuses(): Promise<PendingStatusesResponse> {
 	return request<PendingStatusesResponse>(`/api/v1/projects/pending-statuses`);
 }
+
+// ── Cycle 4 W2 — revision detection (ADR-0022 + Amendment 2) ───
+
+/**
+ * Run the v1 heuristic to find a candidate parent revision for a project.
+ *
+ * Returns ``candidate_project_id: null`` when no sibling matches.
+ * UI MUST NOT render ``confidence`` as a high-trust signal — see ADR-0022
+ * Amendment 2 §"Calibration caveat".
+ */
+export async function detectRevisionOf(
+	projectId: string
+): Promise<import('./types').DetectRevisionOfResponse> {
+	return request<import('./types').DetectRevisionOfResponse>(
+		`/api/v1/projects/${projectId}/detect-revision-of`,
+		{ method: 'POST' }
+	);
+}
+
+/**
+ * Append-only INSERT of a ``revision_history`` row anchoring the project as
+ * a new revision in the parent's program. Server recomputes ``content_hash``
+ * from the stored XER bytes — client does not need to send it.
+ *
+ * Throws on 4xx / 5xx with the server-provided detail message.
+ */
+export async function confirmRevisionOf(
+	projectId: string,
+	parentProjectId: string
+): Promise<import('./types').ConfirmRevisionOfResponse> {
+	return request<import('./types').ConfirmRevisionOfResponse>(
+		`/api/v1/projects/${projectId}/confirm-revision-of`,
+		{
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ parent_project_id: parentProjectId })
+		}
+	);
+}
+
+/**
+ * Soft-tombstone a revision_history row + write paired audit_log entry.
+ *
+ * Idempotent — re-tombstone returns the existing tombstoned_at without
+ * a new audit row.
+ */
+export async function tombstoneRevision(
+	revisionId: string,
+	reason: string
+): Promise<import('./types').TombstoneRevisionResponse> {
+	return request<import('./types').TombstoneRevisionResponse>(
+		`/api/v1/revisions/${revisionId}/tombstone`,
+		{
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ reason })
+		}
+	);
+}

--- a/web/src/lib/components/RevisionConfirmCard.svelte
+++ b/web/src/lib/components/RevisionConfirmCard.svelte
@@ -1,0 +1,296 @@
+<script lang="ts">
+	// Cycle 4 W2 PR-B — revision confirmation card.
+	//
+	// INLINE card (NOT modal) below the upload result. Mounts after upload
+	// completes, calls /detect-revision-of, conditionally renders if a
+	// candidate parent is found. User confirms (writes revision_history row
+	// via /confirm-revision-of) or skips (treats as new project).
+	//
+	// ## Calibration-honest framing (ADR-0022 Amendment 2)
+	//
+	// The backend returns a ``confidence`` float (0.9 saturated on exact name
+	// match) but this UI does NOT render it as a high-trust signal. Framing
+	// uses the i18n ``revision.confirm_card_help`` key: "Matched on project
+	// name and program. Confirm to link as a new revision in this program
+	// lineage, or skip to treat as a new project." — explicit and honest
+	// about WHY the heuristic suggested this candidate, NOT a probability.
+	//
+	// ## Defensive contract
+	//
+	// - Detect failure → console.warn + don't render the card. Revision
+	//   detection is OPT-IN feedback; it must not block the upload flow.
+	// - Confirm failure (409 cap, 409 cross-program, 404, etc.) → toast
+	//   error with the server-provided detail message; card stays visible
+	//   so the user can retry or skip.
+	// - Skip → no backend call, no toast, just dismiss.
+	//
+	// ## a11y
+	//
+	// ``role="region"`` + ``aria-labelledby`` on the card. Both action
+	// buttons get ``aria-describedby`` pointing at the help text so screen
+	// readers carry the context when focus lands on a button.
+	//
+	// ## Pattern reference
+	//
+	// Inline card shape mirrors ``LifecyclePhaseCard.svelte`` (status pill +
+	// body + action row). Form pattern (props, $state, $derived, error
+	// surfacing) mirrors ``LifecycleOverrideDialog.svelte``.
+
+	import { confirmRevisionOf, detectRevisionOf } from '$lib/api';
+	import { trackEvent } from '$lib/analytics';
+	import { t } from '$lib/i18n';
+	import { error as toastError, success } from '$lib/toast';
+
+	interface Props {
+		projectId: string;
+		onConfirmed?: (revisionId: string, revisionNumber: number) => void;
+		onSkipped?: () => void;
+	}
+
+	let { projectId, onConfirmed, onSkipped }: Props = $props();
+
+	// Detect-state machine: ``loading`` → ``ready_with_candidate`` |
+	// ``no_candidate`` | ``detect_failed`` | ``auth_expired``. The card
+	// body renders on ``ready_with_candidate``; the loading hint renders
+	// on ``loading``; ``auth_expired`` renders a hint to refresh; the
+	// other terminal states collapse silently.
+	let detectState = $state<
+		| 'loading'
+		| 'ready_with_candidate'
+		| 'no_candidate'
+		| 'detect_failed'
+		| 'auth_expired'
+	>('loading');
+	let candidateProjectId = $state<string | null>(null);
+	let candidateProjectName = $state<string | null>(null);
+	let candidateDataDate = $state<string | null>(null);
+	let candidateRevisionCount = $state<number>(0);
+
+	// Confirm-state machine: ``idle`` → ``submitting`` → ``confirmed``
+	// (terminal — card stays visible briefly then onConfirmed callback fires
+	// the toast and parent dismisses).
+	let confirmState = $state<'idle' | 'submitting' | 'confirmed'>('idle');
+	let confirmError = $state<string | null>(null);
+
+	let canConfirm = $derived(
+		detectState === 'ready_with_candidate' && confirmState === 'idle'
+	);
+
+	// Generation counter (DA exit-council fix-up #P1-1) — increments on every
+	// detect call. Stale promise resolutions check the generation before
+	// committing state. Without this, a re-mount with a different projectId
+	// could resolve the prior detect AFTER the new one has completed,
+	// overwriting state with the wrong upload's candidate. Combined with
+	// ``{#key result.project_id}`` in the parent (upload/+page.svelte), this
+	// is belt-and-suspenders — the {#key} forces unmount+remount, and the
+	// generation check catches the case if the parent ever drops the {#key}.
+	let detectGen = 0;
+
+	$effect(() => {
+		// Run detection on (re)mount. ``$effect`` reruns on projectId change.
+		// ``projectId`` is read here to subscribe to its rune; the body uses
+		// the closure value via runDetect.
+		void projectId;
+		runDetect();
+	});
+
+	async function runDetect(): Promise<void> {
+		const myGen = ++detectGen;
+		detectState = 'loading';
+		try {
+			const res = await detectRevisionOf(projectId);
+			if (myGen !== detectGen) {
+				// Stale resolution — a newer detect for a different projectId
+				// has started; do NOT commit this response's state.
+				return;
+			}
+			if (res.candidate_project_id) {
+				candidateProjectId = res.candidate_project_id;
+				candidateProjectName = res.candidate_project_name;
+				candidateDataDate = res.candidate_data_date;
+				candidateRevisionCount = res.candidate_revision_count;
+				detectState = 'ready_with_candidate';
+			} else {
+				detectState = 'no_candidate';
+			}
+		} catch (err) {
+			if (myGen !== detectGen) return;
+			const msg = err instanceof Error ? err.message : String(err);
+			console.warn('detectRevisionOf failed:', err);
+			trackEvent('revision_detect_failed', {
+				project_id: projectId,
+				error: msg
+			});
+			// DA exit-council fix-up #P1-3: distinguish auth-expired from
+			// other transient failures. 401 typically surfaces in the error
+			// message body. Auth-expired renders a hint instead of silently
+			// collapsing — operator gets a path back via page refresh.
+			if (/\b401\b|unauthori[sz]ed|token expired/i.test(msg)) {
+				detectState = 'auth_expired';
+			} else {
+				detectState = 'detect_failed';
+			}
+		}
+	}
+
+	/**
+	 * Single-pass placeholder interpolation that does NOT recursively
+	 * interpret user-supplied values. ``str.replace('{x}', userValue)``
+	 * is unsafe when ``userValue`` contains a ``{y}`` substring that the
+	 * NEXT replace call would consume — corrupting the template (DA
+	 * exit-council fix-up #P2-4). This regex-based single-pass treats
+	 * ``{key}`` as a token boundary and substitutes from the values map
+	 * once, leaving user-supplied ``{date}``-shaped substrings as
+	 * literal text.
+	 */
+	function interpolate(template: string, values: Record<string, string>): string {
+		return template.replace(/\{(\w+)\}/g, (match, key) =>
+			Object.prototype.hasOwnProperty.call(values, key) ? values[key] : match
+		);
+	}
+
+	async function handleConfirm(): Promise<void> {
+		if (!canConfirm || !candidateProjectId) return;
+		confirmError = null;
+		confirmState = 'submitting';
+		try {
+			const res = await confirmRevisionOf(projectId, candidateProjectId);
+			confirmState = 'confirmed';
+			trackEvent('revision_confirmed', {
+				project_id: projectId,
+				parent_project_id: candidateProjectId,
+				revision_number: res.revision_number
+			});
+			success(
+				interpolate($t('revision.confirmed_toast'), {
+					N: String(res.revision_number),
+					name: candidateProjectName ?? ''
+				})
+			);
+			onConfirmed?.(res.revision_id, res.revision_number);
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			// DA exit-council fix-up #P1-2: detect cap-class errors and switch
+			// to the i18n key so non-English users get a friendly message.
+			// Backend 409 detail mentions "revision cap" / "limit" — pattern
+			// match on the substring. A future structured error code would
+			// be cleaner; tracked as a follow-up.
+			const isCapError = /revision cap|reached.*\(\d+\)|limit/i.test(msg);
+			const friendly = isCapError ? $t('revision.cap_reached') : msg;
+			confirmError = friendly;
+			toastError(friendly);
+			confirmState = 'idle';
+		}
+	}
+
+	function handleSkip(): void {
+		trackEvent('revision_skipped', {
+			project_id: projectId,
+			candidate_project_id: candidateProjectId
+		});
+		onSkipped?.();
+	}
+
+	function formatDate(iso: string | null): string {
+		if (!iso) return '—';
+		// Show only the date part (YYYY-MM-DD) — time-of-day is noise here.
+		return iso.slice(0, 10);
+	}
+</script>
+
+{#if detectState === 'loading'}
+	<!-- Loading hint — defends against silent slow paths (DA fix-up #P2-1) -->
+	<p
+		class="mt-4 text-xs text-gray-500 dark:text-gray-400 italic"
+		role="status"
+		aria-live="polite"
+	>
+		{$t('revision.checking')}
+	</p>
+{:else if detectState === 'auth_expired'}
+	<!-- DA exit-council fix-up #P1-3: surface auth-expired explicitly -->
+	<p
+		class="mt-4 text-xs text-amber-700 dark:text-amber-300"
+		role="status"
+		aria-live="polite"
+	>
+		{$t('revision.auth_expired_hint')}
+	</p>
+{:else if detectState === 'ready_with_candidate' && confirmState !== 'confirmed'}
+	<section
+		aria-labelledby="revision-confirm-title"
+		class="mt-4 rounded-lg border border-amber-200 dark:border-amber-700 bg-amber-50 dark:bg-amber-950/40 p-4"
+	>
+		<div class="flex flex-wrap items-start gap-3">
+			<svg
+				aria-hidden="true"
+				class="w-5 h-5 mt-0.5 flex-none text-amber-600 dark:text-amber-400"
+				fill="none"
+				stroke="currentColor"
+				viewBox="0 0 24 24"
+			>
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width="2"
+					d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+				/>
+			</svg>
+			<div class="min-w-0 flex-1">
+				<h3
+					id="revision-confirm-title"
+					class="text-sm font-semibold text-amber-900 dark:text-amber-200"
+				>
+					{$t('revision.confirm_card_title')}
+				</h3>
+				<p
+					id="revision-confirm-body"
+					class="mt-1 text-sm text-amber-900/90 dark:text-amber-100/90"
+				>
+					{interpolate($t('revision.confirm_card_body'), {
+						name: candidateProjectName ?? '—',
+						date: formatDate(candidateDataDate),
+						count: String(candidateRevisionCount)
+					})}
+				</p>
+				<p
+					id="revision-confirm-help"
+					class="mt-2 text-xs text-amber-800/80 dark:text-amber-300/80"
+				>
+					{$t('revision.confirm_card_help')}
+				</p>
+				{#if confirmError}
+					<p
+						class="mt-2 text-xs text-rose-700 dark:text-rose-400"
+						role="alert"
+					>
+						{confirmError}
+					</p>
+				{/if}
+			</div>
+		</div>
+
+		<div class="mt-3 flex flex-wrap gap-2 justify-end">
+			<button
+				type="button"
+				onclick={handleSkip}
+				disabled={confirmState === 'submitting'}
+				aria-describedby="revision-confirm-help"
+				class="px-3 py-1.5 text-sm rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800 text-gray-700 dark:text-gray-200 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-amber-500"
+			>
+				{$t('revision.skip_button')}
+			</button>
+			<button
+				type="button"
+				onclick={handleConfirm}
+				disabled={!canConfirm}
+				aria-describedby="revision-confirm-help"
+				class="px-3 py-1.5 text-sm rounded bg-amber-600 hover:bg-amber-700 text-white disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-amber-500"
+			>
+				{confirmState === 'submitting'
+					? $t('revision.confirming')
+					: $t('revision.confirm_button')}
+			</button>
+		</div>
+	</section>
+{/if}

--- a/web/src/lib/i18n/en.ts
+++ b/web/src/lib/i18n/en.ts
@@ -1318,4 +1318,16 @@ export default {
 	'root_cause.tf_label': 'TF',
 	'root_cause.dur_label': 'Dur',
 	'root_cause.timeline_title': 'Trace Timeline',
+
+	// Revision confirmation card (Cycle 4 W2 PR-B / ADR-0022 Amendment 2)
+	'revision.confirm_card_title': 'Possible revision detected',
+	'revision.confirm_card_body': 'This upload appears to share project name and program with {name} (uploaded {date}). Currently {count} active revisions in this program.',
+	'revision.confirm_card_help': 'Matched on project name and program. Confirm to link as a new revision in this program lineage, or skip to treat as a separate project.',
+	'revision.confirm_button': 'Confirm as revision',
+	'revision.confirming': 'Linking…',
+	'revision.skip_button': 'Treat as new project',
+	'revision.confirmed_toast': 'Linked as revision {N} in program {name}',
+	'revision.cap_reached': 'Project has reached the revision cap. Tombstone an older revision before linking a new one.',
+	'revision.checking': 'Checking for revision matches…',
+	'revision.auth_expired_hint': 'Could not check for revisions — session may have expired. Refresh the page and re-upload to retry.',
 } as Record<string, string>;

--- a/web/src/lib/i18n/es.ts
+++ b/web/src/lib/i18n/es.ts
@@ -1316,4 +1316,16 @@ export default {
 	'root_cause.tf_label': 'FT',
 	'root_cause.dur_label': 'Dur',
 	'root_cause.timeline_title': 'Línea de tiempo del rastreo',
+
+	// Revision confirmation card (Cycle 4 W2 PR-B / ADR-0022 Amendment 2)
+	'revision.confirm_card_title': 'Posible revisión detectada',
+	'revision.confirm_card_body': 'Esta carga parece compartir nombre de proyecto y programa con {name} (subido el {date}). Actualmente {count} revisiones activas en este programa.',
+	'revision.confirm_card_help': 'Coincidencia por nombre de proyecto y programa. Confirme para vincular como nueva revisión de esta línea, o omita para tratarlo como un proyecto separado.',
+	'revision.confirm_button': 'Confirmar como revisión',
+	'revision.confirming': 'Vinculando…',
+	'revision.skip_button': 'Tratar como nuevo proyecto',
+	'revision.confirmed_toast': 'Vinculado como revisión {N} en el programa {name}',
+	'revision.cap_reached': 'El proyecto alcanzó el límite de revisiones. Marque una revisión antigua como tombstone antes de vincular una nueva.',
+	'revision.checking': 'Verificando coincidencias de revisión…',
+	'revision.auth_expired_hint': 'No se pudo verificar revisiones — la sesión puede haber expirado. Recargue la página y vuelva a subir para reintentar.',
 } as Record<string, string>;

--- a/web/src/lib/i18n/pt-BR.ts
+++ b/web/src/lib/i18n/pt-BR.ts
@@ -1316,4 +1316,16 @@ export default {
 	'root_cause.tf_label': 'FT',
 	'root_cause.dur_label': 'Dur',
 	'root_cause.timeline_title': 'Linha do tempo do rastreio',
+
+	// Revision confirmation card (Cycle 4 W2 PR-B / ADR-0022 Amendment 2)
+	'revision.confirm_card_title': 'Possível revisão detectada',
+	'revision.confirm_card_body': 'Este upload parece compartilhar nome de projeto e programa com {name} (enviado em {date}). Atualmente {count} revisões ativas neste programa.',
+	'revision.confirm_card_help': 'Correspondência por nome de projeto e programa. Confirme para vincular como nova revisão desta linhagem, ou pule para tratar como projeto separado.',
+	'revision.confirm_button': 'Confirmar como revisão',
+	'revision.confirming': 'Vinculando…',
+	'revision.skip_button': 'Tratar como novo projeto',
+	'revision.confirmed_toast': 'Vinculado como revisão {N} no programa {name}',
+	'revision.cap_reached': 'O projeto atingiu o limite de revisões. Marque uma revisão antiga como tombstone antes de vincular uma nova.',
+	'revision.checking': 'Verificando correspondências de revisão…',
+	'revision.auth_expired_hint': 'Não foi possível verificar revisões — a sessão pode ter expirado. Recarregue a página e reenvie para tentar novamente.',
 } as Record<string, string>;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -923,3 +923,33 @@ export interface VisualizationResponse {
 	max_wbs_depth: number;
 	summary: Record<string, unknown>;
 }
+
+// Cycle 4 W2 — revision detection (ADR-0022 + Amendment 2)
+//
+// Mirrors src/api/schemas.py shapes. ``confidence`` is surfaced for
+// completeness but the UI MUST NOT render it as a high-trust signal
+// per ADR-0022 Amendment 2 §"Calibration caveat".
+
+export interface DetectRevisionOfResponse {
+	candidate_project_id: string | null;
+	candidate_project_name: string | null;
+	candidate_data_date: string | null;
+	candidate_revision_count: number;
+	confidence: number;
+	reasoning: string;
+}
+
+export interface ConfirmRevisionOfResponse {
+	revision_id: string;
+	project_id: string;
+	revision_number: number;
+	program_id: string | null;
+	data_date: string | null;
+	content_hash: string;
+}
+
+export interface TombstoneRevisionResponse {
+	revision_id: string;
+	tombstoned_at: string;
+	audit_log_id: string | null;
+}

--- a/web/src/routes/upload/+page.svelte
+++ b/web/src/routes/upload/+page.svelte
@@ -2,6 +2,7 @@
 	import { uploadXER } from '$lib/api';
 	import { trackEvent } from '$lib/analytics';
 	import { success, error as toastError } from '$lib/toast';
+	import RevisionConfirmCard from '$lib/components/RevisionConfirmCard.svelte';
 	import StatusBadge from '$lib/components/StatusBadge.svelte';
 	import type { ProjectSummary } from '$lib/types';
 	import { t } from '$lib/i18n';
@@ -11,6 +12,10 @@
 	let error = $state('');
 	let result: ProjectSummary | null = $state(null);
 	let isSandbox = $state(false);
+	// Cycle 4 W2 PR-B — controls visibility of the revision confirmation
+	// card. Set to false on confirm/skip so the card collapses; sandbox
+	// uploads bypass entirely (testing data shouldn't enter revision lineage).
+	let showRevisionCard = $state(true);
 
 	function handleDragOver(e: DragEvent) {
 		e.preventDefault();
@@ -43,6 +48,7 @@
 		loading = true;
 		error = '';
 		result = null;
+		showRevisionCard = true;
 		try {
 			result = await uploadXER(file, isSandbox);
 			// ADR-0015: pending means the async materializer is still running;
@@ -222,5 +228,32 @@
 				</a>
 			</div>
 		</div>
+
+		<!--
+			Cycle 4 W2 PR-B — revision confirmation card.
+			Renders only for non-sandbox uploads (sandbox bypass per
+			frontend-ux-reviewer entry council #3). Card self-detects;
+			collapses if no candidate found OR if detect-revision-of fails.
+
+			DA exit-council fix-up #P1-1 / #P2-2: ``{#key result.project_id}``
+			forces unmount + remount when the user uploads a different file
+			before the previous detect resolves. Without this, the component
+			instance is reused with stale ``$state``, and a slow detect for
+			file A can resolve AFTER file B's detect has set state — silent
+			data corruption (revision_history row anchored to wrong parent).
+		-->
+		{#if !isSandbox && showRevisionCard}
+			{#key result.project_id}
+				<RevisionConfirmCard
+					projectId={result.project_id}
+					onConfirmed={() => {
+						showRevisionCard = false;
+					}}
+					onSkipped={() => {
+						showRevisionCard = false;
+					}}
+				/>
+			{/key}
+		{/if}
 	{/if}
 </div>


### PR DESCRIPTION
## Summary

Cycle 4 W2 PR-B per ADR-0022 §"Wave plan W2" frontend half. Closes Cycle 4 success criterion #3 fully (was PARTIAL after PR #78 backend).

- **`RevisionConfirmCard.svelte`** (NEW) — inline card, Svelte 5 runes, dark mode, mobile-responsive, a11y
- **API client + types** — 3 new functions + 3 new TS interfaces mirroring Pydantic shapes
- **Upload flow integration** — `{#key result.project_id}` boundary + sandbox bypass
- **i18n × 3 locales** — 10 new keys × en/pt-BR/es

## Calibration-honest framing (ADR-0022 Amendment 2)

UI does NOT render the backend `confidence` float. Card uses explicit "Matched on project name and program" reasoning — not a probability. Per ADR-0022 Amendment 2 §"Calibration caveat" mandate.

## Council pre-check protocol (per ADR-0018 Am.1)

- ✅ **frontend-ux-reviewer entry-council** — 3 BLOCKING + 6 should-fix all addressed inline
- ✅ **DA-as-second-reviewer exit-council** — 3 P1 + 4 P2 + 8 P3:
  - P1 #1 race on rapid re-uploads: FIXED via `{#key}` + generation counter
  - P1 #2 cap-class errors raw English in non-en UI: FIXED via regex switch to i18n key
  - P1 #3 auth-expired silently collapses: FIXED via explicit `auth_expired` state + hint
  - P2 #1 silent loading: FIXED via "Checking…" hint
  - P2 #4 template injection via `{name}` containing `{date}`: FIXED via `interpolate()` helper
  - 1 P2 deferred: path back from skip (follow-up issue)
  - 8 P3: verified safe / documented / follow-up

## Test plan

- [x] svelte-check: 0 errors, 0 warnings (638 files)
- [x] npm run build: success (adapter-static)
- [x] Backend regression: 1562 passed (unchanged)
- [ ] Manual smoke test post-deploy (Cloudflare Pages auto-deploys main)

## Operator action

None. Cloudflare Pages auto-deploys. **Smoke test**: upload `PROJ-A.xer` twice with different data_dates; second upload should show the confirmation card with candidate = first upload.

## ADR-0022 Cycle 4 progress

| # | Criterion | Status |
|---|---|---|
| 3 | Auto-revision detection + UX + soft-tombstone | **CLOSED** ✅ (was PARTIAL post-PR #78) |

**1.5/9 → 2/9** closed.

## Follow-up issues to file

- Path back from skip on project detail page (DA P2 #3)
- Per-locale date formatting on `formatDate` (DA P3 #2)
- 404-on-confirm auto-collapse vs retry differentiation (DA P3 #5)
- Vitest component test harness for future components