### PR TITLE
feat(w3c): Cycle 4 W3 PR-C — optimism_synth fixtures + hash-lock + sub-gate C F1

### DIFF
--- a/tests/test_optimism_synth_fixtures.py
+++ b/tests/test_optimism_synth_fixtures.py
@@ -1,0 +1,347 @@
+# MIT License
+# Copyright (c) 2026 Vitor Maia Rodovalho
+"""Regression + tamper-detection tests for the optimism_synth fixtures.
+
+Source: Cycle 4 W3-C per ADR-0022 §"W3 fixture authoring + hash lock"
+(HB-D). The W4 sub-gate C calibration depends on these fixtures NOT
+being silently retuned between W3-close and W4 evaluation. These tests
+guarantee:
+
+1. **Determinism contract** — re-running the generator produces byte-
+   identical fixtures matching the committed lock. CI catches drift
+   from NumPy float-formatting changes, accidental edits, or seed-
+   value tampering.
+2. **Lock parity** — every committed fixture has a lock entry, and
+   every lock entry has an on-disk fixture (no orphans, no dangling
+   locked-but-missing files).
+3. **Tamper detection** — modifying a single fixture byte triggers
+   ``FixtureHashMismatch`` from ``verify_optimism_synth_hash_lock``,
+   so W4 sub-gate C can reliably abort evaluation when fixtures drift.
+4. **Engine compatibility** — all eight fixtures parse cleanly and
+   produce CUSUM input (``np.diff(finish_days)``) that the engine's
+   ``cusum_change_points`` consumes without raising.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from src.analytics.revision_trends import cusum_change_points
+from tools.calibration_harness import (
+    FixtureHashMismatch,
+    collapse_detection_clusters,
+    evaluate_cusum_f1,
+    parse_fixture_lock,
+    verify_optimism_synth_hash_lock,
+)
+from tools.calibration_harness.fixtures.optimism_synth._generator import (
+    CORNERS,
+    regenerate_all,
+)
+
+
+_FIXTURES_DIR = (
+    Path(__file__).parent.parent / "tools" / "calibration_harness" / "fixtures" / "optimism_synth"
+)
+_LOCK_PATH = _FIXTURES_DIR.parent / "optimism_synth.lock"
+
+# Locked sub-gate C F1 for the 8 committed fixtures + the engine at
+# revision_trends.py current state. DA exit-council P1 #1: ship F1
+# alongside the fixture lock to close the metric-definition axis of the
+# circular-tuning attack. If this number changes, EITHER the engine was
+# bumped (legitimate — re-baseline + amend ADR-0022) OR fixtures drifted
+# (the lock test catches that first). The literal value below is THE
+# pre-registered W4 sub-gate C result against the current engine.
+_LOCKED_SUB_GATE_C_F1: float = 0.769231
+
+
+def test_eight_corner_fixtures_committed() -> None:
+    """ADR-0022 spec: 8 corners of the 2³ design (σ × CP × baseline)."""
+    assert len(CORNERS) == 8
+    on_disk = sorted(p.name for p in _FIXTURES_DIR.glob("corner_*.json"))
+    assert len(on_disk) == 8
+
+
+def test_lock_file_present_and_parseable() -> None:
+    locked = parse_fixture_lock(_LOCK_PATH)
+    assert len(locked) == 8
+    for name, sha in locked.items():
+        assert name.startswith("corner_")
+        assert name.endswith(".json")
+        assert len(sha) == 64
+
+
+def test_committed_fixtures_match_lock() -> None:
+    """Regression: on-disk fixtures must match lock entries verbatim."""
+    actual = verify_optimism_synth_hash_lock()
+    assert len(actual) == 8
+
+
+def test_generator_is_deterministic(tmp_path: Path) -> None:
+    """Re-running the generator produces byte-identical fixtures.
+
+    DA exit-council P1 #2: drives the generator entirely under
+    ``tmp_path`` via parameterised ``regenerate_all(out_dir=, lock_path=)``,
+    so a test crash cannot corrupt the live working tree.
+
+    Catches NumPy float-formatting drift between minor versions, JSON
+    library changes, or accidental edits to ``_generator.py`` that
+    would silently change the locked content.
+    """
+    expected_hashes = parse_fixture_lock(_LOCK_PATH)
+    regenerated_hashes = regenerate_all(
+        out_dir=tmp_path / "fixtures",
+        lock_path=tmp_path / "optimism_synth.lock",
+    )
+    assert regenerated_hashes == expected_hashes, (
+        "Generator drift: re-running _generator.py into tmp_path produced different hashes "
+        "than the committed lock. Either NumPy/Python float formatting changed, or the "
+        "generator was edited. Investigate before regenerating + relocking."
+    )
+
+
+def test_tamper_detection_on_byte_flip(tmp_path: Path) -> None:
+    """Modifying a single fixture byte triggers FixtureHashMismatch.
+
+    Simulates the exact scenario the lock is designed to detect:
+    someone "improves" a fixture between W3-close and W4 evaluation.
+    """
+    # Mirror the committed fixtures + lock into a tmp dir.
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    for p in _FIXTURES_DIR.glob("corner_*.json"):
+        shutil.copy2(p, work_dir / p.name)
+    work_lock = tmp_path / "work.lock"
+    shutil.copy2(_LOCK_PATH, work_lock)
+
+    # Sanity: clean state verifies.
+    verify_optimism_synth_hash_lock(fixtures_dir=work_dir, lock_path=work_lock)
+
+    # Tamper: flip one character in the first fixture.
+    target = work_dir / "corner_01.json"
+    raw = target.read_text(encoding="utf-8")
+    tampered = raw.replace("100.", "999.", 1)
+    assert tampered != raw, "test setup: replace did not modify content"
+    target.write_text(tampered, encoding="utf-8")
+
+    with pytest.raises(FixtureHashMismatch, match="hash drift"):
+        verify_optimism_synth_hash_lock(fixtures_dir=work_dir, lock_path=work_lock)
+
+
+def test_tamper_detection_on_extra_file(tmp_path: Path) -> None:
+    """Adding an unlocked fixture triggers FixtureHashMismatch.
+
+    Catches a "I added a new corner without updating the lock"
+    tampering pattern (e.g., someone planting an easy fixture to
+    inflate sub-gate C F1).
+    """
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    for p in _FIXTURES_DIR.glob("corner_*.json"):
+        shutil.copy2(p, work_dir / p.name)
+    work_lock = tmp_path / "work.lock"
+    shutil.copy2(_LOCK_PATH, work_lock)
+
+    # Plant an extra corner.
+    extra = work_dir / "corner_99.json"
+    extra.write_text(json.dumps({"fixture_id": "corner_99", "schema_version": 1}), encoding="utf-8")
+
+    with pytest.raises(FixtureHashMismatch, match="missing_lock"):
+        verify_optimism_synth_hash_lock(fixtures_dir=work_dir, lock_path=work_lock)
+
+
+def test_tamper_detection_on_missing_file(tmp_path: Path) -> None:
+    """Removing a locked fixture triggers FixtureHashMismatch.
+
+    Catches a "I deleted a corner I didn't like" tampering pattern.
+    """
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    for p in _FIXTURES_DIR.glob("corner_*.json"):
+        shutil.copy2(p, work_dir / p.name)
+    work_lock = tmp_path / "work.lock"
+    shutil.copy2(_LOCK_PATH, work_lock)
+
+    # Delete one corner.
+    (work_dir / "corner_01.json").unlink()
+
+    with pytest.raises(FixtureHashMismatch, match="missing_disk"):
+        verify_optimism_synth_hash_lock(fixtures_dir=work_dir, lock_path=work_lock)
+
+
+def test_each_fixture_consumable_by_engine_cusum() -> None:
+    """All eight fixtures parse + run through the engine's CUSUM helper.
+
+    Does NOT assert detection success — that is W4 sub-gate C territory.
+    Asserts only that the fixture format is engine-compatible (no
+    parse error, no exception inside ``cusum_change_points``).
+    """
+    for path in sorted(_FIXTURES_DIR.glob("corner_*.json")):
+        fixture = json.loads(path.read_text(encoding="utf-8"))
+        finish_days = np.array(fixture["finish_days"], dtype=float)
+        assert finish_days.size == 12, (
+            f"{path.name}: expected N=12 revisions, got {finish_days.size}"
+        )
+        shifts = np.diff(finish_days)
+        # Should not raise.
+        result = cusum_change_points(shifts)
+        # Result is a list of (index, cusum_value) tuples; can be empty
+        # (engine correctly fails to detect under high-noise corners).
+        assert isinstance(result, list)
+        for idx, cusum_val in result:
+            assert 0 <= idx < shifts.size
+            assert isinstance(cusum_val, float)
+
+
+def test_fixtures_have_complete_ground_truth() -> None:
+    """Each fixture's ground truth is structurally complete for W4 F1 eval."""
+    for path in sorted(_FIXTURES_DIR.glob("corner_*.json")):
+        fixture = json.loads(path.read_text(encoding="utf-8"))
+        gt = fixture["ground_truth"]
+        assert "regime_change_at_revision_index" in gt
+        assert "tolerance_revisions" in gt
+        cp = gt["regime_change_at_revision_index"]
+        n = fixture["spec"]["n_revisions"]
+        assert 0 < cp < n, f"{path.name}: CP={cp} must be in (0, {n})"
+        assert gt["tolerance_revisions"] >= 0
+
+
+def test_fixture_design_covers_orthogonal_corners() -> None:
+    """The 8 corners cover the 2³ design space evenly.
+
+    σ ∈ {0.1, 0.4} × CP ∈ {3, 7} × baseline ∈ {A, B}: every cell exactly once.
+    Catches accidental duplication (e.g., two seeds for the same corner).
+    """
+    cells: set[tuple[float, int, str]] = set()
+    for path in sorted(_FIXTURES_DIR.glob("corner_*.json")):
+        f = json.loads(path.read_text(encoding="utf-8"))
+        spec = f["spec"]
+        cells.add(
+            (spec["noise_sigma"], spec["ground_truth_cp_revision_index"], spec["baseline_pattern"])
+        )
+    expected = {
+        (0.1, 3, "A"),
+        (0.1, 7, "A"),
+        (0.4, 3, "A"),
+        (0.4, 7, "A"),
+        (0.1, 3, "B"),
+        (0.1, 7, "B"),
+        (0.4, 3, "B"),
+        (0.4, 7, "B"),
+    }
+    assert cells == expected
+
+
+# --------------------------------------------------------------------------- #
+# Sub-gate C F1 evaluator tests (DA P1 #1+#3 closure).
+# --------------------------------------------------------------------------- #
+
+
+def test_collapse_clusters_basic() -> None:
+    assert collapse_detection_clusters([]) == []
+    assert collapse_detection_clusters([5]) == [(5, 5)]
+    assert collapse_detection_clusters([3, 4, 5, 6]) == [(3, 6)]
+    # max_gap=1 → gap of 2 splits clusters.
+    assert collapse_detection_clusters([3, 5, 8]) == [(3, 3), (5, 5), (8, 8)]
+    # max_gap=2 collapses 3↔5 but not 5↔8.
+    assert collapse_detection_clusters([3, 5, 8], max_gap=2) == [(3, 5), (8, 8)]
+    assert collapse_detection_clusters([3, 4, 7, 8]) == [(3, 4), (7, 8)]
+
+
+def test_collapse_clusters_handles_unsorted_input() -> None:
+    assert collapse_detection_clusters([6, 3, 5, 4]) == [(3, 6)]
+
+
+def test_evaluate_cusum_f1_perfect_match() -> None:
+    """One detection cluster perfectly aligned with the truth → F1=1.0."""
+    r = evaluate_cusum_f1(detections=[3, 4], ground_truths=[3])
+    assert r.f1 == 1.0
+    assert r.true_positives == 1
+    assert r.false_positives == 0
+    assert r.false_negatives == 0
+
+
+def test_evaluate_cusum_f1_no_detections_with_truths() -> None:
+    """Engine returns nothing — all FN, F1=0."""
+    r = evaluate_cusum_f1(detections=[], ground_truths=[3])
+    assert r.f1 == 0.0
+    assert r.true_positives == 0
+    assert r.false_positives == 0
+    assert r.false_negatives == 1
+
+
+def test_evaluate_cusum_f1_no_truths_no_detections() -> None:
+    """Vacuous case — no truths AND no detections. F1=0 by spec."""
+    r = evaluate_cusum_f1(detections=[], ground_truths=[])
+    assert r.f1 == 0.0
+    assert r.true_positives == 0
+
+
+def test_evaluate_cusum_f1_only_false_positive() -> None:
+    """Detection cluster nowhere near any truth → F1=0."""
+    r = evaluate_cusum_f1(detections=[10, 11], ground_truths=[3])
+    assert r.f1 == 0.0
+    assert r.false_positives == 1
+    assert r.false_negatives == 1
+
+
+def test_evaluate_cusum_f1_tolerance_window_inclusive() -> None:
+    """Cluster span [4, 8] with tolerance 1 covers truth 7."""
+    r = evaluate_cusum_f1(detections=[4, 5, 6, 7, 8], ground_truths=[7], tolerance=1)
+    assert r.true_positives == 1
+    assert r.false_positives == 0
+    assert r.f1 == 1.0
+
+
+def test_evaluate_cusum_f1_locked_baseline_against_committed_fixtures() -> None:
+    """LOCKED sub-gate C F1 against the 8 committed fixtures + engine.
+
+    DA exit-council P1 #3: ship F1 metric definition alongside the
+    fixture hash-lock so W4 evaluation cannot redefine F1 to produce
+    its preferred outcome. This test PINS the expected F1 — any drift
+    must be a legitimate engine bump (re-baseline + amend ADR-0022) or
+    a fixture drift (caught earlier by the lock test).
+    """
+    all_detections: list[int] = []
+    all_truths: list[int] = []
+    truth_offset = 0
+    for path in sorted(_FIXTURES_DIR.glob("corner_*.json")):
+        fx = json.loads(path.read_text(encoding="utf-8"))
+        finish_days = np.array(fx["finish_days"], dtype=float)
+        shifts = np.diff(finish_days)
+        # Engine convention: rev_index = idx + 1.
+        detected = [idx + 1 for idx, _ in cusum_change_points(shifts)]
+        # Offset each fixture's revision indices into a non-overlapping
+        # range so cross-fixture coincidences cannot spuriously match
+        # across corners.
+        all_detections.extend(d + truth_offset for d in detected)
+        all_truths.append(fx["ground_truth"]["regime_change_at_revision_index"] + truth_offset)
+        truth_offset += 100
+
+    result = evaluate_cusum_f1(detections=all_detections, ground_truths=all_truths, tolerance=1)
+    assert abs(result.f1 - _LOCKED_SUB_GATE_C_F1) < 1e-3, (
+        f"Sub-gate C F1 drift: got {result.f1}, locked {_LOCKED_SUB_GATE_C_F1}. "
+        f"TP={result.true_positives} FP={result.false_positives} FN={result.false_negatives}. "
+        "Either the engine changed (re-baseline + amend ADR-0022) or fixtures drifted "
+        "(should have failed the lock test first)."
+    )
+
+
+def test_locked_f1_relationship_to_sub_gate_c_threshold() -> None:
+    """Document whether the locked F1 passes ADR-0022 sub-gate C ≥ 0.75.
+
+    A structural pin: if the locked F1 is ever rotated to a value
+    below 0.75 (engine regression OR fixture-set toughening), this
+    assertion catches the rotation and forces an explicit ADR
+    update before the new path-A outcome lands silently.
+    """
+    assert _LOCKED_SUB_GATE_C_F1 >= 0.75, (
+        f"Locked F1 {_LOCKED_SUB_GATE_C_F1} would fail sub-gate C threshold 0.75. "
+        "If this is intentional (path-A activation expected), update ADR-0022 first "
+        "and replace this assertion with the explicit < 0.75 expectation."
+    )

