### PR TITLE
feat(w3a): Cycle 4 W3 PR-A — multi-rev S-curve overlay backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ mypy src/ --strict              # type check
 
 ## Architecture
 
-- **47 analysis engines** in `src/analytics/` + 1 export module in `src/export/` — each standalone, no cross-dependencies
+- **48 analysis engines** in `src/analytics/` + 1 export module in `src/export/` — each standalone, no cross-dependencies
 - **API**: FastAPI with 127 endpoints under `/api/v1/` across 25 routers, rate-limited critical endpoints
 - **Frontend**: SvelteKit + Tailwind v4, 54 pages, Svelte 5 runes ($state, $derived, $effect), dark mode, i18n (en/pt-BR/es), keyboard shortcuts (?)
 - **Database**: Supabase PostgreSQL with RLS, 28 migrations in `supabase/migrations/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ mypy src/ --strict              # type check
 ## Architecture
 
 - **47 analysis engines** in `src/analytics/` + 1 export module in `src/export/` — each standalone, no cross-dependencies
-- **API**: FastAPI with 126 endpoints under `/api/v1/` across 25 routers, rate-limited critical endpoints
+- **API**: FastAPI with 127 endpoints under `/api/v1/` across 25 routers, rate-limited critical endpoints
 - **Frontend**: SvelteKit + Tailwind v4, 54 pages, Svelte 5 runes ($state, $derived, $effect), dark mode, i18n (en/pt-BR/es), keyboard shortcuts (?)
 - **Database**: Supabase PostgreSQL with RLS, 28 migrations in `supabase/migrations/`
 - **Auth**: Supabase Auth (Google + LinkedIn + Microsoft OAuth), ES256 JWT

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Every methodology is traceable to published standards: AACE Recommended Practice
 
 | Indicator | Value |
 |-----------|-------|
-| Analysis engines | 47 + 1 export module |
+| Analysis engines | 48 + 1 export module |
 | MCP tools | 22 (Claude integration via FastMCP) |
 | Schedule formats | 2 (Primavera P6 XER + Microsoft Project XML) |
 | Tests passing | 1490 backend + 26 Vitest composables + Playwright E2E |
@@ -120,7 +120,7 @@ graph TB
     end
 
     subgraph "Compute Layer — Fly.io"
-        FASTAPI["FastAPI Container<br/>Analysis Engines (47)<br/>127 endpoints"]
+        FASTAPI["FastAPI Container<br/>Analysis Engines (48)<br/>127 endpoints"]
     end
 
     subgraph "Platform Layer — Supabase"
@@ -320,7 +320,7 @@ meridianiq/
 │   │   ├── cost_integration.py # CBS/WBS cost correlation
 │   │   ├── schedule_trends.py  # Period-over-period evolution
 │   │   ├── narrative_report.py # Structured claim narratives
-│   │   └── ...                 # 47 engines total + 1 export
+│   │   └── ...                 # 48 engines total + 1 export
 │   ├── database/         # Supabase client, config, store abstraction
 │   └── api/
 │       ├── app.py        # FastAPI entry point

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Every methodology is traceable to published standards: AACE Recommended Practice
 | Schedule formats | 2 (Primavera P6 XER + Microsoft Project XML) |
 | Tests passing | 1490 backend + 26 Vitest composables + Playwright E2E |
 | Frontend pages | 54 (Schedule Viewer, EVM S-Curve, Cost Integration, Health Score, NLP Query, Early Warning, Lifecycle Phase, …) |
-| API endpoints | 126 across 25 routers |
+| API endpoints | 127 across 25 routers |
 | SVG chart components | 11 (incl. EVM S-Curve) + ScheduleViewer (hand-crafted, no chart.js) |
 | Released versions | v0.1.0 → v4.1.0 |
 | Live platform | [meridianiq.vitormr.dev](https://meridianiq.vitormr.dev) |
@@ -120,7 +120,7 @@ graph TB
     end
 
     subgraph "Compute Layer — Fly.io"
-        FASTAPI["FastAPI Container<br/>Analysis Engines (47)<br/>126 endpoints"]
+        FASTAPI["FastAPI Container<br/>Analysis Engines (47)<br/>127 endpoints"]
     end
 
     subgraph "Platform Layer — Supabase"
@@ -324,7 +324,7 @@ meridianiq/
 │   ├── database/         # Supabase client, config, store abstraction
 │   └── api/
 │       ├── app.py        # FastAPI entry point
-│       ├── routers/      # 126 endpoints across modular routers
+│       ├── routers/      # 127 endpoints across modular routers
 │       └── schemas.py    # Request/response models
 ├── web/                  # SvelteKit + Tailwind (54 pages)
 ├── tests/                # 1490+ backend tests

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,6 +1,6 @@
 # API Reference
 
-Generated from `src/api/app.py` — **126 endpoints** across **25 routers**. Interactive Swagger UI is served at `/docs` when the API is running; this document is a static browseable index.
+Generated from `src/api/app.py` — **127 endpoints** across **25 routers**. Interactive Swagger UI is served at `/docs` when the API is running; this document is a static browseable index.
 
 All paths are prefixed with the deployment base URL (e.g. `https://meridianiq.fly.dev`). Auth column: `none` (public), `optional` (degrades gracefully), `required` (returns 401 without bearer token).
 
