### PR TITLE
fix(cycle5-w1): /revision-trends endpoint P3 batch 1 (#89, #90, #91, #92)

### DIFF
--- a/src/analytics/revision_trends.py
+++ b/src/analytics/revision_trends.py
@@ -137,6 +137,13 @@ class ChangePointMarker:
     """Signed days difference from the prior revision's planned_finish."""
     cusum_value: float
     description: str
+    direction: str
+    """``"slip"`` when ``cusum_value > 0`` (accumulated above-mean drift =
+    later finish than the trend); ``"improvement"`` when ``cusum_value < 0``
+    (accumulated below-mean drift = earlier finish than the trend); ``"flat"``
+    only when ``cusum_value == 0`` (which the threshold would not cross —
+    included for type-completeness). UI surfaces "improvement" in green,
+    "slip" in amber. Issue #89 / DA P3-1 from PR #88."""
 
 
 @dataclass
@@ -446,16 +453,21 @@ def analyze_revision_trends(
             # is idx + 1 (the revision AFTER the prior).
             rev_index = idx + 1
             rev_curve = out.curves[rev_index]
+            # Direction per issue #89 / DA P3-1: sign(cusum_value).
+            # cusum_value > 0 = accumulated above-mean drift = SLIP.
+            # cusum_value < 0 = accumulated below-mean drift = IMPROVEMENT.
+            direction = "slip" if cusum_val > 0 else "improvement" if cusum_val < 0 else "flat"
             out.change_points.append(
                 ChangePointMarker(
                     revision_index=rev_index,
                     revision_id=rev_curve.revision_id,
                     delta_days=int(shifts[idx]),
                     cusum_value=cusum_val,
+                    direction=direction,
                     description=(
                         f"shift of {int(shifts[idx])} days vs prior revision; "
                         f"CUSUM={cusum_val:.1f} crosses {_CUSUM_SIGMA_THRESHOLD}σ "
-                        f"threshold — regime change detected"
+                        f"threshold — regime change detected ({direction})"
                     ),
                 )
             )

--- a/src/analytics/revision_trends.py
+++ b/src/analytics/revision_trends.py
@@ -138,12 +138,25 @@ class ChangePointMarker:
     cusum_value: float
     description: str
     direction: str
-    """``"slip"`` when ``cusum_value > 0`` (accumulated above-mean drift =
-    later finish than the trend); ``"improvement"`` when ``cusum_value < 0``
-    (accumulated below-mean drift = earlier finish than the trend); ``"flat"``
-    only when ``cusum_value == 0`` (which the threshold would not cross —
-    included for type-completeness). UI surfaces "improvement" in green,
-    "slip" in amber. Issue #89 / DA P3-1 from PR #88."""
+    """``"slip"`` when ``delta_days > 0`` (this revision plans LATER finish
+    than prior — the local change is worsening); ``"improvement"`` when
+    ``delta_days < 0`` (this revision plans EARLIER finish than prior — the
+    local change is improving); ``"flat"`` when ``delta_days == 0``.
+
+    **DA exit-council on PR #104 P0 #1 fix**: earlier draft mapped from
+    ``sign(cusum_value)``, which is a path-dependent cumulative signal of
+    drift-from-trend-mean (NOT a local change). At a CUSUM threshold-cross
+    where local ``delta_days = +40`` (a slip) and cumulative ``cusum < 0``
+    (because earlier shifts were even larger and pulled cumsum negative),
+    the cusum-based mapping labels the revision "improvement" — which is
+    forensically inverted. The user-facing semantic of "slip" / "improvement"
+    must derive from the LOCAL revision's signed shift, not the cumulative
+    drift. ``cusum_value`` remains exposed as a separate field for users who
+    want the cumulative-drift signal.
+
+    UI surfaces "improvement" in green, "slip" in amber, "flat" in neutral.
+    Issue #89 / DA P3-1 from PR #88; DA P0 #1 fix on PR #104.
+    """
 
 
 @dataclass
@@ -170,6 +183,11 @@ class RevisionTrendsAnalysis:
     methodology: str = METHODOLOGY_CITATION
     notes: list[str] = field(default_factory=list)
     """Free-form operator-facing strings (e.g., '<5 revisions — change-point detection skipped')."""
+    skipped_revisions: list[str] = field(default_factory=list)
+    """Sibling project_ids skipped during sibling iteration (schedule unavailable
+    OR RLS-denied). Populated by the endpoint orchestrator, not by analyze_revision_trends.
+    Issue #91 / DA P3-3 from PR #88; DA exit-council P2 #8 fix on PR #104 — typed
+    field accompanying the count-only note."""
 
 
 # ── Curve extraction ──────────────────────────────────────
@@ -453,10 +471,14 @@ def analyze_revision_trends(
             # is idx + 1 (the revision AFTER the prior).
             rev_index = idx + 1
             rev_curve = out.curves[rev_index]
-            # Direction per issue #89 / DA P3-1: sign(cusum_value).
-            # cusum_value > 0 = accumulated above-mean drift = SLIP.
-            # cusum_value < 0 = accumulated below-mean drift = IMPROVEMENT.
-            direction = "slip" if cusum_val > 0 else "improvement" if cusum_val < 0 else "flat"
+            # Direction per issue #89 / DA P3-1, semantically corrected per
+            # DA exit-council P0 #1 on PR #104: derived from sign(delta_days)
+            # of the LOCAL shift at the change point, NOT sign(cusum_value)
+            # which is a path-dependent cumulative signal that can invert
+            # relative to the local user-facing change. cusum_value remains
+            # exposed as a separate field for users who want the trend signal.
+            local_delta = shifts[idx]
+            direction = "slip" if local_delta > 0 else "improvement" if local_delta < 0 else "flat"
             out.change_points.append(
                 ChangePointMarker(
                     revision_index=rev_index,

--- a/src/api/routers/revisions.py
+++ b/src/api/routers/revisions.py
@@ -32,9 +32,13 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+import numpy as np
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from src.analytics.revision_trends import analyze_revision_trends
+from src.analytics.revision_trends import (
+    RevisionTrendsAnalysis,
+    analyze_revision_trends,
+)
 
 from ..auth import require_auth
 from ..deps import RATE_LIMIT_ANALYSIS, RATE_LIMIT_WRITE, get_store, limiter
@@ -344,20 +348,24 @@ def revision_trends_endpoint(
         analysis = _analyze_with_fallback(
             project_id=project_id, program_id=program_id, revisions=[]
         )
+        analysis.skipped_revisions = list(skipped_pids)
         if skipped_pids:
             analysis.notes.append(
                 f"{len(skipped_pids)} sibling revision(s) skipped: schedule data not "
-                f"available (project missing OR RLS denied)"
+                f"available (project missing OR RLS denied) — see "
+                f"`skipped_revisions` field for the project_ids"
             )
         return _to_response(analysis)
 
     analysis = _analyze_with_fallback(
         project_id=project_id, program_id=program_id, revisions=revisions
     )
+    analysis.skipped_revisions = list(skipped_pids)
     if skipped_pids:
         analysis.notes.append(
             f"{len(skipped_pids)} sibling revision(s) skipped: schedule data not "
-            f"available (project missing OR RLS denied)"
+            f"available (project missing OR RLS denied) — see "
+            f"`skipped_revisions` field for the project_ids"
         )
     return _to_response(analysis)
 
@@ -367,26 +375,57 @@ def _analyze_with_fallback(
     project_id: str,
     program_id: str | None,
     revisions: list[tuple[str, str | None, int | None, str | None, Any]],
-) -> Any:
-    """Wrap ``analyze_revision_trends`` with try/except per issue #90 / DA P3-2.
+) -> RevisionTrendsAnalysis:
+    """Wrap ``analyze_revision_trends`` with narrow exception catch per issue
+    #90 / DA P3-2 (DA exit-council P1 #7 narrowing on PR #104).
 
-    NumPy edge cases (NaN, zero-variance shifts, malformed CPM output) could
-    raise from inside ``analyze_revision_trends``. Per ADR-0022 §"W3 —
-    C-visualization": viz should ship value even when downstream computation
-    fails (same principle as W4 path-A fallback). Returns a partial analysis
-    with ``notes: ["analysis failed: <ExceptionClassName>"]`` rather than 500.
+    NumPy data-edge cases (NaN, zero-variance shifts, near-singular OLS
+    matrices, divide-by-zero) could raise from inside
+    ``analyze_revision_trends``. Per ADR-0022 §"W3 — C-visualization": viz
+    should ship value even when downstream computation fails (same principle
+    as W4 path-A fallback). Returns a partial analysis with
+    ``notes: ["analysis failed: <ExceptionClassName> ..."]`` rather than 500.
+
+    **Narrow catch per DA exit-council P1 #7**: only data-edge exceptions
+    are caught (``ValueError``, ``ArithmeticError``, ``FloatingPointError``,
+    ``np.linalg.LinAlgError``). Programming bugs (``TypeError``,
+    ``AttributeError``, ``KeyError``, ``MemoryError``, ``RecursionError``)
+    propagate as 500 to surface in Sentry/CI rather than silently degrade
+    to "analysis failed: TypeError" with no alert.
+
+    Methodology field is ALSO cleared on the fallback path per DA exit-
+    council P1 #5 — failed analyses should not surface the AACE 29R-03
+    citation as if the analysis ran.
     """
     try:
         return analyze_revision_trends(
             project_id=project_id, program_id=program_id, revisions=revisions
         )
-    except Exception as exc:  # noqa: BLE001 — boundary catch by design
-        from src.analytics.revision_trends import RevisionTrendsAnalysis
-
+    except (
+        ValueError,
+        ArithmeticError,
+        FloatingPointError,
+        np.linalg.LinAlgError,
+    ) as exc:
         fallback = RevisionTrendsAnalysis(project_id=project_id, program_id=program_id)
+        # P1 #5 fix: clear methodology so failed-analysis response does NOT
+        # carry the AACE citation as if the analysis ran.
+        fallback.methodology = ""
         fallback.notes.append(
             f"analysis failed: {type(exc).__name__} — partial response per ADR-0022 "
-            f"viz-ships-value principle (issue #90 / DA P3-2)"
+            f"viz-ships-value principle (issue #90 / DA P3-2). Methodology citation "
+            f"cleared (DA exit-council P1 #5 on PR #104). Server-side log retains "
+            f"full exception."
+        )
+        # Log the full exception for operator triage (DA exit-council P3 #16).
+        logger.warning(
+            "revision_trends analysis failed; returning fallback. project_id=%s, "
+            "program_id=%s, revisions_n=%d, exc=%s",
+            project_id,
+            program_id,
+            len(revisions),
+            exc,
+            exc_info=True,
         )
         return fallback
 
@@ -437,4 +476,5 @@ def _to_response(analysis: Any) -> RevisionTrendsResponse:
         ),
         methodology=analysis.methodology,
         notes=analysis.notes,
+        skipped_revisions=list(getattr(analysis, "skipped_revisions", [])),
     )

--- a/src/api/routers/revisions.py
+++ b/src/api/routers/revisions.py
@@ -297,7 +297,7 @@ def revision_trends_endpoint(
         sched = store.get_project(project_id, user_id=user_id)
         if sched is None:
             raise HTTPException(status_code=404, detail="project schedule not available")
-        analysis = analyze_revision_trends(
+        analysis = _analyze_with_fallback(
             project_id=project_id,
             program_id=None,
             revisions=[(project_id, None, None, current.get("data_date"), sched)],
@@ -317,12 +317,16 @@ def revision_trends_endpoint(
     }
 
     # 3. Build (project_id, rev_id, rev_num, data_date_iso, schedule) tuples,
-    #    sorted ascending by data_date for the orchestrator.
+    #    sorted ascending by data_date for the orchestrator. Track skipped
+    #    siblings per issue #91 / DA P3-3 (silent skip masks "missing" vs
+    #    "RLS-denied" cases — surface in notes for operator audit).
     revisions: list[tuple[str, str | None, int | None, str | None, Any]] = []
+    skipped_pids: list[str] = []
     for s in siblings:
         pid = s["project_id"]
         sched = store.get_project(pid, user_id=user_id)
         if sched is None:
+            skipped_pids.append(pid)
             continue
         rh = rh_by_project.get(pid)
         revisions.append(
@@ -337,15 +341,54 @@ def revision_trends_endpoint(
     revisions.sort(key=lambda t: t[3] or "")
 
     if not revisions:
-        analysis = analyze_revision_trends(
+        analysis = _analyze_with_fallback(
             project_id=project_id, program_id=program_id, revisions=[]
         )
+        if skipped_pids:
+            analysis.notes.append(
+                f"{len(skipped_pids)} sibling revision(s) skipped: schedule data not "
+                f"available (project missing OR RLS denied)"
+            )
         return _to_response(analysis)
 
-    analysis = analyze_revision_trends(
+    analysis = _analyze_with_fallback(
         project_id=project_id, program_id=program_id, revisions=revisions
     )
+    if skipped_pids:
+        analysis.notes.append(
+            f"{len(skipped_pids)} sibling revision(s) skipped: schedule data not "
+            f"available (project missing OR RLS denied)"
+        )
     return _to_response(analysis)
+
+
+def _analyze_with_fallback(
+    *,
+    project_id: str,
+    program_id: str | None,
+    revisions: list[tuple[str, str | None, int | None, str | None, Any]],
+) -> Any:
+    """Wrap ``analyze_revision_trends`` with try/except per issue #90 / DA P3-2.
+
+    NumPy edge cases (NaN, zero-variance shifts, malformed CPM output) could
+    raise from inside ``analyze_revision_trends``. Per ADR-0022 §"W3 —
+    C-visualization": viz should ship value even when downstream computation
+    fails (same principle as W4 path-A fallback). Returns a partial analysis
+    with ``notes: ["analysis failed: <ExceptionClassName>"]`` rather than 500.
+    """
+    try:
+        return analyze_revision_trends(
+            project_id=project_id, program_id=program_id, revisions=revisions
+        )
+    except Exception as exc:  # noqa: BLE001 — boundary catch by design
+        from src.analytics.revision_trends import RevisionTrendsAnalysis
+
+        fallback = RevisionTrendsAnalysis(project_id=project_id, program_id=program_id)
+        fallback.notes.append(
+            f"analysis failed: {type(exc).__name__} — partial response per ADR-0022 "
+            f"viz-ships-value principle (issue #90 / DA P3-2)"
+        )
+        return fallback
 
 
 def _to_response(analysis: Any) -> RevisionTrendsResponse:
@@ -377,6 +420,7 @@ def _to_response(analysis: Any) -> RevisionTrendsResponse:
                 revision_id=cp.revision_id,
                 delta_days=cp.delta_days,
                 cusum_value=cp.cusum_value,
+                direction=cp.direction,
                 description=cp.description,
             )
             for cp in analysis.change_points

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -2026,6 +2026,15 @@ class ChangePointMarkerSchema(BaseModel):
     revision_id: Optional[str] = None
     delta_days: int
     cusum_value: float
+    direction: str = Field(
+        default="slip",
+        description=(
+            "'slip' (cusum_value > 0, above-mean drift / later finish than trend), "
+            "'improvement' (cusum_value < 0, below-mean drift / earlier finish), "
+            "or 'flat' (degenerate). UI renders 'improvement' in green, 'slip' "
+            "in amber. Issue #89 / DA P3-1 from PR #88."
+        ),
+    )
     description: str
 
 

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -2027,12 +2027,16 @@ class ChangePointMarkerSchema(BaseModel):
     delta_days: int
     cusum_value: float
     direction: str = Field(
-        default="slip",
         description=(
-            "'slip' (cusum_value > 0, above-mean drift / later finish than trend), "
-            "'improvement' (cusum_value < 0, below-mean drift / earlier finish), "
-            "or 'flat' (degenerate). UI renders 'improvement' in green, 'slip' "
-            "in amber. Issue #89 / DA P3-1 from PR #88."
+            "'slip' (delta_days > 0, this revision plans LATER finish than prior — "
+            "local change is worsening), 'improvement' (delta_days < 0, this revision "
+            "plans EARLIER finish than prior — local change is improving), or 'flat' "
+            "(delta_days == 0). DA exit-council P0 #1 fix on PR #104: direction is "
+            "derived from sign(delta_days) of the LOCAL shift, NOT sign(cusum_value) "
+            "which is a path-dependent cumulative drift signal. UI renders 'improvement' "
+            "in green, 'slip' in amber, 'flat' in neutral. No default — schema and "
+            "dataclass require explicit value (DA exit-council P1 #4 fix). "
+            "Issue #89 / DA P3-1 from PR #88."
         ),
     )
     description: str
@@ -2072,3 +2076,14 @@ class RevisionTrendsResponse(BaseModel):
     slope_band: Optional[SlopeBandSchema] = None
     methodology: str = ""
     notes: list[str] = Field(default_factory=list)
+    skipped_revisions: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Sibling project_ids that were skipped during sibling iteration "
+            "because store.get_project() returned None (project missing OR "
+            "RLS-denied — the API does not distinguish). Surfaced as a typed "
+            "list per DA exit-council P2 #8 fix on PR #104; the count also "
+            "appears in `notes` for human-readable surfacing. Issue #91 / "
+            "DA P3-3 from PR #88."
+        ),
+    )

--- a/tests/test_revision_trends.py
+++ b/tests/test_revision_trends.py
@@ -288,6 +288,66 @@ def test_analyze_only_latest_carries_executed_actuals() -> None:
     assert latest_actuals, "Most recent revision should expose actual values"
 
 
+def test_change_point_marker_direction_slip_at_3_sigma() -> None:
+    """Issue #89 / DA P3-1: positive cusum → direction='slip'.
+
+    Default _CUSUM_SIGMA_THRESHOLD = 3.0; symmetric step functions don't fire
+    at 3σ. Asymmetric step (2 HIGH + 6 LOW shifts) fires.
+
+    Construction: shifts [200, 200, 40, 40, 40, 40, 40, 40] (front-loaded
+    HIGH). Mean=80; sigma=74.07; threshold=222.2. Cumsum=[120, 240, 200, …];
+    abs(cusum_value) at idx=1 = 240 > 222 → fires with cusum=+240 → 'slip'.
+
+    Orchestrator: shift_i = 30 + (fd_{i+1} - fd_i), so target shifts
+    ``[170, 170, 10, 10, 10, 10, 10, 10]`` need fd-deltas ``[170, 170, 10×6]``.
+    """
+    finish_offsets = [10, 180, 350, 360, 370, 380, 390, 400, 410]
+    revs = []
+    for i, fd in enumerate(finish_offsets):
+        sched = _schedule_with_acts([_act("t1", duration_hr=float(fd) * 8.0)])
+        dd_iso = (datetime(2026, 1, 1, tzinfo=timezone.utc) + timedelta(days=30 * i)).isoformat()
+        revs.append((f"proj-{i}", f"rev-{i}", i + 1, dd_iso, sched))
+    out = analyze_revision_trends(project_id="proj-A", program_id="prog-1", revisions=revs)
+    assert out.change_points, f"expected CUSUM to fire on planted regime change; notes={out.notes}"
+    cp = out.change_points[0]
+    # The load-bearing contract of issue #89: sign(cusum_value) determines direction.
+    if cp.cusum_value > 0:
+        assert cp.direction == "slip", f"cusum {cp.cusum_value} should be 'slip'"
+    elif cp.cusum_value < 0:
+        assert cp.direction == "improvement", f"cusum {cp.cusum_value} should be 'improvement'"
+    else:
+        assert cp.direction == "flat"
+    # Description should surface the direction label.
+    assert cp.direction in cp.description, (
+        f"description should surface direction; got {cp.description!r}"
+    )
+
+
+def test_change_point_marker_direction_improvement_at_3_sigma() -> None:
+    """Issue #89 / DA P3-1: negative cusum → direction='improvement'.
+
+    Mirror construction: back-loaded HIGH (6 LOW + 2 HIGH).
+    Shifts [40×6, 200×2]; cumsum drifts to -240 at idx=5 < -222 threshold.
+    """
+    finish_offsets = [10, 20, 30, 40, 50, 60, 70, 240, 410]
+    revs = []
+    for i, fd in enumerate(finish_offsets):
+        sched = _schedule_with_acts([_act("t1", duration_hr=float(fd) * 8.0)])
+        dd_iso = (datetime(2026, 1, 1, tzinfo=timezone.utc) + timedelta(days=30 * i)).isoformat()
+        revs.append((f"proj-{i}", f"rev-{i}", i + 1, dd_iso, sched))
+    out = analyze_revision_trends(project_id="proj-A", program_id="prog-1", revisions=revs)
+    assert out.change_points, f"expected CUSUM to fire on planted regime change; notes={out.notes}"
+    # All firing CPs must satisfy the sign-consistency contract.
+    for cp in out.change_points:
+        assert cp.direction in ("slip", "improvement", "flat"), cp.direction
+        if cp.cusum_value > 0:
+            assert cp.direction == "slip"
+        elif cp.cusum_value < 0:
+            assert cp.direction == "improvement"
+        else:
+            assert cp.direction == "flat"
+
+
 def test_analyze_curves_ordered_by_data_date() -> None:
     """Caller is responsible for ascending data_date order; verify it survives."""
     revs = []

--- a/tests/test_revision_trends.py
+++ b/tests/test_revision_trends.py
@@ -288,18 +288,15 @@ def test_analyze_only_latest_carries_executed_actuals() -> None:
     assert latest_actuals, "Most recent revision should expose actual values"
 
 
-def test_change_point_marker_direction_slip_at_3_sigma() -> None:
-    """Issue #89 / DA P3-1: positive cusum → direction='slip'.
+def test_change_point_marker_direction_slip_when_local_delta_positive() -> None:
+    """Issue #89 / DA P3-1 + DA exit-council P0 #1 fix on PR #104:
+    direction is derived from sign(delta_days) of the LOCAL shift, NOT
+    sign(cusum_value).
 
-    Default _CUSUM_SIGMA_THRESHOLD = 3.0; symmetric step functions don't fire
-    at 3σ. Asymmetric step (2 HIGH + 6 LOW shifts) fires.
-
-    Construction: shifts [200, 200, 40, 40, 40, 40, 40, 40] (front-loaded
-    HIGH). Mean=80; sigma=74.07; threshold=222.2. Cumsum=[120, 240, 200, …];
-    abs(cusum_value) at idx=1 = 240 > 222 → fires with cusum=+240 → 'slip'.
-
-    Orchestrator: shift_i = 30 + (fd_{i+1} - fd_i), so target shifts
-    ``[170, 170, 10, 10, 10, 10, 10, 10]`` need fd-deltas ``[170, 170, 10×6]``.
+    Construction: shifts [200, 200, 40×6] (front-loaded HIGH). Mean=80;
+    sigma=74.07; threshold=3σ=222.2. abs(cusum) > 222 fires at idx=1
+    only (cumsum=+240). At idx=1 the LOCAL shift = +200 (this revision
+    plans 200d LATER than prior = SLIP forensically).
     """
     finish_offsets = [10, 180, 350, 360, 370, 380, 390, 400, 410]
     revs = []
@@ -308,26 +305,71 @@ def test_change_point_marker_direction_slip_at_3_sigma() -> None:
         dd_iso = (datetime(2026, 1, 1, tzinfo=timezone.utc) + timedelta(days=30 * i)).isoformat()
         revs.append((f"proj-{i}", f"rev-{i}", i + 1, dd_iso, sched))
     out = analyze_revision_trends(project_id="proj-A", program_id="prog-1", revisions=revs)
-    assert out.change_points, f"expected CUSUM to fire on planted regime change; notes={out.notes}"
-    cp = out.change_points[0]
-    # The load-bearing contract of issue #89: sign(cusum_value) determines direction.
-    if cp.cusum_value > 0:
-        assert cp.direction == "slip", f"cusum {cp.cusum_value} should be 'slip'"
-    elif cp.cusum_value < 0:
-        assert cp.direction == "improvement", f"cusum {cp.cusum_value} should be 'improvement'"
-    else:
-        assert cp.direction == "flat"
-    # Description should surface the direction label.
-    assert cp.direction in cp.description, (
-        f"description should surface direction; got {cp.description!r}"
+    assert out.change_points, f"expected CUSUM to fire; notes={out.notes}"
+    # Sign-consistency contract per DA P0 #1 fix: direction = sign(delta_days).
+    for cp in out.change_points:
+        if cp.delta_days > 0:
+            assert cp.direction == "slip", (
+                f"delta_days={cp.delta_days} (>0) MUST map to 'slip', got {cp.direction!r}"
+            )
+        elif cp.delta_days < 0:
+            assert cp.direction == "improvement"
+        else:
+            assert cp.direction == "flat"
+    assert any(cp.direction == "slip" for cp in out.change_points), (
+        "expected ≥1 'slip' direction in front-loaded-positive-shifts construction"
+    )
+    assert all(cp.direction in cp.description for cp in out.change_points)
+
+
+def test_change_point_marker_direction_improvement_when_local_delta_negative() -> None:
+    """Issue #89 / DA P3-1 + DA exit-council P0 #1 fix on PR #104:
+    NEGATIVE local delta at change-point fires 'improvement' direction.
+
+    Construction: shifts [-200, -200, 50×6] (front-loaded NEGATIVE — early
+    revisions plan EARLIER finish than prior; later revisions slip 50d).
+    Mean=-12.5; sigma=115.7; threshold=347.2. abs(cusum) > 347 fires at
+    idx=1 (cumsum=-375). At idx=1 the LOCAL shift = -200 (this revision
+    plans 200d EARLIER than prior = IMPROVEMENT forensically). To get
+    shift=-200 via orchestrator (shift = 30 + fd-delta): fd-deltas =
+    [-230, -230, 20×6]. Pick fd_0=500 so all fd values stay positive.
+    """
+    finish_offsets = [500, 270, 40, 60, 80, 100, 120, 140, 160]
+    revs = []
+    for i, fd in enumerate(finish_offsets):
+        sched = _schedule_with_acts([_act("t1", duration_hr=float(fd) * 8.0)])
+        dd_iso = (datetime(2026, 1, 1, tzinfo=timezone.utc) + timedelta(days=30 * i)).isoformat()
+        revs.append((f"proj-{i}", f"rev-{i}", i + 1, dd_iso, sched))
+    out = analyze_revision_trends(project_id="proj-A", program_id="prog-1", revisions=revs)
+    assert out.change_points, f"expected CUSUM to fire; notes={out.notes}"
+    for cp in out.change_points:
+        if cp.delta_days > 0:
+            assert cp.direction == "slip"
+        elif cp.delta_days < 0:
+            assert cp.direction == "improvement", (
+                f"delta_days={cp.delta_days} (<0) MUST map to 'improvement', got {cp.direction!r}"
+            )
+        else:
+            assert cp.direction == "flat"
+    assert any(cp.direction == "improvement" for cp in out.change_points), (
+        "expected ≥1 'improvement' direction in front-loaded-negative-shifts construction"
     )
 
 
-def test_change_point_marker_direction_improvement_at_3_sigma() -> None:
-    """Issue #89 / DA P3-1: negative cusum → direction='improvement'.
+def test_change_point_marker_direction_decoupled_from_cusum_sign() -> None:
+    """DA exit-council P0 #1 fix on PR #104: direction is decoupled from
+    cusum_value sign (which is path-dependent), tied to local delta sign.
 
-    Mirror construction: back-loaded HIGH (6 LOW + 2 HIGH).
-    Shifts [40×6, 200×2]; cumsum drifts to -240 at idx=5 < -222 threshold.
+    Pinning regression: a CP where cusum_value < 0 BUT delta_days > 0
+    MUST be labeled 'slip' (not 'improvement'). The earlier draft mapped
+    from sign(cusum) which would inverted-label this revision.
+
+    Construction: shifts [40×6, 200×2] (back-loaded HIGH). Cumsum drifts
+    NEGATIVE on the early-low-shifts and stays negative through the
+    late-high-shifts because cumsum-from-mean integral is below zero
+    overall. At idx=5 cumsum=-240 (NEGATIVE), but shifts[5]=40 (POSITIVE
+    — local slip). With the CORRECT semantic, direction='slip'. With the
+    broken sign(cusum) semantic, direction would have been 'improvement'.
     """
     finish_offsets = [10, 20, 30, 40, 50, 60, 70, 240, 410]
     revs = []
@@ -336,16 +378,17 @@ def test_change_point_marker_direction_improvement_at_3_sigma() -> None:
         dd_iso = (datetime(2026, 1, 1, tzinfo=timezone.utc) + timedelta(days=30 * i)).isoformat()
         revs.append((f"proj-{i}", f"rev-{i}", i + 1, dd_iso, sched))
     out = analyze_revision_trends(project_id="proj-A", program_id="prog-1", revisions=revs)
-    assert out.change_points, f"expected CUSUM to fire on planted regime change; notes={out.notes}"
-    # All firing CPs must satisfy the sign-consistency contract.
-    for cp in out.change_points:
-        assert cp.direction in ("slip", "improvement", "flat"), cp.direction
-        if cp.cusum_value > 0:
-            assert cp.direction == "slip"
-        elif cp.cusum_value < 0:
-            assert cp.direction == "improvement"
-        else:
-            assert cp.direction == "flat"
+    assert out.change_points, f"expected CUSUM to fire; notes={out.notes}"
+    inverted_cases = [cp for cp in out.change_points if cp.cusum_value < 0 and cp.delta_days > 0]
+    assert inverted_cases, (
+        "test construction failed to produce a CP with cusum<0 + delta>0; "
+        "rebalance shifts to surface the inversion case"
+    )
+    for cp in inverted_cases:
+        assert cp.direction == "slip", (
+            f"DA P0 #1 fix regression: cusum<0+delta>0 case must be 'slip' "
+            f"(local slip dominant), got {cp.direction!r}"
+        )
 
 
 def test_analyze_curves_ordered_by_data_date() -> None:

--- a/tests/test_revisions_router.py
+++ b/tests/test_revisions_router.py
@@ -9,7 +9,7 @@ under the InMemoryStore-backed test harness. Uses TestClient + JWT mint.
 from __future__ import annotations
 
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import jwt
@@ -571,13 +571,15 @@ def test_revision_trends_200_with_sibling_revisions(
 
 
 def test_revision_trends_skipped_sibling_in_notes(
-    client: TestClient, fresh_store: InMemoryStore
+    client: TestClient, fresh_store: InMemoryStore, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Issue #91 / DA P3-3: silent skip masks 'missing' vs 'RLS-denied'.
 
-    Construct two siblings; manually wipe one's schedule from `_projects` to
-    simulate the case `get_project(pid, user_id) returns None`. Endpoint
-    must surface a skipped-sibling note rather than silently dropping.
+    Two siblings; monkeypatch `get_project` to return None for sibling p1
+    (simulates RLS-denied OR missing). Endpoint surfaces a skipped-sibling
+    note + populates the typed `skipped_revisions` list. DA exit-council
+    P2 #8 + P2 #11 fix on PR #104: monkeypatch is less brittle than reaching
+    into ProjectStore inner dict; the response also exposes the typed field.
     """
     p1 = fresh_store.save_project(
         upload_id="u1",
@@ -589,10 +591,15 @@ def test_revision_trends_skipped_sibling_in_notes(
         schedule=_schedule("PROJ-SKIP", datetime(2026, 2, 1, tzinfo=timezone.utc)),
         user_id="user-w2-test",
     )
-    # Simulate "schedule unavailable" for sibling p1 (RLS-denied OR missing).
-    # ProjectStore wraps the inner dict; pop directly to drop the schedule
-    # without affecting project_meta or owner mappings.
-    fresh_store._projects._projects.pop(p1, None)
+    # Public-API simulation: monkeypatch get_project to return None for p1.
+    real_get = fresh_store.get_project
+
+    def _patched_get(pid: str, user_id: str | None = None) -> Any:
+        if pid == p1:
+            return None
+        return real_get(pid, user_id=user_id)
+
+    monkeypatch.setattr(fresh_store, "get_project", _patched_get)
     token = _make_token()
     resp = client.get(
         f"/api/v1/projects/{p2}/revision-trends",
@@ -600,11 +607,19 @@ def test_revision_trends_skipped_sibling_in_notes(
     )
     assert resp.status_code == 200, resp.text
     body = resp.json()
+    # Note-based surfacing (count + reference to typed field).
     skipped_notes = [n for n in body["notes"] if "skipped" in n.lower()]
     assert skipped_notes, (
         f"expected skipped-sibling note when schedule unavailable; got notes={body['notes']}"
     )
     assert "1 sibling" in skipped_notes[0] or "1 sibling revision" in skipped_notes[0]
+    # Typed-field surfacing (DA exit-council P2 #8 fix): actual project_ids exposed.
+    assert p1 in body["skipped_revisions"], (
+        f"expected p1={p1} in skipped_revisions; got {body['skipped_revisions']}"
+    )
+    assert p2 not in body["skipped_revisions"], (
+        f"p2={p2} should NOT be in skipped_revisions (its schedule was returned)"
+    )
 
 
 def test_revision_trends_error_fallback_on_analytics_failure(
@@ -626,7 +641,11 @@ def test_revision_trends_error_fallback_on_analytics_failure(
     )
 
     def _raise(*args: Any, **kwargs: Any) -> Any:
-        raise RuntimeError("synthetic numpy edge-case for issue #90 test")
+        # ValueError simulates a data-edge case the fallback IS expected to
+        # catch per DA exit-council P1 #7 narrowing on PR #104. RuntimeError
+        # would propagate as 500 (programming-bug class), which is the
+        # correct behavior — see test_revision_trends_programming_bug_propagates.
+        raise ValueError("synthetic numpy edge-case for issue #90 test")
 
     monkeypatch.setattr("src.api.routers.revisions.analyze_revision_trends", _raise)
     token = _make_token()
@@ -640,33 +659,117 @@ def test_revision_trends_error_fallback_on_analytics_failure(
     assert failure_notes, (
         f"expected 'analysis failed' note on synthetic exception; got notes={body['notes']}"
     )
-    assert "RuntimeError" in failure_notes[0]
+    assert "ValueError" in failure_notes[0]
+    # P1 #5 fix: methodology MUST be cleared on fallback path so the response
+    # does NOT carry the AACE 29R-03 citation as if the analysis ran.
+    assert body["methodology"] == "", (
+        f"expected empty methodology on fallback (P1 #5 fix); got {body['methodology']!r}"
+    )
+
+
+def test_revision_trends_programming_bug_propagates_as_500(
+    client: TestClient,
+    fresh_store: InMemoryStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DA exit-council P1 #7 fix on PR #104: programming bugs (TypeError,
+    AttributeError, KeyError, RuntimeError) MUST propagate as 500, NOT be
+    swallowed by the fallback. The narrow exception catch in
+    `_analyze_with_fallback` only catches data-edge errors (ValueError,
+    ArithmeticError, FloatingPointError, np.linalg.LinAlgError).
+
+    A wider catch would silently degrade programming bugs to "analysis
+    failed: TypeError" with no Sentry trip, hiding regressions indefinitely.
+    """
+    p1_id = fresh_store.save_project(
+        upload_id="u1",
+        schedule=_schedule("PROJ-BUG", datetime(2026, 1, 1, tzinfo=timezone.utc)),
+        user_id="user-w2-test",
+    )
+
+    def _raise_typeerror(*args: Any, **kwargs: Any) -> Any:
+        raise TypeError("synthetic programming-bug — should propagate, not degrade")
+
+    monkeypatch.setattr("src.api.routers.revisions.analyze_revision_trends", _raise_typeerror)
+    token = _make_token()
+    # FastAPI/TestClient surfaces uncaught exceptions as 500.
+    # Use raise_server_exceptions=False to capture the 500 response.
+    test_client = TestClient(app, raise_server_exceptions=False)
+    resp = test_client.get(
+        f"/api/v1/projects/{p1_id}/revision-trends",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 500, (
+        f"TypeError MUST propagate as 500 (programming bug class); got {resp.status_code}"
+    )
 
 
 def test_revision_trends_change_point_carries_direction_field(
     client: TestClient, fresh_store: InMemoryStore
 ) -> None:
-    """Issue #89 / DA P3-1: ChangePointMarkerSchema.direction surfaces in API.
+    """Issue #89 / DA P3-1 + DA exit-council P0 #3 fix on PR #104.
 
-    Schema field exists with default 'slip'; verify the response shape includes
-    it for any change_point emitted (analytic-level direction tests live in
-    test_revision_trends.py — this is the API surface contract pin).
+    Earlier draft used a single-revision construction that NEVER produces
+    change_points (CUSUM requires N≥5 revisions); the for-loop iterated
+    zero times and the test was VACUOUSLY passing. Fixed by constructing
+    9 sibling revisions with the same shifts that the analytic-level test
+    `test_change_point_marker_direction_slip_when_local_delta_positive`
+    uses, so the endpoint actually emits change_points + the API surface
+    contract on `direction` is non-vacuously verified.
     """
-    p1 = fresh_store.save_project(
-        upload_id="u1",
-        schedule=_schedule("PROJ-DIR", datetime(2026, 1, 1, tzinfo=timezone.utc)),
-        user_id="user-w2-test",
-    )
+    # Same finish-offset construction as the analytic-level slip test:
+    # shifts [200, 200, 40×6] → fires at idx=1 with direction='slip'.
+    finish_offsets = [10, 180, 350, 360, 370, 380, 390, 400, 410]
+    project_ids: list[str] = []
+    base_dt = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    for i, fd in enumerate(finish_offsets):
+        # Schedule with single activity whose duration_hr = fd*8 (8hr/day) →
+        # planned_finish_day = fd days. Same convention as test_revision_trends.py.
+        from src.parser.models import Task
+
+        sched = ParsedSchedule()
+        sched.projects.append(
+            Project(
+                proj_id="1",
+                proj_short_name="PROJ-DIR-MR",
+                last_recalc_date=base_dt + timedelta(days=30 * i),
+            )
+        )
+        sched.activities = [
+            Task(
+                task_id="t1",
+                target_drtn_hr_cnt=float(fd) * 8.0,
+                remain_drtn_hr_cnt=float(fd) * 8.0,
+                target_end_date=base_dt + timedelta(days=30 * i),
+            )
+        ]
+        pid = fresh_store.save_project(upload_id=f"u{i}", schedule=sched, user_id="user-w2-test")
+        project_ids.append(pid)
+
+    # Query against the LATEST revision (last project_id); endpoint resolves
+    # siblings via auto-grouped program_id and analyzes all 9 revisions.
     token = _make_token()
     resp = client.get(
-        f"/api/v1/projects/{p1}/revision-trends",
+        f"/api/v1/projects/{project_ids[-1]}/revision-trends",
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 200, resp.text
     body = resp.json()
-    # Single revision → no change_points. But schema should still validate.
-    assert "change_points" in body
-    # If any change_point existed, the direction field must be present.
+    # The 9-revision construction MUST produce ≥1 change_point per analytic-
+    # level test guarantees; the API surface contract on `direction` is now
+    # actually verified.
+    assert body["change_points"], (
+        f"expected ≥1 change_point on 9-revision construction (API surface "
+        f"contract for direction field); got notes={body['notes']}"
+    )
     for cp in body["change_points"]:
-        assert "direction" in cp
-        assert cp["direction"] in ("slip", "improvement", "flat")
+        assert "direction" in cp, "API surface MUST include direction field"
+        assert cp["direction"] in ("slip", "improvement", "flat"), cp["direction"]
+        # Sign-consistency contract per DA exit-council P0 #1 fix: direction
+        # follows sign(delta_days), NOT sign(cusum_value).
+        if cp["delta_days"] > 0:
+            assert cp["direction"] == "slip"
+        elif cp["delta_days"] < 0:
+            assert cp["direction"] == "improvement"
+        else:
+            assert cp["direction"] == "flat"

--- a/tests/test_revisions_router.py
+++ b/tests/test_revisions_router.py
@@ -487,3 +487,186 @@ def test_tombstone_does_not_leak_state_to_other_user(
         f"Expected 404 (cross-tenant ownership reject) but got "
         f"{leak_attempt.status_code} — RLS bypass via idempotent tombstone return"
     )
+
+
+# ────────────────────────────────────────────────────────────
+# revision-trends endpoint (Cycle 5 W1 batch 1 — issues #89, #90, #91, #92)
+# ────────────────────────────────────────────────────────────
+
+
+def test_revision_trends_unauth_returns_401(client: TestClient) -> None:
+    """Issue #92 / DA P3-6: endpoint integration test — 401 path."""
+    resp = client.get("/api/v1/projects/p1/revision-trends")
+    assert resp.status_code == 401
+
+
+def test_revision_trends_404_when_project_missing(
+    client: TestClient, fresh_store: InMemoryStore
+) -> None:
+    """Issue #92 / DA P3-6: endpoint integration test — 404 path."""
+    token = _make_token()
+    resp = client.get(
+        "/api/v1/projects/nonexistent/revision-trends",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 404
+
+
+def test_revision_trends_200_owner_happy_path_single_revision(
+    client: TestClient, fresh_store: InMemoryStore
+) -> None:
+    """Issue #92 / DA P3-6: 200 owner path with single revision (no program siblings).
+
+    Assigns a project to a fresh program; no other siblings in the program.
+    Endpoint returns curve-only response (single-revision view).
+    """
+    p1 = fresh_store.save_project(
+        upload_id="u1",
+        schedule=_schedule("PROJ-A", datetime(2026, 1, 1, tzinfo=timezone.utc)),
+        user_id="user-w2-test",
+    )
+    token = _make_token()
+    resp = client.get(
+        f"/api/v1/projects/{p1}/revision-trends",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["project_id"] == p1
+    assert "curves" in body
+    assert "change_points" in body
+    assert "notes" in body
+    # methodology citation surfaced
+    assert "29R-03" in body["methodology"] or "AACE" in body["methodology"]
+
+
+def test_revision_trends_200_with_sibling_revisions(
+    client: TestClient, fresh_store: InMemoryStore
+) -> None:
+    """Issue #92 / DA P3-6: 200 owner path with multi-revision (sibling) program."""
+    # Two siblings under same proj_short_name → same auto-grouped program.
+    p1 = fresh_store.save_project(
+        upload_id="u1",
+        schedule=_schedule("PROJ-MR", datetime(2026, 1, 1, tzinfo=timezone.utc)),
+        user_id="user-w2-test",
+    )
+    p2 = fresh_store.save_project(
+        upload_id="u2",
+        schedule=_schedule("PROJ-MR", datetime(2026, 2, 1, tzinfo=timezone.utc)),
+        user_id="user-w2-test",
+    )
+    token = _make_token()
+    resp = client.get(
+        f"/api/v1/projects/{p2}/revision-trends",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["project_id"] == p2
+    assert len(body["curves"]) >= 1
+    # Both siblings should be reachable; no skipped-sibling note for happy path.
+    skipped_notes = [n for n in body["notes"] if "skipped" in n.lower()]
+    assert not skipped_notes, f"unexpected skipped-sibling note: {skipped_notes}"
+    _ = p1  # referenced by sibling lookup
+
+
+def test_revision_trends_skipped_sibling_in_notes(
+    client: TestClient, fresh_store: InMemoryStore
+) -> None:
+    """Issue #91 / DA P3-3: silent skip masks 'missing' vs 'RLS-denied'.
+
+    Construct two siblings; manually wipe one's schedule from `_projects` to
+    simulate the case `get_project(pid, user_id) returns None`. Endpoint
+    must surface a skipped-sibling note rather than silently dropping.
+    """
+    p1 = fresh_store.save_project(
+        upload_id="u1",
+        schedule=_schedule("PROJ-SKIP", datetime(2026, 1, 1, tzinfo=timezone.utc)),
+        user_id="user-w2-test",
+    )
+    p2 = fresh_store.save_project(
+        upload_id="u2",
+        schedule=_schedule("PROJ-SKIP", datetime(2026, 2, 1, tzinfo=timezone.utc)),
+        user_id="user-w2-test",
+    )
+    # Simulate "schedule unavailable" for sibling p1 (RLS-denied OR missing).
+    # ProjectStore wraps the inner dict; pop directly to drop the schedule
+    # without affecting project_meta or owner mappings.
+    fresh_store._projects._projects.pop(p1, None)
+    token = _make_token()
+    resp = client.get(
+        f"/api/v1/projects/{p2}/revision-trends",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    skipped_notes = [n for n in body["notes"] if "skipped" in n.lower()]
+    assert skipped_notes, (
+        f"expected skipped-sibling note when schedule unavailable; got notes={body['notes']}"
+    )
+    assert "1 sibling" in skipped_notes[0] or "1 sibling revision" in skipped_notes[0]
+
+
+def test_revision_trends_error_fallback_on_analytics_failure(
+    client: TestClient,
+    fresh_store: InMemoryStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #90 / DA P3-2: analyze_revision_trends raising MUST NOT 500.
+
+    Patches the analytics function to raise; endpoint should return 200 with
+    a partial response carrying ``notes: ['analysis failed: <ExceptionClass>...']``.
+    Per ADR-0022 §"W3 — C-visualization": viz ships value even when downstream
+    computation fails.
+    """
+    p1_id = fresh_store.save_project(
+        upload_id="u1",
+        schedule=_schedule("PROJ-ERR", datetime(2026, 1, 1, tzinfo=timezone.utc)),
+        user_id="user-w2-test",
+    )
+
+    def _raise(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("synthetic numpy edge-case for issue #90 test")
+
+    monkeypatch.setattr("src.api.routers.revisions.analyze_revision_trends", _raise)
+    token = _make_token()
+    resp = client.get(
+        f"/api/v1/projects/{p1_id}/revision-trends",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    failure_notes = [n for n in body["notes"] if "analysis failed" in n.lower()]
+    assert failure_notes, (
+        f"expected 'analysis failed' note on synthetic exception; got notes={body['notes']}"
+    )
+    assert "RuntimeError" in failure_notes[0]
+
+
+def test_revision_trends_change_point_carries_direction_field(
+    client: TestClient, fresh_store: InMemoryStore
+) -> None:
+    """Issue #89 / DA P3-1: ChangePointMarkerSchema.direction surfaces in API.
+
+    Schema field exists with default 'slip'; verify the response shape includes
+    it for any change_point emitted (analytic-level direction tests live in
+    test_revision_trends.py — this is the API surface contract pin).
+    """
+    p1 = fresh_store.save_project(
+        upload_id="u1",
+        schedule=_schedule("PROJ-DIR", datetime(2026, 1, 1, tzinfo=timezone.utc)),
+        user_id="user-w2-test",
+    )
+    token = _make_token()
+    resp = client.get(
+        f"/api/v1/projects/{p1}/revision-trends",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    # Single revision → no change_points. But schema should still validate.
+    assert "change_points" in body
+    # If any change_point existed, the direction field must be present.
+    for cp in body["change_points"]:
+        assert "direction" in cp
+        assert cp["direction"] in ("slip", "improvement", "flat")


### PR DESCRIPTION
## Summary

Cycle 5 W1 batch 1 per [ADR-0024 §"Wave plan"](docs/adr/0024-cycle-5-entry-z-shape-consolidation.md). Closes 4 Cycle 4 W3 backend P3 follow-ups, all co-located on the `/revision-trends` endpoint surface.

| Issue | Title | Fix |
|---|---|---|
| #89 (DA P3-1) | distinguish CUSUM improvement vs slip | Added `direction: str` field to `ChangePointMarker` + schema; `direction = sign(cusum_value)` at each detection |
| #90 (DA P3-2) | error handling on `analyze_revision_trends` | New `_analyze_with_fallback()` wrapper with try/except → partial response with `notes: ["analysis failed: ..."]` instead of 500 |
| #91 (DA P3-3) | distinguish 404 not-found from RLS-denied | Track `skipped_pids` list when iterating siblings; surface in notes as `"{N} sibling revision(s) skipped: schedule data not available (project missing OR RLS denied)"` |
| #92 (DA P3-6) | endpoint integration test | 7 new tests in `test_revisions_router.py` + 2 analytic-level direction tests in `test_revision_trends.py` |

## Test plan

- [x] `python3 -m pytest tests/ -q` → **1661 passed**, 6 skipped (was 1652 baseline; +9 new tests)
- [x] `ruff check src/ tests/ tools/` clean
- [x] `ruff format --check` clean (auto-formatted 2 files)
- [x] `python3 -m mypy src/analytics/revision_trends.py src/api/routers/revisions.py src/api/schemas.py --strict` clean on changed files (pre-existing unrelated errors in other modules unaffected)
- [x] Manual smoke: `direction` field surfaces in API response per issue #89 contract

## Process

- **Backend-reviewer entry-council skipped** per [ADR-0018 Am.1 §"Skip protocol"](docs/adr/0018-cycle-cadence-doc-artifacts.md): small targeted P3 batch with established patterns (extending existing `ChangePointMarker` dataclass + `ChangePointMarkerSchema` + endpoint try/except pattern from other routers).
- **DA exit-council per ADR-0018 Am.1** on this PR (recursive validation pattern from Cycle 3 close-arc still in force for Cycle 5).

## Cycle 5 progress

Closes 4 of 13 open P3 issues from W1-W3 target list (criterion #5 progress: 4/13 → need ≥6/13 for graceful threshold, on track for W2 batch).

Closes #89, #90, #91, #92.

## Cross-references

- Parent: [ADR-0024 §"Wave plan W1"](docs/adr/0024-cycle-5-entry-z-shape-consolidation.md)
- Cycle 4 W3 source PR: [#88](https://github.com/VitorMRodovalho/meridianiq/pull/88)
- Wraps the W3 visualization-only contract: NO forecast curve added; ADR-0023 §"Pattern check" stays load-bearing