--- a/tools/calibration_harness/__init__.py
+++ b/tools/calibration_harness/__init__.py
@@ -516,6 +516,225 @@ def truncated_program_key_hash(key: str) -> str:
     return hashlib.sha256(key.encode("utf-8")).hexdigest()[:12]
 
 
+# --------------------------------------------------------------------------- #
+# W3-C — optimism_synth fixture hash-lock verification (ADR-0022 HB-D).
+# --------------------------------------------------------------------------- #
+
+
+_OPTIMISM_SYNTH_DIR = Path(__file__).parent / "fixtures" / "optimism_synth"
+_OPTIMISM_SYNTH_LOCK = Path(__file__).parent / "fixtures" / "optimism_synth.lock"
+
+
+class FixtureHashMismatch(RuntimeError):
+    """Raised when an on-disk fixture does not match its hash-lock entry.
+
+    W4 sub-gate C MUST treat this as an evaluation abort: the fixtures
+    have been retuned post-W3-close, so the gate is structurally
+    invalid. ADR-0023 documents the tampering when this fires.
+    """
+
+
+def parse_fixture_lock(lock_path: Path) -> dict[str, str]:
+    """Parse a fixture lock file into ``{filename: sha256}``.
+
+    Lock-file format (W3-C, intentionally minimal — no library
+    dependency, no JSON-schema overhead):
+
+        # comments start with '#'
+        # blank lines ignored
+        <sha256_hex>  <relative_filename>
+
+    Spaces between hash and filename are flexible (≥1 whitespace).
+    """
+    out: dict[str, str] = {}
+    if not lock_path.exists():
+        raise FileNotFoundError(f"fixture lock not found: {lock_path}")
+    for raw in lock_path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split(None, 1)
+        if len(parts) != 2:
+            raise ValueError(f"malformed lock entry: {raw!r}")
+        sha, name = parts
+        if len(sha) != 64 or not all(c in "0123456789abcdef" for c in sha.lower()):
+            raise ValueError(f"non-sha256 hash in lock: {sha!r}")
+        out[name] = sha.lower()
+    return out
+
+
+def verify_optimism_synth_hash_lock(
+    fixtures_dir: Path | None = None,
+    lock_path: Path | None = None,
+) -> dict[str, str]:
+    """Verify every fixture in ``fixtures_dir`` matches its lock entry.
+
+    Returns the ``{filename: sha256}`` dict on success.
+
+    Raises:
+        FixtureHashMismatch: if any fixture's on-disk SHA256 differs
+            from the lock, OR the lock has entries with no on-disk
+            file, OR the directory has fixtures absent from the lock.
+            All three are tampering signals.
+
+    W4 sub-gate C invocation contract: call this BEFORE any
+    F1-evaluation work begins. A clean return is the only path to
+    proceeding; any raise aborts and lands in ADR-0023.
+    """
+    fdir = fixtures_dir or _OPTIMISM_SYNTH_DIR
+    lpath = lock_path or _OPTIMISM_SYNTH_LOCK
+    expected = parse_fixture_lock(lpath)
+    actual: dict[str, str] = {}
+    for path in sorted(fdir.glob("corner_*.json")):
+        actual[path.name] = sha256_path(path)
+    if set(expected) != set(actual):
+        missing_disk = sorted(set(expected) - set(actual))
+        missing_lock = sorted(set(actual) - set(expected))
+        raise FixtureHashMismatch(
+            f"fixture set mismatch — locked={sorted(expected)} disk={sorted(actual)} "
+            f"missing_disk={missing_disk} missing_lock={missing_lock}"
+        )
+    drift: dict[str, tuple[str, str]] = {}
+    for name, want in expected.items():
+        got = actual[name]
+        if got != want:
+            drift[name] = (want, got)
+    if drift:
+        report = ", ".join(f"{n}: locked={w[:8]}… got={g[:8]}…" for n, (w, g) in drift.items())
+        raise FixtureHashMismatch(f"hash drift detected (W4 sub-gate C MUST abort): {report}")
+    return actual
+
+
+# --------------------------------------------------------------------------- #
+# W3-C — sub-gate C F1 evaluator (DA P1 #1+#3 closure).
+# --------------------------------------------------------------------------- #
+#
+# Locked HERE before the W4 evaluation runs, on the SAME PR as the fixture
+# hash-lock, to close both axes of the circular-tuning attack: fixtures
+# can't be retuned post-W3 (hash-lock) AND the F1 metric definition
+# can't be retuned post-W3 (code-lock). DA exit-council finding P1 #1+#3.
+
+
+@dataclass(frozen=True)
+class CusumF1Result:
+    """Sub-gate C output: cluster-span-match F1 against ground truth.
+
+    Notation:
+    * ``true_positives`` — clusters that overlap at least one truth's
+      tolerance window. Counted per-truth (at most one TP per truth).
+    * ``false_positives`` — clusters that overlap no truth window.
+    * ``false_negatives`` — truths with no overlapping cluster.
+
+    F1 returns 0.0 on undefined cases (zero detections + zero truths,
+    or zero TP). Avoids division-by-zero ambiguity that future
+    evaluators could exploit to redefine the threshold.
+    """
+
+    true_positives: int
+    false_positives: int
+    false_negatives: int
+    precision: float
+    recall: float
+    f1: float
+    matched_truths: tuple[int, ...]
+    fp_cluster_starts: tuple[int, ...]
+
+
+def collapse_detection_clusters(
+    detections: Sequence[int],
+    *,
+    max_gap: int = 1,
+) -> list[tuple[int, int]]:
+    """Collapse adjacent detection indices into ``(first, last)`` spans.
+
+    CUSUM is multi-fire by design (every index where ``|cumsum| ≥ Nσ``
+    appears in the result list — see ``revision_trends.py:312-315``).
+    For F1 evaluation we treat a contiguous run of detections as ONE
+    regime-change signal, not N false positives. ``max_gap=1`` allows
+    a single missing index inside a run (defensive — single index
+    drop-outs are common at threshold boundaries).
+    """
+    if not detections:
+        return []
+    sorted_dets = sorted(detections)
+    clusters: list[tuple[int, int]] = []
+    start = prev = sorted_dets[0]
+    for d in sorted_dets[1:]:
+        if d - prev > max_gap:
+            clusters.append((start, prev))
+            start = d
+        prev = d
+    clusters.append((start, prev))
+    return clusters
+
+
+def evaluate_cusum_f1(
+    detections: Sequence[int],
+    ground_truths: Sequence[int],
+    *,
+    tolerance: int = 1,
+    cluster_max_gap: int = 1,
+) -> CusumF1Result:
+    """F1 against ground-truth change-points using cluster-span match.
+
+    Match rule: a detection cluster ``[first, last]`` matches a truth
+    ``t`` iff its expanded span ``[first - tolerance, last + tolerance]``
+    contains ``t``. Each truth can match at most one cluster (chosen
+    greedily by cluster start index). Each cluster can match at most
+    one truth.
+
+    Span-match (vs first-detection match) chosen because the engine's
+    CUSUM-on-shifts naturally fires across multiple revisions during
+    the same regime shift (the cumsum minimum often lands at the END
+    of pre-CP run, not at the CP itself). Span-match rewards the
+    engine for correctly identifying the WINDOW containing the
+    regime change — which is the user-facing semantic of the
+    revision_trends visualization (vertical change-point markers
+    indicate the contested window, not a single point estimate).
+
+    Returns:
+        ``CusumF1Result`` with TP / FP / FN / precision / recall / F1.
+        ``f1 = 0.0`` on undefined cases (no detections + truths, or
+        zero TP after matching). Returning 0 on undefined is the
+        conservative choice — sub-gate C threshold ≥ 0.75 cannot be
+        "passed by vacuity" via empty inputs.
+    """
+    clusters = collapse_detection_clusters(detections, max_gap=cluster_max_gap)
+    truths = sorted(set(ground_truths))
+    matched_truths: list[int] = []
+    matched_cluster_idx: set[int] = set()
+    for t in truths:
+        for ci, (first, last) in enumerate(clusters):
+            if ci in matched_cluster_idx:
+                continue
+            if (first - tolerance) <= t <= (last + tolerance):
+                matched_truths.append(t)
+                matched_cluster_idx.add(ci)
+                break
+    tp = len(matched_truths)
+    fp = len(clusters) - len(matched_cluster_idx)
+    fn = len(truths) - tp
+    fp_starts = tuple(c[0] for ci, c in enumerate(clusters) if ci not in matched_cluster_idx)
+
+    precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+    recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+    if tp == 0 or (precision + recall) == 0:
+        f1 = 0.0
+    else:
+        f1 = 2 * precision * recall / (precision + recall)
+
+    return CusumF1Result(
+        true_positives=tp,
+        false_positives=fp,
+        false_negatives=fn,
+        precision=round(precision, 6),
+        recall=round(recall, 6),
+        f1=round(f1, 6),
+        matched_truths=tuple(matched_truths),
+        fp_cluster_starts=fp_starts,
+    )
+
+
 class _LifecyclePhaseV1Adapter:
     """Adapter for ``src.analytics.lifecycle_phase`` v1 — the engine
     that backed the Wave-4 calibration. Used for the W3 demo run."""