@@ -31,7 +31,7 @@ Regenerate with: `python3 scripts/generate_api_reference.py`
 - [Observability](#observability) — 1 endpoints
 - [Organizations](#organizations) — 11 endpoints
 - [Plugins](#plugins) — 2 endpoints
-- [Revisions](#revisions) — 3 endpoints
+- [Revisions](#revisions) — 4 endpoints
 - [Ws](#ws) — 1 endpoints
 
 ## Upload
@@ -313,6 +313,7 @@ _Readiness and liveness_
 |---|---|---|---|---|
 | `POST` | `/api/v1/projects/{project_id}/confirm-revision-of` | Write a ``revision_history`` row anchoring the current upload as a | `ConfirmRevisionOfResponse` | required |
 | `POST` | `/api/v1/projects/{project_id}/detect-revision-of` | Return candidate parent project per the v1 heuristic. | `DetectRevisionOfResponse` | required |
+| `GET` | `/api/v1/projects/{project_id}/revision-trends` | Return the multi-revision S-curve overlay + change-points + slope band. | `RevisionTrendsResponse` | required |
 | `POST` | `/api/v1/revisions/{revision_id}/tombstone` | Soft-tombstone a revision_history row + write paired audit_log entry. | `TombstoneRevisionResponse` | required |
 
 ## Ws

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@
 
 MeridianIQ is a **modular monolith**: a single FastAPI application with clearly separated analysis engines, each implementing a specific published methodology and written to stay independent of every other engine. The frontend is a SvelteKit SPA served from Cloudflare Pages and talks to the backend via REST.
 
-As of **v4.1.0** + Cycle 3 in-flight + post-Cycle-3 follow-ups + Cycle 4 W1: 47 analysis engines + 1 export module, 126 API endpoints across 25 routers, 54 SvelteKit pages, 11 hand-crafted SVG chart components, 28 Supabase migrations, 22 MCP tools, 15 PDF report types, 1490 tests.
+As of **v4.1.0** + Cycle 3 in-flight + post-Cycle-3 follow-ups + Cycle 4 W1: 47 analysis engines + 1 export module, 127 API endpoints across 25 routers, 54 SvelteKit pages, 11 hand-crafted SVG chart components, 28 Supabase migrations, 22 MCP tools, 15 PDF report types, 1490 tests.
 
 ```mermaid
 graph TB
@@ -14,7 +14,7 @@ graph TB
     end
 
     subgraph "Compute — Fly.io"
-        API[FastAPI application<br/>126 endpoints · 25 routers<br/>Rate-limited · CORS whitelist<br/>Sentry telemetry]
+        API[FastAPI application<br/>127 endpoints · 25 routers<br/>Rate-limited · CORS whitelist<br/>Sentry telemetry]
         ENGINES[47 analysis engines<br/>+ 1 export module<br/>src/analytics/ + src/export/]
         MATERIALIZER[Async materializer<br/>asyncio.Task · Semaphore(1)<br/>ProcessPoolExecutor spawn<br/>src/materializer/]
         MCP[MCP server<br/>22 tools · stdio + http + sse<br/>src/mcp_server.py]
@@ -296,7 +296,7 @@ Supports universal ERP fields per AACE RP 10S-90, ANSI/EIA-748, ISO 21511, with 
 
 ## Catalogs & references
 
-- [API Reference](api-reference.md) — auto-generated from FastAPI app (126 endpoints × 25 routers)
+- [API Reference](api-reference.md) — auto-generated from FastAPI app (127 endpoints × 25 routers)
 - [Methodologies](methodologies.md) — auto-generated from engine docstrings (47 engines + citations)
 - [MCP Tools](mcp-tools.md) — auto-generated from `@mcp.tool()` decorators (22 tools)
 - [Deploy Checklist](DEPLOY_CHECKLIST.md) — 5-phase procedure

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@
 
 MeridianIQ is a **modular monolith**: a single FastAPI application with clearly separated analysis engines, each implementing a specific published methodology and written to stay independent of every other engine. The frontend is a SvelteKit SPA served from Cloudflare Pages and talks to the backend via REST.
 
-As of **v4.1.0** + Cycle 3 in-flight + post-Cycle-3 follow-ups + Cycle 4 W1: 47 analysis engines + 1 export module, 127 API endpoints across 25 routers, 54 SvelteKit pages, 11 hand-crafted SVG chart components, 28 Supabase migrations, 22 MCP tools, 15 PDF report types, 1490 tests.
+As of **v4.1.0** + Cycle 3 in-flight + post-Cycle-3 follow-ups + Cycle 4 W1: 48 analysis engines + 1 export module, 127 API endpoints across 25 routers, 54 SvelteKit pages, 11 hand-crafted SVG chart components, 28 Supabase migrations, 22 MCP tools, 15 PDF report types, 1490 tests.
 
 ```mermaid
 graph TB
@@ -15,7 +15,7 @@ graph TB
 
     subgraph "Compute — Fly.io"
         API[FastAPI application<br/>127 endpoints · 25 routers<br/>Rate-limited · CORS whitelist<br/>Sentry telemetry]
-        ENGINES[47 analysis engines<br/>+ 1 export module<br/>src/analytics/ + src/export/]
+        ENGINES[48 analysis engines<br/>+ 1 export module<br/>src/analytics/ + src/export/]
         MATERIALIZER[Async materializer<br/>asyncio.Task · Semaphore(1)<br/>ProcessPoolExecutor spawn<br/>src/materializer/]
         MCP[MCP server<br/>22 tools · stdio + http + sse<br/>src/mcp_server.py]
         API --> ENGINES
@@ -58,7 +58,7 @@ graph TB
 src/
   parser/            XER / MS Project XML readers, Pydantic models (17+ tables),
                      structured P6 calendar_data parser (CalendarSchedule + exceptions)
-  analytics/         47 analysis engines (see docs/methodologies.md)
+  analytics/         48 analysis engines (see docs/methodologies.md)
   export/            XER round-trip writer
   database/          InMemoryStore + SupabaseStore abstraction, Supabase client
   api/
@@ -297,7 +297,7 @@ Supports universal ERP fields per AACE RP 10S-90, ANSI/EIA-748, ISO 21511, with 
 ## Catalogs & references
 
 - [API Reference](api-reference.md) — auto-generated from FastAPI app (127 endpoints × 25 routers)
-- [Methodologies](methodologies.md) — auto-generated from engine docstrings (47 engines + citations)
+- [Methodologies](methodologies.md) — auto-generated from engine docstrings (48 engines + citations)
 - [MCP Tools](mcp-tools.md) — auto-generated from `@mcp.tool()` decorators (22 tools)
 - [Deploy Checklist](DEPLOY_CHECKLIST.md) — 5-phase procedure
 - [Schedule Submission Standards](SCHEDULE_SUBMISSION_STANDARDS.md)

--- a/docs/methodologies.md
+++ b/docs/methodologies.md
@@ -1,6 +1,6 @@
 # Methodology Catalog
 
-MeridianIQ's analysis stack is **47 engines** plus **1 export module** in `src/export/`. Every engine is a standalone module whose docstring cites the published standard it implements — this catalog is auto-generated from those docstrings.
+MeridianIQ's analysis stack is **48 engines** plus **1 export module** in `src/export/`. Every engine is a standalone module whose docstring cites the published standard it implements — this catalog is auto-generated from those docstrings.
 
 When a scheduler or forensic analyst asks *"what standard does this calculation follow?"*, the answer is in the engine docstring and in this catalog.
 
@@ -43,6 +43,7 @@ When a scheduler or forensic analyst asks *"what standard does this calculation 
 | [`recovery_validation`](#recovery-validation--recovery-validation) | Recovery Schedule Validation Engine. |
 | [`report_generator`](#report-generator--report-generator) | Professional PDF report generator per AACE RP 29R-03 S5.3. |
 | [`resource_leveling`](#resource-leveling--resource-leveling) | Resource-constrained project scheduling (RCPSP) via Serial SGS. |
+| [`revision_trends`](#revision-trends--revision-trends) | Multi-revision schedule trend analysis (Cycle 4 W3 PR-A). |
 | [`risk`](#risk--risk) | Monte Carlo schedule risk simulation per AACE RP 57R-09. |
 | [`risk_register`](#risk-register--risk-register) | Risk register — discrete risk event management and Monte Carlo integration. |
 | [`root_cause`](#root-cause--root-cause) | Root Cause Analysis — backwards network trace to delay origin. |
@@ -836,6 +837,52 @@ The algorithm:
 - PMI Practice Standard for Scheduling — Resource Leveling
 - Kelley & Walker (1959) — CPM with Resource Constraints
 - Kolisch (1996) — Serial and Parallel SGS for RCPSP
+
+---
+
+### `revision_trends` — Revision Trends
+
+**Multi-revision schedule trend analysis (Cycle 4 W3 PR-A).**
+
+Implements **AACE RP 29R-03 Forensic Schedule Analysis §"Window analysis" multi-revision overlay** primitive: extracts the planned-completion-percent S-curve from each successive revision of a project, detects regime changes via CUSUM, and surfaces slope CI bands with the heteroscedasticity-aware contract per ADR-0022 §"W3 — C-visualization".
+
+## Why CPM-based completion curves, NOT cashflow
+
+Backend-reviewer entry-council on PR #N flagged that
+``src.analytics.cashflow.analyze_cashflow`` produces a cost-mass-weighted
+S-curve (with duration-as-proxy fallback when cost data is missing).
+Window Analysis (AACE 29R-03) is **completion-percent-weighted**: the
+curve point at day D is "what fraction of the schedule was planned to be
+complete at day D, by activity count or duration-weighted activity
+count". This module computes that directly from CPM ``early_finish``
+output — no cost dependency.
+
+## Methodology citation surfaced in the response
+
+``"AACE RP 29R-03 — Forensic Schedule Analysis, §'Window analysis'
+(multi-revision overlay); CUSUM change-point detection (Page 1954);
+heteroscedasticity-aware OLS with σ ∝ √horizon. Forecast curve
+intentionally omitted pending W4 calibration gate (ADR-0022 path-A
+pre-commitment)."``
+
+## Pure-numpy implementation
+
+scipy is NOT in the dependency set (per ``pyproject.toml`` and verified
+by grep across ``src/``). CUSUM is 5 lines of ``numpy.cumsum``; OLS for
+the slope band is closed-form via ``numpy.polyfit``. Future migration to
+scipy.stats would be a separate dep-add ADR.
+
+## What this module does NOT do (W3 scope discipline)
+
+- Does NOT produce a forecast curve (path-A pre-commit per ADR-0022 W4).
+- Does NOT calibrate the heuristic (W4 deliverable).
+- Does NOT cache responses (W2-coupling concern; future follow-up).
+- Does NOT re-rank candidates by content_hash similarity (W3+ deferral
+  per ADR-0022 Amendment 2).
+
+**Standards implemented:**
+
+- AACE RP 29R-03 — Forensic Schedule Analysis
 
 ---
 

--- a/src/analytics/revision_trends.py
+++ b/src/analytics/revision_trends.py
@@ -1,0 +1,483 @@
+# MIT License
+# Copyright (c) 2026 Vitor Maia Rodovalho
+"""Multi-revision schedule trend analysis (Cycle 4 W3 PR-A).
+
+Implements **AACE RP 29R-03 Forensic Schedule Analysis §"Window analysis"
+multi-revision overlay** primitive: extracts the planned-completion-percent
+S-curve from each successive revision of a project, detects regime
+changes via CUSUM, and surfaces slope CI bands with the
+heteroscedasticity-aware contract per ADR-0022 §"W3 — C-visualization".
+
+## Why CPM-based completion curves, NOT cashflow
+
+Backend-reviewer entry-council on PR #N flagged that
+``src.analytics.cashflow.analyze_cashflow`` produces a cost-mass-weighted
+S-curve (with duration-as-proxy fallback when cost data is missing).
+Window Analysis (AACE 29R-03) is **completion-percent-weighted**: the
+curve point at day D is "what fraction of the schedule was planned to be
+complete at day D, by activity count or duration-weighted activity
+count". This module computes that directly from CPM ``early_finish``
+output — no cost dependency.
+
+## Methodology citation surfaced in the response
+
+``"AACE RP 29R-03 — Forensic Schedule Analysis, §'Window analysis'
+(multi-revision overlay); CUSUM change-point detection (Page 1954);
+heteroscedasticity-aware OLS with σ ∝ √horizon. Forecast curve
+intentionally omitted pending W4 calibration gate (ADR-0022 path-A
+pre-commitment)."``
+
+## Pure-numpy implementation
+
+scipy is NOT in the dependency set (per ``pyproject.toml`` and verified
+by grep across ``src/``). CUSUM is 5 lines of ``numpy.cumsum``; OLS for
+the slope band is closed-form via ``numpy.polyfit``. Future migration to
+scipy.stats would be a separate dep-add ADR.
+
+## What this module does NOT do (W3 scope discipline)
+
+- Does NOT produce a forecast curve (path-A pre-commit per ADR-0022 W4).
+- Does NOT calibrate the heuristic (W4 deliverable).
+- Does NOT cache responses (W2-coupling concern; future follow-up).
+- Does NOT re-rank candidates by content_hash similarity (W3+ deferral
+  per ADR-0022 Amendment 2).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from src.analytics.cpm import CPMCalculator
+
+if TYPE_CHECKING:
+    from src.parser.models import ParsedSchedule
+
+logger = logging.getLogger(__name__)
+
+
+METHODOLOGY_CITATION = (
+    "AACE RP 29R-03 §'Window analysis' (multi-revision overlay primitive). "
+    "CUSUM change-point per Page (1954, Biometrika 41) — applied as a "
+    "separate exploratory SPC layer, NOT prescribed by AACE 29R-03. "
+    "Heteroscedasticity-aware OLS slope band with σ ∝ √horizon (ADR-0022 "
+    "§'W3 — C-visualization' simple model). Forecast curve intentionally "
+    "omitted pending W4 calibration gate per ADR-0022 path-A pre-commitment."
+)
+"""DA exit-council fix-up #P1-2: split AACE 29R-03 (Window Analysis primitive)
+from Page (1954) CUSUM (separate SPC layer) so the methodology line
+does not imply AACE prescribes the CUSUM convention.
+"""
+
+# Minimum revision count for CUSUM emission. With N=3 revisions there
+# are only 2 deltas; sample std on 2 points is degenerate. Backend-
+# reviewer entry-council recommended N≥5 as the "informative-but-not-
+# powered" threshold for heuristic emission.
+_MIN_REVISIONS_FOR_CUSUM = 5
+# DA exit-council fix-up #P3-5: bumped from 3 to 4. With 3 revisions
+# (2 deltas) OLS gives slope but residual variance is undefined (df=0),
+# producing a zero-width CI that the UI would mis-render as confident.
+# 4 revisions (3 deltas) gives df=1 — minimum non-degenerate fit.
+_MIN_REVISIONS_FOR_SLOPE = 4
+# DA exit-council fix-up #P1-3: lowered from 5σ to 3σ. 5σ on N=4-11 deltas
+# gives ARL ~10000+ — the detector essentially never fires (the unit
+# test had to drop to 2σ to fire). 3σ is more sensitive while still
+# ARL-conservative (~370 in classical CUSUM). Honest signal beats
+# theoretically-pure-but-mute.
+_CUSUM_SIGMA_THRESHOLD = 3.0
+
+
+@dataclass
+class CurvePoint:
+    """One point on a per-revision completion curve."""
+
+    day_offset: int
+    """Days from the revision's ``data_date``."""
+
+    planned_cumulative_pct: float
+    """Fraction in [0.0, 1.0] of activities planned to be complete by this day."""
+
+    actual_cumulative_pct: float | None = None
+    """Fraction in [0.0, 1.0] of activities ACTUALLY complete by this day.
+
+    Populated only on the most recent revision (the "executed" view) per
+    ADR-0022 W3 spec. Older revisions have ``actual_cumulative_pct=None`` —
+    suppressed to avoid past-actuals-vs-past-planned confusion.
+    """
+
+
+@dataclass
+class RevisionCurve:
+    """Per-revision S-curve metadata + points."""
+
+    project_id: str
+    revision_id: str | None = None
+    """``revision_history.id`` if the project has been confirmed-as-revision; None for pre-W1 / unconfirmed."""
+    revision_number: int | None = None
+    data_date: str | None = None
+    """ISO-8601 date string of the schedule's data_date."""
+    points: list[CurvePoint] = field(default_factory=list)
+    is_executed: bool = False
+    """True only for the most recent revision (carries the actual_cumulative_pct values)."""
+
+
+@dataclass
+class ChangePointMarker:
+    """A revision index where the CUSUM crossed the threshold."""
+
+    revision_index: int
+    """0-based position in the time-ordered revision list."""
+
+    revision_id: str | None
+    delta_days: int
+    """Signed days difference from the prior revision's planned_finish."""
+    cusum_value: float
+    description: str
+
+
+@dataclass
+class SlopeBand:
+    """Heteroscedasticity-aware OLS slope of the inter-revision shift series."""
+
+    slope_days_per_revision: float
+    ci_lower: float
+    ci_upper: float
+    horizon_revisions: int
+    """How many revisions ahead the CI was widened for (sigma ∝ √horizon)."""
+
+
+@dataclass
+class RevisionTrendsAnalysis:
+    """Top-level analysis output for the /revision-trends endpoint."""
+
+    project_id: str
+    program_id: str | None
+    curves: list[RevisionCurve] = field(default_factory=list)
+    """Ordered by ``data_date`` ascending. Most recent has ``is_executed=True``."""
+    change_points: list[ChangePointMarker] = field(default_factory=list)
+    slope_band: SlopeBand | None = None
+    methodology: str = METHODOLOGY_CITATION
+    notes: list[str] = field(default_factory=list)
+    """Free-form operator-facing strings (e.g., '<5 revisions — change-point detection skipped')."""
+
+
+# ── Curve extraction ──────────────────────────────────────
+
+
+def extract_planned_curve(schedule: "ParsedSchedule") -> list[tuple[int, float]]:
+    """Return the planned completion-percent S-curve as ``(day_offset, pct)`` pairs.
+
+    Computes from CPM ``early_finish`` per activity. Day 0 is the start of
+    the schedule's earliest activity; ``pct`` at day D is the fraction of
+    activities whose ``early_finish <= D`` (activity-count weighted).
+
+    Per AACE 29R-03 Window Analysis, this is the "planned completion
+    percent at data date" projected forward — the canonical Window
+    Analysis curve.
+
+    Returns an empty list on CPM failure or empty schedule (defensive;
+    the orchestrator MUST handle empty-curve cases without raising).
+    """
+    if not schedule.activities:
+        return []
+    try:
+        cpm = CPMCalculator(schedule).calculate()
+    except Exception:  # noqa: BLE001 — CPM failures degrade to empty curve
+        logger.warning("revision_trends: CPM failed; planned curve unavailable")
+        return []
+    if not cpm.activity_results:
+        return []
+    # DA exit-council fix-up #P1-1: do NOT filter ``early_finish > 0``.
+    # CPM (cpm.py:148) sets duration=0 for tasks with
+    # ``status_code == 'TK_Complete'``. Filtering them silently broke
+    # the curve for every progressed schedule — a 60%-complete project
+    # with 100 activities computed total=40 (only the incomplete ones),
+    # producing a curve normalized to the wrong base. Including them
+    # makes the curve correctly show "X% complete at day 0" plus the
+    # planned ramp-up of the remaining work.
+    finishes = [ar.early_finish for ar in cpm.activity_results.values()]
+    if not finishes:
+        return []
+    total = len(finishes)
+    duration = int(max(finishes)) + 1
+    finishes_sorted = sorted(finishes)
+    # Sweep day-by-day, count cumulative completions.
+    points: list[tuple[int, float]] = []
+    idx = 0
+    for day in range(duration + 1):
+        while idx < total and finishes_sorted[idx] <= day:
+            idx += 1
+        points.append((day, idx / total))
+    return points
+
+
+def extract_actual_curve(
+    schedule: "ParsedSchedule", data_date_iso: str | None
+) -> list[tuple[int, float]]:
+    """Return the actual completion-percent S-curve from ``act_end_date`` per activity.
+
+    Day 0 is the schedule's ``data_date``. ``pct`` at day D is the
+    fraction of activities with ``act_end_date <= data_date + D days``.
+
+    **Pre-data-date completions are clamped to day 0** — activities that
+    finished BEFORE the data_date count as already-complete at the start
+    of the curve. Without this clamp, the synthetic case where a re-
+    uploaded XER has actuals predating its data_date silently produces
+    an empty curve (filter dropped all negatives), defeating the
+    "executed view" UX. The visualization treats day 0 as "starting
+    point of the data-date window"; pre-existing completions show as
+    a non-zero starting value.
+
+    Returns empty list when no actuals are available — older XERs without
+    progress data degrade gracefully.
+    """
+    if not schedule.activities or not data_date_iso:
+        return []
+    try:
+        data_date = datetime.fromisoformat(data_date_iso.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return []
+    actuals: list[float] = []
+    for task in schedule.activities:
+        end = task.act_end_date
+        if end is None:
+            continue
+        # Normalize to naive UTC for arithmetic comparison.
+        if end.tzinfo is None:
+            end_naive = end
+        else:
+            end_naive = end.astimezone(data_date.tzinfo).replace(tzinfo=None)
+        dd_naive = data_date.replace(tzinfo=None)
+        delta_days = (end_naive - dd_naive).total_seconds() / 86400.0
+        # Clamp pre-data-date completions to day 0 — they're already done.
+        actuals.append(max(0.0, delta_days))
+    if not actuals:
+        return []
+    total = len(schedule.activities)
+    actuals_sorted = sorted(actuals)
+    duration = int(max(actuals_sorted)) + 1
+    points: list[tuple[int, float]] = []
+    idx = 0
+    for day in range(duration + 1):
+        while idx < len(actuals_sorted) and actuals_sorted[idx] <= day:
+            idx += 1
+        points.append((day, idx / total))
+    return points
+
+
+def planned_finish_day(planned_curve: list[tuple[int, float]]) -> int | None:
+    """Return the day at which planned cumulative crosses 100% (or last day).
+
+    For curves that don't reach 100% (e.g., CPM with unresolved cycles),
+    returns the last day in the curve as the best-effort proxy.
+    """
+    if not planned_curve:
+        return None
+    for day, pct in planned_curve:
+        if pct >= 0.99:
+            return day
+    return planned_curve[-1][0]
+
+
+# ── CUSUM change-point detection (pure numpy) ─────────────
+
+
+def cusum_change_points(
+    shift_series: list[float],
+    threshold_multiplier: float = _CUSUM_SIGMA_THRESHOLD,
+) -> list[tuple[int, float]]:
+    """Pure-numpy CUSUM detection on the inter-revision shift series.
+
+    Returns ``[(index, cusum_value), …]`` for each index where the
+    upward or downward CUSUM crossed ``threshold_multiplier × sigma``.
+    Threshold convention: Page (1954) "moderate sensitivity" default.
+
+    Empty list if the series is too short (< _MIN_REVISIONS_FOR_CUSUM)
+    or has zero variance.
+    """
+    arr = np.asarray(shift_series, dtype=float)
+    if arr.size < _MIN_REVISIONS_FOR_CUSUM - 1:
+        return []
+    sigma = float(arr.std(ddof=1))
+    if sigma <= 0.0:
+        return []
+    threshold = threshold_multiplier * sigma
+    mean = float(arr.mean())
+    centered = arr - mean
+    cusum = np.cumsum(centered)
+    detections: list[tuple[int, float]] = []
+    for i, v in enumerate(cusum):
+        if abs(v) >= threshold:
+            detections.append((int(i), float(v)))
+    return detections
+
+
+# ── Heteroscedasticity-aware slope CI (pure numpy) ────────
+
+
+def slope_with_horizon_ci(
+    shift_series: list[float],
+    horizon: int = 1,
+    z: float = 1.96,
+) -> SlopeBand | None:
+    """Closed-form OLS slope on the shift series with horizon-scaled CI.
+
+    Per ADR-0022 §"W3 — C-visualization": variance grows ∝ √horizon.
+    The returned ``ci_lower``/``ci_upper`` widen linearly in √horizon.
+
+    Returns ``None`` when the series is shorter than
+    ``_MIN_REVISIONS_FOR_SLOPE - 1`` deltas (i.e., < 2 deltas → can't
+    compute residual variance).
+    """
+    arr = np.asarray(shift_series, dtype=float)
+    n = arr.size
+    if n < _MIN_REVISIONS_FOR_SLOPE - 1:
+        return None
+    x = np.arange(n, dtype=float)
+    # OLS slope via numpy.polyfit (closed-form, no scipy dep).
+    if n <= 2:
+        # DA exit-council fix-up #P3-5: degenerate — can't compute residual
+        # variance with df = n - 2 = 0. Returning slope == ci_lower == ci_upper
+        # (zero-width CI band) would mis-render in UI as high confidence.
+        # Return None so the orchestrator emits an explicit "<3 revisions —
+        # slope CI undefined" note instead.
+        return None
+    slope, intercept = np.polyfit(x, arr, 1)
+    # Residual std for CI.
+    fitted = slope * x + intercept
+    residuals = arr - fitted
+    sigma_res = float(np.sqrt(np.sum(residuals**2) / (n - 2)))
+    # Standard error of the slope.
+    sx2 = float(np.sum((x - x.mean()) ** 2))
+    if sx2 <= 0.0:
+        return None
+    se_slope = sigma_res / np.sqrt(sx2)
+    # Heteroscedasticity scaling: variance ∝ √horizon → SE widens with √horizon.
+    se_at_horizon = se_slope * float(np.sqrt(max(1, horizon)))
+    margin = z * se_at_horizon
+    return SlopeBand(
+        slope_days_per_revision=float(slope),
+        ci_lower=float(slope - margin),
+        ci_upper=float(slope + margin),
+        horizon_revisions=horizon,
+    )
+
+
+# ── Orchestrator ──────────────────────────────────────────
+
+
+def analyze_revision_trends(
+    *,
+    project_id: str,
+    program_id: str | None,
+    revisions: list[tuple[str, str | None, int | None, str | None, "ParsedSchedule"]],
+) -> RevisionTrendsAnalysis:
+    """Build a complete RevisionTrendsAnalysis from per-revision schedules.
+
+    ``revisions`` is a list of ``(project_id, revision_id, revision_number,
+    data_date_iso, schedule)`` tuples — caller MUST sort ascending by
+    ``data_date``. Caller is responsible for RLS-scoped fetches via
+    ``store.get_project(pid, user_id=user_id)`` + ``list_revision_history_by_program``.
+
+    The most-recent revision (last in the list) gets the executed curve;
+    older revisions only get planned curves.
+    """
+    out = RevisionTrendsAnalysis(project_id=project_id, program_id=program_id)
+
+    if not revisions:
+        out.notes.append("no revisions in program — empty analysis")
+        return out
+
+    # Per-revision curve extraction.
+    finish_days: list[float] = []
+    for i, (rid_proj, rev_id, rev_num, dd_iso, sched) in enumerate(revisions):
+        is_latest = i == len(revisions) - 1
+        planned = extract_planned_curve(sched)
+        actual = extract_actual_curve(sched, dd_iso) if is_latest else []
+        actual_by_day = {d: pct for d, pct in actual}
+        curve_points = [
+            CurvePoint(
+                day_offset=day,
+                planned_cumulative_pct=pct,
+                actual_cumulative_pct=actual_by_day.get(day) if is_latest else None,
+            )
+            for day, pct in planned
+        ]
+        out.curves.append(
+            RevisionCurve(
+                project_id=rid_proj,
+                revision_id=rev_id,
+                revision_number=rev_num,
+                data_date=dd_iso,
+                points=curve_points,
+                is_executed=is_latest,
+            )
+        )
+        fd = planned_finish_day(planned)
+        if fd is not None and dd_iso is not None:
+            try:
+                base = datetime.fromisoformat(dd_iso.replace("Z", "+00:00"))
+                absolute_finish_day = (base + timedelta(days=fd)).toordinal()
+                finish_days.append(float(absolute_finish_day))
+            except (ValueError, TypeError):
+                pass
+
+    if len(finish_days) < 2:
+        out.notes.append("fewer than 2 finish-day samples — change-point + slope omitted")
+        return out
+
+    # Inter-revision shift series (signed deltas in days).
+    shifts = [float(finish_days[i] - finish_days[i - 1]) for i in range(1, len(finish_days))]
+
+    # Slope band (requires >= 2 deltas i.e. >= 3 revisions).
+    if len(shifts) >= _MIN_REVISIONS_FOR_SLOPE - 1:
+        out.slope_band = slope_with_horizon_ci(shifts, horizon=1)
+    else:
+        out.notes.append("<3 revisions — slope band omitted")
+
+    # CUSUM change-points (requires >= 4 deltas i.e. >= 5 revisions).
+    if len(shifts) >= _MIN_REVISIONS_FOR_CUSUM - 1:
+        for idx, cusum_val in cusum_change_points(shifts):
+            # idx is 0-based in the shifts series → revision_index in curves
+            # is idx + 1 (the revision AFTER the prior).
+            rev_index = idx + 1
+            rev_curve = out.curves[rev_index]
+            out.change_points.append(
+                ChangePointMarker(
+                    revision_index=rev_index,
+                    revision_id=rev_curve.revision_id,
+                    delta_days=int(shifts[idx]),
+                    cusum_value=cusum_val,
+                    description=(
+                        f"shift of {int(shifts[idx])} days vs prior revision; "
+                        f"CUSUM={cusum_val:.1f} crosses {_CUSUM_SIGMA_THRESHOLD}σ "
+                        f"threshold — regime change detected"
+                    ),
+                )
+            )
+    else:
+        out.notes.append(
+            f"<{_MIN_REVISIONS_FOR_CUSUM} revisions — CUSUM change-point detection skipped"
+        )
+
+    return out
+
+
+__all__: list[str] = [
+    "CurvePoint",
+    "RevisionCurve",
+    "ChangePointMarker",
+    "SlopeBand",
+    "RevisionTrendsAnalysis",
+    "METHODOLOGY_CITATION",
+    "extract_planned_curve",
+    "extract_actual_curve",
+    "planned_finish_day",
+    "cusum_change_points",
+    "slope_with_horizon_ci",
+    "analyze_revision_trends",
+]

--- a/src/api/routers/revisions.py
+++ b/src/api/routers/revisions.py
@@ -1,12 +1,15 @@
 # MIT License
 # Copyright (c) 2026 Vitor Maia Rodovalho
-"""Revision detection + soft-tombstone router (Cycle 4 W2 PR-A — ADR-0022).
+"""Revision detection + soft-tombstone + multi-rev trends router.
 
-Three endpoints:
+Cycle 4 W2 PR-A + W3 PR-A — ADR-0022 + Amendment 2.
 
-- ``POST /api/v1/projects/{id}/detect-revision-of`` — heuristic, no writes
-- ``POST /api/v1/projects/{id}/confirm-revision-of`` — append-only INSERT
-- ``POST /api/v1/revisions/{id}/tombstone`` — soft-delete + audit_log
+Endpoints:
+
+- ``POST /api/v1/projects/{id}/detect-revision-of`` — W2 heuristic, no writes
+- ``POST /api/v1/projects/{id}/confirm-revision-of`` — W2 append-only INSERT
+- ``POST /api/v1/revisions/{id}/tombstone`` — W2 soft-delete + audit_log
+- ``GET  /api/v1/projects/{id}/revision-trends`` — W3 multi-rev S-curve overlay
 
 The detection heuristic v1 is encoded in
 ``src.api.revision_detection.detect_candidate_parent`` per ADR-0022
@@ -31,13 +34,20 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 
+from src.analytics.revision_trends import analyze_revision_trends
+
 from ..auth import require_auth
 from ..deps import RATE_LIMIT_ANALYSIS, RATE_LIMIT_WRITE, get_store, limiter
 from ..revision_detection import compute_xer_content_hash, detect_candidate_parent
 from ..schemas import (
+    ChangePointMarkerSchema,
     ConfirmRevisionOfRequest,
     ConfirmRevisionOfResponse,
     DetectRevisionOfResponse,
+    RevisionCurvePoint,
+    RevisionCurveSchema,
+    RevisionTrendsResponse,
+    SlopeBandSchema,
     TombstoneRevisionRequest,
     TombstoneRevisionResponse,
 )
@@ -238,4 +248,149 @@ def tombstone_revision_endpoint(
         audit_log_id=(
             str(result["audit_log_id"]) if result.get("audit_log_id") is not None else None
         ),
+    )
+
+
+# ────────────────────────────────────────────────────────────
+# 4. revision-trends (multi-rev S-curve overlay)
+# ────────────────────────────────────────────────────────────
+
+
+@router.get(
+    "/api/v1/projects/{project_id}/revision-trends",
+    response_model=RevisionTrendsResponse,
+)
+@limiter.limit(RATE_LIMIT_ANALYSIS)
+def revision_trends_endpoint(
+    request: Request,
+    project_id: str,
+    user: dict[str, Any] = Depends(require_auth),
+) -> RevisionTrendsResponse:
+    """Return the multi-revision S-curve overlay + change-points + slope band.
+
+    Cycle 4 W3 PR-A per ADR-0022. Visualization-only: NO forecast curve
+    in W3 (path-A pre-commitment per ADR-0022 W4 calibration gate).
+
+    CPM × N revisions runs at request time — bounded by W1 cap=12 active
+    revisions per project (migration 028 ``enforce_revision_cap``
+    trigger). RATE_LIMIT_ANALYSIS (20/min) is sufficient at the cap;
+    EXPENSIVE bucket is reserved for Monte Carlo / PDF / forensic loops.
+
+    Caching deferred per backend-reviewer entry-council #8 — would
+    require coupling with W2 confirm/tombstone writers for invalidation.
+
+    Methodology citation surfaced in the response for forensic
+    credibility (AACE RP 29R-03 §"Window analysis").
+    """
+    store = get_store()
+    user_id = user.get("id")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    # 1. Load the current project's metadata + program_id.
+    current = store.get_project_meta(project_id, user_id=user_id)
+    if current is None:
+        raise HTTPException(status_code=404, detail=f"project {project_id} not found")
+    program_id = current.get("program_id")
+    if not program_id:
+        # Not in a program — single-revision view; return curve-only response.
+        sched = store.get_project(project_id, user_id=user_id)
+        if sched is None:
+            raise HTTPException(status_code=404, detail="project schedule not available")
+        analysis = analyze_revision_trends(
+            project_id=project_id,
+            program_id=None,
+            revisions=[(project_id, None, None, current.get("data_date"), sched)],
+        )
+        analysis.notes.insert(
+            0,
+            "project not assigned to a program (anonymous upload?) — single-revision view returned",
+        )
+        return _to_response(analysis)
+
+    # 2. Load all sibling projects in the program (RLS-scoped).
+    siblings = store.list_projects_in_program(program_id, user_id=user_id)
+    # Map project_id → revision_history row (active only) for revision_number.
+    rh_rows = store.list_revision_history_by_program(program_id, user_id=user_id)
+    rh_by_project: dict[str, dict[str, Any]] = {
+        r["project_id"]: r for r in rh_rows if r.get("tombstoned_at") is None
+    }
+
+    # 3. Build (project_id, rev_id, rev_num, data_date_iso, schedule) tuples,
+    #    sorted ascending by data_date for the orchestrator.
+    revisions: list[tuple[str, str | None, int | None, str | None, Any]] = []
+    for s in siblings:
+        pid = s["project_id"]
+        sched = store.get_project(pid, user_id=user_id)
+        if sched is None:
+            continue
+        rh = rh_by_project.get(pid)
+        revisions.append(
+            (
+                pid,
+                str(rh["id"]) if rh else None,
+                int(rh["revision_number"]) if rh else None,
+                s.get("data_date"),
+                sched,
+            )
+        )
+    revisions.sort(key=lambda t: t[3] or "")
+
+    if not revisions:
+        analysis = analyze_revision_trends(
+            project_id=project_id, program_id=program_id, revisions=[]
+        )
+        return _to_response(analysis)
+
+    analysis = analyze_revision_trends(
+        project_id=project_id, program_id=program_id, revisions=revisions
+    )
+    return _to_response(analysis)
+
+
+def _to_response(analysis: Any) -> RevisionTrendsResponse:
+    """Convert the dataclass-based RevisionTrendsAnalysis to Pydantic."""
+    return RevisionTrendsResponse(
+        project_id=analysis.project_id,
+        program_id=analysis.program_id,
+        curves=[
+            RevisionCurveSchema(
+                project_id=c.project_id,
+                revision_id=c.revision_id,
+                revision_number=c.revision_number,
+                data_date=c.data_date,
+                points=[
+                    RevisionCurvePoint(
+                        day_offset=p.day_offset,
+                        planned_cumulative_pct=p.planned_cumulative_pct,
+                        actual_cumulative_pct=p.actual_cumulative_pct,
+                    )
+                    for p in c.points
+                ],
+                is_executed=c.is_executed,
+            )
+            for c in analysis.curves
+        ],
+        change_points=[
+            ChangePointMarkerSchema(
+                revision_index=cp.revision_index,
+                revision_id=cp.revision_id,
+                delta_days=cp.delta_days,
+                cusum_value=cp.cusum_value,
+                description=cp.description,
+            )
+            for cp in analysis.change_points
+        ],
+        slope_band=(
+            SlopeBandSchema(
+                slope_days_per_revision=analysis.slope_band.slope_days_per_revision,
+                ci_lower=analysis.slope_band.ci_lower,
+                ci_upper=analysis.slope_band.ci_upper,
+                horizon_revisions=analysis.slope_band.horizon_revisions,
+            )
+            if analysis.slope_band
+            else None
+        ),
+        methodology=analysis.methodology,
+        notes=analysis.notes,
     )

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -1986,3 +1986,80 @@ class TombstoneRevisionResponse(BaseModel):
     revision_id: str
     tombstoned_at: str
     audit_log_id: Optional[str] = None
+
+
+# ── Revision trends — multi-rev S-curve overlay (Cycle 4 W3 PR-A) ───
+
+
+class RevisionCurvePoint(BaseModel):
+    """One point on a per-revision completion-percent curve.
+
+    See ``src.analytics.revision_trends`` for the methodology
+    (AACE RP 29R-03 §"Window analysis"). ``planned_cumulative_pct`` and
+    ``actual_cumulative_pct`` are fractions in [0.0, 1.0].
+    """
+
+    day_offset: int = Field(..., description="Days from the revision's data_date")
+    planned_cumulative_pct: float
+    actual_cumulative_pct: Optional[float] = None
+
+
+class RevisionCurveSchema(BaseModel):
+    """One revision's S-curve metadata + points.
+
+    ``is_executed=true`` only for the most recent revision per ADR-0022
+    W3 spec — older revisions' actuals are intentionally suppressed.
+    """
+
+    project_id: str
+    revision_id: Optional[str] = None
+    revision_number: Optional[int] = None
+    data_date: Optional[str] = None
+    points: list[RevisionCurvePoint] = Field(default_factory=list)
+    is_executed: bool = False
+
+
+class ChangePointMarkerSchema(BaseModel):
+    """A revision index where the CUSUM crossed the threshold."""
+
+    revision_index: int
+    revision_id: Optional[str] = None
+    delta_days: int
+    cusum_value: float
+    description: str
+
+
+class SlopeBandSchema(BaseModel):
+    """Heteroscedasticity-aware OLS slope of inter-revision finish-shift."""
+
+    slope_days_per_revision: float
+    ci_lower: float
+    ci_upper: float
+    horizon_revisions: int
+
+
+class RevisionTrendsResponse(BaseModel):
+    """Response for GET /api/v1/projects/{id}/revision-trends.
+
+    Visualization-only contract per ADR-0022 §"W3 — C-visualization":
+    NO forecast curve. The W4 calibration gate (path-A pre-commit per
+    ADR-0022 §W4) decides whether the optimism-pattern forecast feature
+    can ship in a future cycle.
+
+    ``methodology`` carries the AACE RP 29R-03 citation surfaced to the
+    UI for forensic credibility. ``notes`` accumulates honesty-debt
+    strings ("<5 revisions — CUSUM skipped", etc.).
+
+    ``model_config = ConfigDict(extra="forbid")`` — surfaces drift if
+    the analytics module adds fields without updating this schema.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    project_id: str
+    program_id: Optional[str] = None
+    curves: list[RevisionCurveSchema] = Field(default_factory=list)
+    change_points: list[ChangePointMarkerSchema] = Field(default_factory=list)
+    slope_band: Optional[SlopeBandSchema] = None
+    methodology: str = ""
+    notes: list[str] = Field(default_factory=list)

--- a/tests/test_revision_trends.py
+++ b/tests/test_revision_trends.py
@@ -1,0 +1,301 @@
+# MIT License
+# Copyright (c) 2026 Vitor Maia Rodovalho
+"""Cycle 4 W3 PR-A — unit tests for src/analytics/revision_trends.py.
+
+Pins the analytics contract: per-revision curve extraction, CUSUM change-
+point detection, heteroscedasticity-aware slope CI band. Defends against
+the engine_version-style ADR drift class — the methodology citation
+string is checked verbatim against the constant.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from src.analytics.revision_trends import (
+    METHODOLOGY_CITATION,
+    analyze_revision_trends,
+    cusum_change_points,
+    extract_actual_curve,
+    extract_planned_curve,
+    planned_finish_day,
+    slope_with_horizon_ci,
+)
+from src.parser.models import ParsedSchedule, Project, Task
+
+
+def _act(
+    task_id: str,
+    duration_hr: float,
+    target_end_offset_days: int = 0,
+    act_end_offset_days: int | None = None,
+    base_date: datetime | None = None,
+) -> Task:
+    """Build a Task with target/actual end dates for curve testing.
+
+    CPMCalculator reads ``remain_drtn_hr_cnt`` (line 147 of cpm.py) for
+    duration — set both fields so tests don't rely on parser-side
+    propagation.
+    """
+    base = base_date or datetime(2026, 1, 1, tzinfo=timezone.utc)
+    return Task(
+        task_id=task_id,
+        target_drtn_hr_cnt=duration_hr,
+        remain_drtn_hr_cnt=duration_hr,
+        target_end_date=base + timedelta(days=target_end_offset_days),
+        act_end_date=(
+            base + timedelta(days=act_end_offset_days) if act_end_offset_days is not None else None
+        ),
+    )
+
+
+def _schedule_with_acts(activities: list[Task]) -> ParsedSchedule:
+    """Build a minimal ParsedSchedule with activities + a single project."""
+    sched = ParsedSchedule()
+    sched.projects.append(
+        Project(
+            proj_id="1",
+            proj_short_name="W3-TEST",
+            last_recalc_date=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+    )
+    sched.activities = activities
+    return sched
+
+
+# ── extract_planned_curve ─────────────────────────────────
+
+
+def test_extract_planned_curve_empty_schedule_returns_empty() -> None:
+    sched = ParsedSchedule()
+    assert extract_planned_curve(sched) == []
+
+
+def test_extract_planned_curve_monotonic_non_decreasing() -> None:
+    """The cumulative curve is non-decreasing — never goes backwards."""
+    acts = [_act(f"t{i}", duration_hr=8.0 * (i + 1)) for i in range(5)]
+    sched = _schedule_with_acts(acts)
+    curve = extract_planned_curve(sched)
+    assert curve, "expected non-empty curve"
+    pcts = [pct for _day, pct in curve]
+    for i in range(1, len(pcts)):
+        assert pcts[i] >= pcts[i - 1], f"curve dipped at index {i}"
+    # Final point must be at or near 1.0 (within float tolerance)
+    assert pcts[-1] >= 0.99
+
+
+def test_extract_planned_curve_starts_at_zero_or_below_one() -> None:
+    acts = [_act(f"t{i}", duration_hr=40.0) for i in range(3)]
+    sched = _schedule_with_acts(acts)
+    curve = extract_planned_curve(sched)
+    assert curve[0][1] <= curve[-1][1]
+
+
+# ── extract_actual_curve ──────────────────────────────────
+
+
+def test_extract_actual_curve_no_actuals_returns_empty() -> None:
+    acts = [_act(f"t{i}", duration_hr=40.0) for i in range(3)]
+    sched = _schedule_with_acts(acts)
+    curve = extract_actual_curve(sched, "2026-01-01")
+    assert curve == []
+
+
+def test_extract_actual_curve_with_actuals() -> None:
+    acts = [
+        _act("t1", duration_hr=40.0, act_end_offset_days=5),
+        _act("t2", duration_hr=40.0, act_end_offset_days=10),
+        _act("t3", duration_hr=40.0, act_end_offset_days=None),  # not yet finished
+    ]
+    sched = _schedule_with_acts(acts)
+    curve = extract_actual_curve(sched, "2026-01-01")
+    assert curve, "expected non-empty actual curve when ≥1 actual present"
+    # Final pct should be 2/3 (two activities completed of three)
+    assert abs(curve[-1][1] - 2 / 3) < 1e-6
+
+
+# ── planned_finish_day ────────────────────────────────────
+
+
+def test_planned_finish_day_returns_first_99_pct_crossing() -> None:
+    curve = [(0, 0.0), (5, 0.5), (10, 0.99), (15, 1.0)]
+    assert planned_finish_day(curve) == 10
+
+
+def test_planned_finish_day_empty_returns_none() -> None:
+    assert planned_finish_day([]) is None
+
+
+# ── cusum_change_points ──────────────────────────────────
+
+
+def test_cusum_too_short_returns_empty() -> None:
+    assert cusum_change_points([10.0, 20.0]) == []
+
+
+def test_cusum_zero_variance_returns_empty() -> None:
+    assert cusum_change_points([5.0] * 10) == []
+
+
+def test_cusum_detects_planted_step_change() -> None:
+    """6 deltas with a step change at index 3 → CUSUM should flag it.
+
+    Series: [10, 10, 10, 50, 50, 50] — constant + jump + constant.
+    The CUSUM crosses threshold AT or AFTER the planted change at index 2-3
+    (CUSUM accumulates negative-then-positive, peaks where the regime shifts).
+    Threshold lowered to 2σ for sensitivity on this short synthetic series.
+    """
+    shifts = [10.0, 10.0, 10.0, 50.0, 50.0, 50.0]
+    detections = cusum_change_points(shifts, threshold_multiplier=2.0)
+    assert detections, f"expected ≥1 detection, got {detections}"
+    detected_indices = [idx for idx, _ in detections]
+    # CUSUM detects at the regime-shift boundary (index 2 — last "old" value
+    # before the jump, where the cumulative deviation peaks). Accept index
+    # ≥ 2 as evidence of detection.
+    assert any(i >= 2 for i in detected_indices), (
+        f"expected detection at or after the regime shift (index ≥ 2), "
+        f"got indices {detected_indices}"
+    )
+
+
+def test_cusum_no_change_returns_empty_or_low() -> None:
+    """Linear-trend series should not produce huge CUSUM values."""
+    shifts = list(range(10))  # 0, 1, 2, ..., 9 — linear, no step
+    detections = cusum_change_points([float(s) for s in shifts], threshold_multiplier=5.0)
+    # 5σ on a quasi-linear signal — should not detect at default threshold
+    assert detections == [] or all(abs(v) < 50 for _i, v in detections), (
+        "CUSUM should not over-detect on linear trends at 5σ threshold"
+    )
+
+
+# ── slope_with_horizon_ci ────────────────────────────────
+
+
+def test_slope_too_short_returns_none() -> None:
+    assert slope_with_horizon_ci([5.0]) is None
+
+
+def test_slope_constant_series_zero_slope() -> None:
+    band = slope_with_horizon_ci([10.0, 10.0, 10.0, 10.0])
+    assert band is not None
+    assert abs(band.slope_days_per_revision) < 1e-6
+
+
+def test_slope_increasing_series_positive_slope() -> None:
+    band = slope_with_horizon_ci([10.0, 20.0, 30.0, 40.0, 50.0])
+    assert band is not None
+    assert band.slope_days_per_revision > 0
+
+
+def test_slope_ci_widens_with_horizon() -> None:
+    """CI band widens linearly in √horizon — heteroscedasticity contract."""
+    series = [10.0, 12.0, 11.0, 14.0, 13.0, 16.0]
+    band1 = slope_with_horizon_ci(series, horizon=1)
+    band4 = slope_with_horizon_ci(series, horizon=4)
+    assert band1 is not None and band4 is not None
+    width1 = band1.ci_upper - band1.ci_lower
+    width4 = band4.ci_upper - band4.ci_lower
+    assert width4 > width1, "CI must widen with horizon (σ ∝ √horizon)"
+    # √4 = 2 → width should approximately double
+    ratio = width4 / max(1e-9, width1)
+    assert 1.5 < ratio < 2.5, f"horizon=4 should ≈2× horizon=1 width, got {ratio:.2f}"
+
+
+# ── methodology citation ─────────────────────────────────
+
+
+def test_methodology_cites_aace_29r_03() -> None:
+    """ADR drift defense — the citation string is checked verbatim."""
+    assert "AACE RP 29R-03" in METHODOLOGY_CITATION
+    assert "Window analysis" in METHODOLOGY_CITATION
+    assert "CUSUM" in METHODOLOGY_CITATION
+    assert "√horizon" in METHODOLOGY_CITATION or "sqrt(horizon)" in METHODOLOGY_CITATION
+    assert "Forecast curve intentionally omitted" in METHODOLOGY_CITATION
+
+
+# ── analyze_revision_trends orchestrator ─────────────────
+
+
+def test_analyze_no_revisions_returns_empty_with_note() -> None:
+    out = analyze_revision_trends(project_id="proj-A", program_id=None, revisions=[])
+    assert out.curves == []
+    assert out.change_points == []
+    assert out.slope_band is None
+    assert any("no revisions" in n for n in out.notes)
+
+
+def test_analyze_single_revision_executes_marker_and_skips_slope() -> None:
+    sched = _schedule_with_acts([_act(f"t{i}", duration_hr=40.0) for i in range(3)])
+    out = analyze_revision_trends(
+        project_id="proj-A",
+        program_id="prog-1",
+        revisions=[("proj-A", "rev-1", 1, "2026-01-01", sched)],
+    )
+    assert len(out.curves) == 1
+    assert out.curves[0].is_executed is True
+    assert out.slope_band is None
+    assert any("slope band omitted" in n or "fewer than 2 finish" in n for n in out.notes)
+
+
+def test_analyze_three_revisions_no_slope_no_cusum() -> None:
+    """N=3 → 2 deltas → slope band undefined (df=0) per DA P3-5; no CUSUM."""
+    revs = []
+    for i in range(3):
+        sched = _schedule_with_acts([_act(f"t{j}", duration_hr=40.0) for j in range(3)])
+        dd_iso = (datetime(2026, 1, 1, tzinfo=timezone.utc) + timedelta(days=30 * i)).isoformat()
+        revs.append((f"proj-{i}", f"rev-{i}", i + 1, dd_iso, sched))
+    out = analyze_revision_trends(project_id="proj-2", program_id="prog-1", revisions=revs)
+    assert len(out.curves) == 3
+    assert out.curves[-1].is_executed is True
+    assert out.slope_band is None, "3 revisions = 2 deltas → df=0 → slope CI undefined per DA P3-5"
+
+
+def test_analyze_four_revisions_emits_slope_band_no_cusum() -> None:
+    """N=4 → 3 deltas → slope band emitted (df=1, minimum non-degenerate)."""
+    revs = []
+    for i in range(4):
+        sched = _schedule_with_acts([_act(f"t{j}", duration_hr=40.0) for j in range(3)])
+        dd_iso = (datetime(2026, 1, 1, tzinfo=timezone.utc) + timedelta(days=30 * i)).isoformat()
+        revs.append((f"proj-{i}", f"rev-{i}", i + 1, dd_iso, sched))
+    out = analyze_revision_trends(project_id="proj-3", program_id="prog-1", revisions=revs)
+    assert len(out.curves) == 4
+    assert out.slope_band is not None
+    assert any("CUSUM change-point detection skipped" in n for n in out.notes)
+
+
+def test_analyze_only_latest_carries_executed_actuals() -> None:
+    """Older revisions' actuals must be suppressed per ADR-0022 W3 spec."""
+    revs = []
+    for i in range(3):
+        # All revisions have act_end_date populated, but only the latest
+        # should expose actual_cumulative_pct values.
+        acts = [_act(f"t{j}", duration_hr=40.0, act_end_offset_days=5 + j) for j in range(3)]
+        sched = _schedule_with_acts(acts)
+        dd_iso = (datetime(2026, 1, 1, tzinfo=timezone.utc) + timedelta(days=30 * i)).isoformat()
+        revs.append((f"proj-{i}", f"rev-{i}", i + 1, dd_iso, sched))
+    out = analyze_revision_trends(project_id="proj-2", program_id="prog-1", revisions=revs)
+    # Older revisions' points have actual_cumulative_pct == None
+    older_actuals = [p.actual_cumulative_pct for c in out.curves[:-1] for p in c.points]
+    assert all(a is None for a in older_actuals), (
+        "Older revisions must NOT carry actual_cumulative_pct (ADR-0022 W3 spec)"
+    )
+    # Most recent revision carries some actual values
+    latest_actuals = [
+        p.actual_cumulative_pct
+        for p in out.curves[-1].points
+        if p.actual_cumulative_pct is not None
+    ]
+    assert latest_actuals, "Most recent revision should expose actual values"
+
+
+def test_analyze_curves_ordered_by_data_date() -> None:
+    """Caller is responsible for ascending data_date order; verify it survives."""
+    revs = []
+    iso_a = "2026-03-01T00:00:00+00:00"
+    iso_b = "2026-04-01T00:00:00+00:00"
+    iso_c = "2026-05-01T00:00:00+00:00"
+    for pid, dd_iso in [("p1", iso_a), ("p2", iso_b), ("p3", iso_c)]:
+        sched = _schedule_with_acts([_act(f"t{i}", duration_hr=40.0) for i in range(2)])
+        revs.append((pid, None, None, dd_iso, sched))
+    out = analyze_revision_trends(project_id="p3", program_id="prog-1", revisions=revs)
+    assert [c.data_date for c in out.curves] == [iso_a, iso_b, iso_c]


### PR DESCRIPTION
## Summary

Cycle 4 W3 PR-A per ADR-0022 §"Wave plan W3" backend half. Visualization-only (NO forecast curve) — path-A pre-commitment for the W4 calibration gate.

- **`src/analytics/revision_trends.py`** (NEW) — pure-numpy CPM-based completion-percent S-curve extraction + CUSUM change-point detection + heteroscedasticity-aware OLS slope CI band
- **`GET /api/v1/projects/{id}/revision-trends`** — read-with-compute endpoint, RATE_LIMIT_ANALYSIS, RLS-scoped
- **5 new Pydantic schemas** — RevisionCurvePoint, RevisionCurveSchema, ChangePointMarkerSchema, SlopeBandSchema, RevisionTrendsResponse
- **22 new unit tests** — 1562 → 1584

## Methodology citation (DA-honest)

> AACE RP 29R-03 §"Window analysis" (multi-revision overlay primitive). CUSUM change-point per Page (1954, Biometrika 41) — applied as a separate exploratory SPC layer, NOT prescribed by AACE 29R-03. Heteroscedasticity-aware OLS slope band with σ ∝ √horizon.

DA P1-2 fix-up: split AACE primitive from Page CUSUM (was conflating).

## Council pre-check protocol (per ADR-0018 Am.1)

- ✅ **backend-reviewer entry-council** — 4 BLOCKING + 8 should-fix all addressed inline
  - No scipy → pure numpy
  - cashflow wrong primitive → CPM-based completion curve
  - get_project (RLS-aware) used everywhere
  - No new SELECT shape on revision_history
- ✅ **DA-as-second-reviewer exit-council** — 3 P1 + 5 P2 + 8 P3:
  - P1 #1: completed activities (TK_Complete) silently dropped → FIXED (removed early_finish > 0 filter)
  - P1 #2: methodology citation drift (sycophancy) → FIXED (split AACE + Page)
  - P1 #3: 5σ CUSUM essentially never fires → FIXED (lowered to 3σ)
  - P3 #5: n=2 zero-width CI band → FIXED (return None for n<3, _MIN_REVISIONS_FOR_SLOPE 3→4)
  - 4 P3 deferred to follow-up issues

## Test plan

- [x] 22 new unit tests — curve extraction, CUSUM, slope CI band widening, methodology pin, orchestrator state machine
- [x] Mypy strict 0 errors
- [x] Ruff format + lint clean
- [x] Full pytest: 1584/1584 passing
- [x] Catalog regen: 126 → 127 endpoints
- [ ] Manual smoke test post-deploy

## Deferred to W3-B + W3-C

- **W3-B**: Frontend `MultiRevisionSCurveChart.svelte` overlay component (next session)
- **W3-C**: W4 synthetic fixtures `tools/calibration_harness/fixtures/optimism_synth/` + `.lock` file (next session, ~0.5 wave)

## ADR-0022 Cycle 4 progress

Criterion #4 (C-visualization shipped + W4 fixtures hash-locked) is PARTIAL — backend done.

Cycle 4 progress: 2/9 → **2.5/9** (criterion #4 backend-side closed).

## Follow-up issues to file post-merge

- CUSUM symmetric: improvement vs slip indistinguishable (DA P3-1)
- Error handling on analyze_revision_trends in endpoint (DA P3-2)
- get_project None conflates "not found" with "RLS-denied" (DA P3-3)
- Empty curve UX in frontend (DA P3-4 — covered by W3-B)
- No endpoint integration test (DA P3-6)