### PR TITLE
chore(deps): backend floor bumps + wrangler-action Node 24 stopgap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,13 @@ jobs:
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
+        env:
+          # Stopgap: cloudflare/wrangler-action@v3.15.0 still uses
+          # `using: node20` (verified 2026-05-09). GitHub deprecates Node 20
+          # actions on 2026-06-02. Force Node 24 runtime until Cloudflare
+          # ships a Node-24-native version of the action. Remove this env
+          # block when wrangler-action declares `using: node24` upstream.
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,10 +32,10 @@ dependencies = [
     "pydantic>=2.13,<3.0",
     "networkx>=3.6",
     "numpy>=2.4",
-    "supabase>=2.29",
-    "python-dotenv>=1.0",
+    "supabase>=2.30",
+    "python-dotenv>=1.2",
     "python-multipart",
-    "sentry-sdk[fastapi]>=2.58",
+    "sentry-sdk[fastapi]>=2.59",
     "PyJWT[crypto]>=2.12",
     "defusedxml>=0.7",
 ]
@@ -46,7 +46,7 @@ export = ["pandas>=2.2", "openpyxl>=3.1"]
 reports = ["weasyprint>=62.0"]
 ai = ["anthropic>=0.97"]
 ml = ["scikit-learn>=1.8"]
-mcp = ["mcp>=1.20"]
+mcp = ["mcp>=1.27"]
 dev = ["pytest>=9.0.3", "pytest-cov>=7.1", "ruff>=0.15.12", "mypy>=1.20", "httpx>=0.27", "slowapi>=0.1.9", "psutil>=5.9"]
 all = ["meridianiq[api,export,reports,ai,ml,mcp,dev]"]
 


### PR DESCRIPTION
## Summary

Follow-up to PR #93 hygiene wave covering items intentionally deferred there. Two narrow tracks:

- **A.** Backend `pyproject.toml` floor bumps for safe minor gaps (no runtime impact — these were already resolved-to-latest on every install).
- **B.** Stopgap `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` on the Cloudflare Pages deploy step, surfaced live as an annotation on PR #93's post-merge CI run.

## What ships

### A. pyproject.toml — floor bumps

| Package | before | after | gap |
|---|---|---|---|
| supabase | `>=2.29` | `>=2.30` | 1 minor |
| python-dotenv | `>=1.0` | `>=1.2` | 2 minor |
| sentry-sdk[fastapi] | `>=2.58` | `>=2.59` | 1 minor |
| mcp | `>=1.20` | `>=1.27` | 7 minor (biggest cleanup) |

### B. .github/workflows/ci.yml — Cloudflare deploy step env block

```yaml
- name: Deploy to Cloudflare Pages
  uses: cloudflare/wrangler-action@v3
  env:
    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"   # remove once wrangler-action declares using: node24
```

`cloudflare/wrangler-action@v3.15.0` (latest stable, 2026-04-15) still declares `using: node20`. GitHub's [2025-09-19 deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) makes Node 24 the default on 2026-06-02 and removes Node 20 entirely on 2026-09-16. The runner-override env var is the documented stopgap.

## Out of scope (intentional — covered in commit body)

- mypy 2.0, pandas 3.0, weasyprint 68, psutil 7.2 — major bumps, each its own audit wave.
- Backend Dockerfile `python:3.13-slim` — pyiceberg 0.11.1 still has no cp314 wheel.
- wrangler-action v4 — does not exist; (B) is the mitigation.

## Test plan

- [x] `ruff check src/ tests/ tools/` — clean
- [x] `ruff format --check` — 228 files already formatted
- [x] `pytest tests/ -q` — 1584 passed, 6 skipped (zero regression vs PR #93 baseline)
- [ ] CI green
- [ ] Cloudflare deploy step shows no Node 20 deprecation annotation post-merge