--- a/tools/calibration_harness/__main__.py
+++ b/tools/calibration_harness/__main__.py
@@ -1,0 +1,18 @@
+# MIT License
+# Copyright (c) 2026 Vitor Maia Rodovalho
+"""CLI entry point for ``python -m tools.calibration_harness``.
+
+Preserved as a separate module after the W3-C conversion of
+``tools.calibration_harness`` from a single .py file to a package so
+the fixture tree (``fixtures/optimism_synth/``) could live under it.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from tools.calibration_harness import _cli
+
+
+if __name__ == "__main__":
+    sys.exit(_cli())

--- a/tools/calibration_harness/fixtures/optimism_synth.lock
+++ b/tools/calibration_harness/fixtures/optimism_synth.lock
@@ -1,0 +1,15 @@
+# optimism_synth fixture hash-lock (W3-C, ADR-0022 HB-D)
+# DO NOT EDIT BY HAND — re-run _generator.py to refresh.
+# W4 sub-gate C aborts if any hash here drifts from the on-disk fixture.
+# Format: <sha256_hex>  <filename>. NOT sha256sum-compatible (comments).
+# Verify via tools.calibration_harness.verify_optimism_synth_hash_lock().
+# schema_version = 1
+
+61ea63373e9b1110670034d64ef131037954051c04942a4ab14fb465e81dfb68  corner_01.json
+320ccd5468f7fbd4dc5ec7b98bfe8c80495552566af07cc0bfe0cad1e4e7e48b  corner_02.json
+f68fb7205cfb1e757fa50b44fd5d39daf5a9a6593f6f83997bc681af1c115a48  corner_03.json
+d65fe96ea7d316d21fde8660fef2b4b545ce9185e29d3658d1b31e19c96f85b7  corner_04.json
+ca721e8130afc41af69904f95012699ec74622798f0e94190abae6b587e86bd6  corner_05.json
+31b70edf03a5ecff80ef5acb82aadac92cd2d7e88376f676e6d1802805fb28d2  corner_06.json
+62a546aeec9442172cd48ebb302acae4ee0d3583a04fba6b001c1726d0e8a6d5  corner_07.json
+c887dd9c6744cdf5ceecb894f1baf82c59155023ae6d0e3534de51b086632b40  corner_08.json

--- a/tools/calibration_harness/fixtures/optimism_synth/_generator.py
+++ b/tools/calibration_harness/fixtures/optimism_synth/_generator.py
@@ -1,0 +1,243 @@
+# MIT License
+# Copyright (c) 2026 Vitor Maia Rodovalho
+"""Deterministic generator for the optimism_synth fixture set (W3-C).
+
+Authored 2026-05-09 per ADR-0022 §"W3 fixture authoring + hash lock"
+(HB-D — moved from W4 to W3 close to prevent circular tuning).
+
+Spec (ADR-0022):
+    8 synthetic schedule-revision sequences with planted regime changes.
+    σ ∈ {0.1, 0.4} × CP ∈ {3, 7} × baseline ∈ {A, B} = 2³ = 8 corners.
+    (Middle σ=0.2 + CP=5 cells dropped — corner design captures main
+    effects + interactions for sub-gate C F1 evaluation.)
+
+Ground truth:
+    Each fixture plants ONE regime-change at revision_index ∈ {3, 7}.
+    W4 sub-gate C evaluates CUSUM-detected change-points against this
+    ground truth using F1 (precision × recall harmonic mean).
+
+Output:
+    Eight ``corner_NN.json`` files in this directory plus the
+    ``../optimism_synth.lock`` SHA-256 hash-lock.
+
+Determinism contract:
+    Each fixture uses a per-corner seeded ``numpy.random.RandomState``.
+    Re-running this generator MUST produce byte-identical files; the
+    lock validates that contract. Drift = a tampered fixture set —
+    W4 evaluation aborts and ADR-0023 documents the tampering.
+
+Usage (developer-only, NOT a CI step):
+    python tools/calibration_harness/fixtures/optimism_synth/_generator.py
+
+    Re-runs the whole set + writes the .lock. Should be run ONCE at W3
+    close. Re-running afterwards (e.g., to "improve" a fixture) is the
+    explicit anti-pattern this hash-lock is designed to detect.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import numpy as np
+
+
+_SCHEMA_VERSION = 1
+# N=12 chosen to give CUSUM enough post-CP shifts to accumulate at CP=7
+# (5 post-CP shifts with N=12 vs 1 with N=8 — engine's
+# _MIN_REVISIONS_FOR_CUSUM=5 effectively requires >=4 shifts).
+_N_REVISIONS = 12
+_BASELINE_FINISH_DAYS = 100.0
+_NOISE_DAYS_PER_SIGMA = 10.0  # σ=0.1 → std=1 day, σ=0.4 → std=4 days
+
+# Pre-CP and post-CP per-revision drift rates (days/revision).
+# CUSUM-on-shifts (revision_trends.cusum_change_points) detects SUSTAINED
+# drift-rate changes, NOT single-jump outliers. Pattern A: stable→drift;
+# Pattern B: slow_drift→fast_drift. The post-CP drift rate of +5 days/rev
+# sustained over the post-CP plateau gives a CUSUM signal of
+# (5 − pre_rate) × post_cp_count vs noise std, which exceeds the 3σ gate
+# even at σ=0.4 with N=8 revisions. Hand-verified at W3-C generation time
+# against ``revision_trends.cusum_change_points`` (line 289).
+_PATTERN_DRIFT_RATES: dict[str, dict[str, float]] = {
+    "A": {"pre_cp_rate": 0.0, "post_cp_rate": 5.0},  # stable → drift
+    "B": {"pre_cp_rate": 1.0, "post_cp_rate": 5.0},  # slow drift → fast drift
+}
+
+_HERE = Path(__file__).parent
+_LOCK_PATH = _HERE.parent / "optimism_synth.lock"
+
+# 8 corners of the 2³ design (DA P2 #5 — middle-cell {σ=0.2, CP=5} dropped
+# per fractional-factorial corner design; main effects + interactions
+# captured at the corners). N=12 (DA P3 #14) chosen so CP=7 has 5 post-CP
+# shifts vs the engine's _MIN_REVISIONS_FOR_CUSUM=5 floor.
+CORNERS: tuple[dict[str, object], ...] = (
+    {"id": "corner_01", "noise_sigma": 0.1, "cp": 3, "baseline": "A", "seed": 142},
+    {"id": "corner_02", "noise_sigma": 0.1, "cp": 7, "baseline": "A", "seed": 242},
+    {"id": "corner_03", "noise_sigma": 0.4, "cp": 3, "baseline": "A", "seed": 342},
+    {"id": "corner_04", "noise_sigma": 0.4, "cp": 7, "baseline": "A", "seed": 442},
+    {"id": "corner_05", "noise_sigma": 0.1, "cp": 3, "baseline": "B", "seed": 542},
+    {"id": "corner_06", "noise_sigma": 0.1, "cp": 7, "baseline": "B", "seed": 642},
+    {"id": "corner_07", "noise_sigma": 0.4, "cp": 3, "baseline": "B", "seed": 742},
+    {"id": "corner_08", "noise_sigma": 0.4, "cp": 7, "baseline": "B", "seed": 842},
+)
+# Backwards-compat alias — internal tests imported `_CORNERS` before
+# DA P2 #10 promoted the symbol to public. Removing the alias is OK
+# once no caller in `tests/` references it.
+_CORNERS = CORNERS
+
+
+def _generate_finish_days(
+    *,
+    n_revisions: int,
+    cp_index: int,
+    sigma: float,
+    baseline: str,
+    seed: int,
+) -> list[float]:
+    """Generate a synthetic finish_days sequence with a planted drift-rate
+    change at ``cp_index``.
+
+    finish_days[i] = baseline + cumulative_drift(i) + gaussian_noise(i)
+
+    cumulative_drift jumps from ``pre_cp_rate * i`` to ``post_cp_rate``
+    starting at ``cp_index``. CUSUM-on-shifts (np.diff(finish_days))
+    detects this as a regime change because the SHIFTS sequence mean
+    shifts from ``pre_cp_rate`` to ``post_cp_rate`` at the CP — exactly
+    what the engine's CUSUM is designed to catch.
+    """
+    rates = _PATTERN_DRIFT_RATES.get(baseline)
+    if rates is None:
+        raise ValueError(f"unknown baseline pattern {baseline!r}")
+    # DA P2 #7: ``np.random.default_rng`` (PCG64) replaces the legacy
+    # ``RandomState`` (MT19937). Single ceremony cost paid here so the
+    # lock provenance survives NumPy's eventual ``RandomState``
+    # deprecation. PCG64 is byte-stable across NumPy 2.x at minimum
+    # per the SeedSequence contract.
+    rng = np.random.default_rng(seed)
+    noise_std = sigma * _NOISE_DAYS_PER_SIGMA
+    noise = rng.normal(loc=0.0, scale=noise_std, size=n_revisions)
+    pre_rate = rates["pre_cp_rate"]
+    post_rate = rates["post_cp_rate"]
+    out: list[float] = []
+    cumulative = 0.0
+    for i in range(n_revisions):
+        # Drift accrues per-revision: pre-CP at pre_rate, post-CP at post_rate.
+        if i > 0:
+            rate = pre_rate if (i - 1) < cp_index else post_rate
+            cumulative += rate
+        # Round to 4 decimals so the JSON is byte-stable across NumPy
+        # minor-version float-formatting drift.
+        out.append(round(_BASELINE_FINISH_DAYS + cumulative + float(noise[i]), 4))
+    return out
+
+
+def _build_fixture(corner: dict[str, object]) -> dict[str, object]:
+    cp = int(corner["cp"])
+    baseline = str(corner["baseline"])
+    sigma = float(corner["noise_sigma"])
+    seed = int(corner["seed"])
+    finish_days = _generate_finish_days(
+        n_revisions=_N_REVISIONS,
+        cp_index=cp,
+        sigma=sigma,
+        baseline=baseline,
+        seed=seed,
+    )
+    return {
+        "fixture_id": corner["id"],
+        "schema_version": _SCHEMA_VERSION,
+        "spec": {
+            "noise_sigma": sigma,
+            "ground_truth_cp_revision_index": cp,
+            "baseline_pattern": baseline,
+            "n_revisions": _N_REVISIONS,
+            "seed": seed,
+        },
+        "ground_truth": {
+            "regime_change_at_revision_index": cp,
+            "tolerance_revisions": 1,
+        },
+        "finish_days": finish_days,
+    }
+
+
+def _serialize(fixture: dict[str, object]) -> bytes:
+    """Stable JSON serialization for hash-lock determinism."""
+    return json.dumps(fixture, indent=2, sort_keys=True, ensure_ascii=False).encode("utf-8") + b"\n"
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def regenerate_all(
+    out_dir: Path | None = None,
+    lock_path: Path | None = None,
+) -> dict[str, str]:
+    """Generate every fixture + write the lock. Returns filename → sha256.
+
+    Parameterised paths (DA P1 #2) so tests can drive the generator
+    entirely under ``tmp_path`` without touching the live working tree.
+    Defaults to the committed fixture tree paths.
+    """
+    odir = out_dir or _HERE
+    lpath = lock_path or _LOCK_PATH
+    odir.mkdir(parents=True, exist_ok=True)
+
+    hashes: dict[str, str] = {}
+    for corner in CORNERS:
+        fixture = _build_fixture(corner)
+        path = odir / f"{corner['id']}.json"
+        data = _serialize(fixture)
+        path.write_bytes(data)
+        hashes[path.name] = _sha256(data)
+
+    lock_lines = [
+        "# optimism_synth fixture hash-lock (W3-C, ADR-0022 HB-D)",
+        "# DO NOT EDIT BY HAND — re-run _generator.py to refresh.",
+        "# W4 sub-gate C aborts if any hash here drifts from the on-disk fixture.",
+        "# Format: <sha256_hex>  <filename>. NOT sha256sum-compatible (comments).",
+        "# Verify via tools.calibration_harness.verify_optimism_synth_hash_lock().",
+        f"# schema_version = {_SCHEMA_VERSION}",
+        "",
+    ]
+    for name in sorted(hashes):
+        lock_lines.append(f"{hashes[name]}  {name}")
+    lock_lines.append("")
+    lpath.write_text("\n".join(lock_lines), encoding="utf-8")
+    return hashes
+
+
+def _cli_main() -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="python -m tools.calibration_harness.fixtures.optimism_synth._generator",
+        description=(
+            "Regenerate the optimism_synth fixture set + lock. "
+            "REQUIRES --force when the lock already exists — regen is a "
+            "deliberate W3-close ceremony, not an idempotent dev step."
+        ),
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Required when the lock already exists. Re-running silently is the W3-C anti-pattern.",
+    )
+    args = parser.parse_args()
+    if _LOCK_PATH.exists() and not args.force:
+        print(
+            f"refusing to overwrite existing lock at {_LOCK_PATH}.\n"
+            "Pass --force to regenerate (this is a deliberate ceremony, not idempotent).",
+        )
+        return 1
+    hashes = regenerate_all()
+    for name in sorted(hashes):
+        print(f"{hashes[name]}  {name}")
+    print(f"# lock: {_LOCK_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_cli_main())

--- a/tools/calibration_harness/fixtures/optimism_synth/corner_01.json
+++ b/tools/calibration_harness/fixtures/optimism_synth/corner_01.json
@@ -1,0 +1,29 @@
+{
+  "finish_days": [
+    99.6886,
+    97.7548,
+    99.7852,
+    100.8869,
+    105.1743,
+    109.8038,
+    113.7019,
+    120.0579,
+    126.2433,
+    129.5582,
+    134.6841,
+    139.4164
+  ],
+  "fixture_id": "corner_01",
+  "ground_truth": {
+    "regime_change_at_revision_index": 3,
+    "tolerance_revisions": 1
+  },
+  "schema_version": 1,
+  "spec": {
+    "baseline_pattern": "A",
+    "ground_truth_cp_revision_index": 3,
+    "n_revisions": 12,
+    "noise_sigma": 0.1,
+    "seed": 142
+  }
+}

--- a/tools/calibration_harness/fixtures/optimism_synth/corner_02.json
+++ b/tools/calibration_harness/fixtures/optimism_synth/corner_02.json
@@ -1,0 +1,29 @@
+{
+  "finish_days": [
+    98.7293,
+    98.1149,
+    100.2909,
+    99.0515,
+    97.9379,
+    100.1656,
+    101.2373,
+    101.1112,
+    105.1762,
+    110.8284,
+    114.0425,
+    119.4012
+  ],
+  "fixture_id": "corner_02",
+  "ground_truth": {
+    "regime_change_at_revision_index": 7,
+    "tolerance_revisions": 1
+  },
+  "schema_version": 1,
+  "spec": {
+    "baseline_pattern": "A",
+    "ground_truth_cp_revision_index": 7,
+    "n_revisions": 12,
+    "noise_sigma": 0.1,
+    "seed": 242
+  }
+}

--- a/tools/calibration_harness/fixtures/optimism_synth/corner_03.json
+++ b/tools/calibration_harness/fixtures/optimism_synth/corner_03.json
@@ -1,0 +1,29 @@
+{
+  "finish_days": [
+    101.065,
+    103.9352,
+    101.1184,
+    106.4671,
+    97.0173,
+    114.766,
+    115.6208,
+    118.4401,
+    124.6495,
+    128.7038,
+    139.2274,
+    140.6496
+  ],
+  "fixture_id": "corner_03",
+  "ground_truth": {
+    "regime_change_at_revision_index": 3,
+    "tolerance_revisions": 1
+  },
+  "schema_version": 1,
+  "spec": {
+    "baseline_pattern": "A",
+    "ground_truth_cp_revision_index": 3,
+    "n_revisions": 12,
+    "noise_sigma": 0.4,
+    "seed": 342
+  }
+}

--- a/tools/calibration_harness/fixtures/optimism_synth/corner_04.json
+++ b/tools/calibration_harness/fixtures/optimism_synth/corner_04.json
@@ -1,0 +1,29 @@
+{
+  "finish_days": [
+    95.5245,
+    101.981,
+    92.0189,
+    96.6106,
+    104.3194,
+    105.5288,
+    99.9773,
+    108.0099,
+    111.8132,
+    108.9774,
+    116.6352,
+    126.4893
+  ],
+  "fixture_id": "corner_04",
+  "ground_truth": {
+    "regime_change_at_revision_index": 7,
+    "tolerance_revisions": 1
+  },
+  "schema_version": 1,
+  "spec": {
+    "baseline_pattern": "A",
+    "ground_truth_cp_revision_index": 7,
+    "n_revisions": 12,
+    "noise_sigma": 0.4,
+    "seed": 442
+  }
+}

--- a/tools/calibration_harness/fixtures/optimism_synth/corner_05.json
+++ b/tools/calibration_harness/fixtures/optimism_synth/corner_05.json
@@ -1,0 +1,29 @@
+{
+  "finish_days": [
+    98.3409,
+    101.3092,
+    101.6429,
+    102.7549,
+    107.7838,
+    112.8132,
+    119.3931,
+    121.3305,
+    127.4078,
+    131.7035,
+    137.7301,
+    144.4982
+  ],
+  "fixture_id": "corner_05",
+  "ground_truth": {
+    "regime_change_at_revision_index": 3,
+    "tolerance_revisions": 1
+  },
+  "schema_version": 1,
+  "spec": {
+    "baseline_pattern": "B",
+    "ground_truth_cp_revision_index": 3,
+    "n_revisions": 12,
+    "noise_sigma": 0.1,
+    "seed": 542
+  }
+}

--- a/tools/calibration_harness/fixtures/optimism_synth/corner_06.json
+++ b/tools/calibration_harness/fixtures/optimism_synth/corner_06.json
@@ -1,0 +1,29 @@
+{
+  "finish_days": [
+    99.8528,
+    101.7538,
+    101.1887,
+    101.4716,
+    105.065,
+    106.0064,
+    105.363,
+    106.3373,
+    112.069,
+    117.586,
+    122.3155,
+    126.3812
+  ],
+  "fixture_id": "corner_06",
+  "ground_truth": {
+    "regime_change_at_revision_index": 7,
+    "tolerance_revisions": 1
+  },
+  "schema_version": 1,
+  "spec": {
+    "baseline_pattern": "B",
+    "ground_truth_cp_revision_index": 7,
+    "n_revisions": 12,
+    "noise_sigma": 0.1,
+    "seed": 642
+  }
+}

--- a/tools/calibration_harness/fixtures/optimism_synth/corner_07.json
+++ b/tools/calibration_harness/fixtures/optimism_synth/corner_07.json
@@ -1,0 +1,29 @@
+{
+  "finish_days": [
+    106.4179,
+    105.3382,
+    103.7236,
+    101.01,
+    100.5825,
+    110.9176,
+    119.3112,
+    120.9908,
+    134.6409,
+    136.5602,
+    139.6291,
+    138.214
+  ],
+  "fixture_id": "corner_07",
+  "ground_truth": {
+    "regime_change_at_revision_index": 3,
+    "tolerance_revisions": 1
+  },
+  "schema_version": 1,
+  "spec": {
+    "baseline_pattern": "B",
+    "ground_truth_cp_revision_index": 3,
+    "n_revisions": 12,
+    "noise_sigma": 0.4,
+    "seed": 742
+  }
+}

--- a/tools/calibration_harness/fixtures/optimism_synth/corner_08.json
+++ b/tools/calibration_harness/fixtures/optimism_synth/corner_08.json
@@ -1,0 +1,29 @@
+{
+  "finish_days": [
+    98.0365,
+    96.0623,
+    100.1417,
+    101.6474,
+    106.1689,
+    108.7182,
+    116.828,
+    100.2882,
+    103.0329,
+    112.5585,
+    119.1623,
+    127.8801
+  ],
+  "fixture_id": "corner_08",
+  "ground_truth": {
+    "regime_change_at_revision_index": 7,
+    "tolerance_revisions": 1
+  },
+  "schema_version": 1,
+  "spec": {
+    "baseline_pattern": "B",
+    "ground_truth_cp_revision_index": 7,
+    "n_revisions": 12,
+    "noise_sigma": 0.4,
+    "seed": 842
+  }
+}


### PR DESCRIPTION
## Summary

Per ADR-0022 §"W3 fixture authoring + hash lock" (HB-D — fixture authoring moved from W4 to W3 close to PREVENT CIRCULAR TUNING). Closes Cycle 4 success criterion #4 fully (was 50% after PR #95 viz half).

**Cycle 4 progress: 3/9 → 4/9.**

The DA exit-council surfaced that hash-locking fixture BYTES was not sufficient — without locking the F1 metric definition in code, W4 evaluation could redefine F1 to produce its preferred outcome (the same circular-tuning attack on a different axis). This PR ships **both axes locked** in the same commit.

## What ships

- **Package conversion** of `tools/calibration_harness.py` → `tools/calibration_harness/__init__.py` so the fixture tree fits under it. CLI preserved via new `__main__.py`.
- **8 synthetic fixtures** under `tools/calibration_harness/fixtures/optimism_synth/` (2³ corner design: σ × CP × baseline). N=12 revisions; CUSUM-on-shifts detects sustained drift changes.
- **Hash-lock** at `optimism_synth.lock` + `verify_optimism_synth_hash_lock()` with 3 tamper modes detected.
- **Sub-gate C F1 evaluator**: `evaluate_cusum_f1()` + `collapse_detection_clusters()` with explicit cluster-span match rule. **Locked baseline F1 = 0.769231** against the 8 fixtures + current engine. Sub-gate C threshold is 0.75 → just above.
- **Generator hardening**: `--force` required when lock exists.
- **`numpy.random.default_rng`** (PCG64) replaces legacy `RandomState` → deprecation-proof.
- **19 tests** in `tests/test_optimism_synth_fixtures.py` covering determinism, lock parity, 3 tamper detection modes, F1 unit tests + locked-baseline assertion.

## Council disposition

**DA exit-council** (3 P1 + 9 P2 + 5 P3):
- **All 3 P1 fixed inline:** F1 evaluator + locked baseline shipped (closes the F1-axis circular-tuning hole); deterministic test driven entirely under `tmp_path` (no live-tree mutation race); sub-gate C metric definition code-locked alongside fixture bytes hash-locked.
- **5 of 9 P2 fixed inline**: `--force` guard, `RandomState`→`default_rng`, `CORNERS` promoted to public, lock format clarification, 2³ + N=12 rationale documented inline.
- **4 P2 + 5 P3 deferred** to a single follow-up issue (post-merge).

**Honest read on the F1 outcome:** F1=0.77 means sub-gate C **passes** the threshold. Path-A activation still expected because sub-gate A fails at corpus N<30 — that's an independent failure axis (corpus availability, not engine quality). The engine clears sub-gate C with thin margin, which means the gate has signal: a future engine regression flips it to fail.

## Test plan

- [x] `pytest tests/`: 1603 passed, 6 skipped, 0 failures.
- [x] `pytest tests/test_optimism_synth_fixtures.py`: 19/19.
- [x] `ruff check + format --check`: clean.
- [x] `python3 -m tools.calibration_harness --help`: works.
- [x] Generator without `--force` + lock present: refuses + exits 1.
- [x] Generator with `--force`: regenerates byte-identically.
- [ ] CI green
- [ ] No deploy-stage regressions on main

## Out of scope (deferred — single follow-up issue post-merge)

- ADR-0022 footnote/amendment for the 2³ corner choice + N=12 (P2 #5 + P3 #14).
- Cross-Python-version byte-stability test for `json.dumps` (P2 #8).
- Better tamper-test naming (P2 #9).
- `_cli` → `cli` rename (P2 #11).
- `_LifecyclePhaseV1Adapter` smoke test under package layout (P3 #16).
- Pattern B drift rate documentation (P3 #13).