### PR TITLE
fix(cycle5-w2): /revision-trends polish batch 2-A (#96 part 1, #97 part 2, #98 partial)

### DIFF
--- a/web/src/lib/components/charts/MultiRevisionSCurveChart.svelte
+++ b/web/src/lib/components/charts/MultiRevisionSCurveChart.svelte
@@ -30,15 +30,35 @@
 	// and pushes methodology disclosure off-screen on first paint. Wrap in
 	// <details> always-in-DOM (LifecyclePhaseCard.svelte pattern); summary
 	// shown only when shouldCollapse=true (sm:hidden via conditional render).
+	//
+	// Initial-mobile-collapse vs resize-to-mobile-preserve (DA exit-council
+	// P0 #2 fix on PR #109): legendOpen defaults to true so the legend is
+	// visible by default on tablet/desktop. On the FIRST detection of
+	// shouldCollapse=true (initial mobile load with N>8), the effect
+	// collapses once. Subsequent resizes (e.g., tablet rotate landscape →
+	// portrait) do NOT re-collapse — `initialCollapseDone` ensures the
+	// auto-collapse runs at most once per chart instance, preserving the
+	// user's manual toggle state across viewport changes.
 	let isMobile = $state(false);
-	let legendOpen = $state(false);
+	let legendOpen = $state(true);
+	let initialCollapseDone = $state(false);
 
 	$effect(() => {
 		if (typeof window === 'undefined') return;
 		const mq = window.matchMedia('(max-width: 640px)');
 		isMobile = mq.matches;
+		// Initial-paint check: collapse once if mobile + N>8 at first mount.
+		// Subsequent resize events do NOT trigger this branch.
+		if (!initialCollapseDone) {
+			initialCollapseDone = true;
+			if (mq.matches && curves.length > 8) {
+				legendOpen = false;
+			}
+		}
 		const handler = (e: MediaQueryListEvent) => {
 			isMobile = e.matches;
+			// Intentionally do NOT re-collapse on resize: preserve user's
+			// manual toggle state. P0 #2 fix.
 		};
 		mq.addEventListener('change', handler);
 		return () => mq.removeEventListener('change', handler);
@@ -228,10 +248,18 @@
 	// "no revisions" empty state.
 	//
 	// Issue #98 item 2 (DA P3 #14 from PR #95) + frontend-ux-reviewer entry-
-	// council nice-to-have #11 on PR #109: extend to also cover the
-	// degenerate-X case where points are populated but all day_offsets=0
-	// (single-day project with multiple revisions all at d=0). Renders
-	// explicit empty-state instead of "D+0..D+1" axis with no curves.
+	// council nice-to-have #11 + DA exit-council P2 #9 on PR #109: extend to
+	// also cover the degenerate-X case where points are populated but all
+	// day_offsets=0 (single-day project with multiple revisions all at d=0).
+	// Renders explicit empty-state instead of "D+0..D+1" axis with no curves.
+	//
+	// **Reachability uncertainty acknowledged**: DA P2 #9 flagged that the
+	// backend's ability to emit all-zero day_offset curves has not been
+	// explicitly verified. Adding this defense without proof of need is
+	// regret-bait per DA. Kept here as a one-line guard with this comment;
+	// if backend guarantee says "extract_planned_curve always emits ≥2
+	// distinct day_offsets when activities have non-zero CPM finishes", a
+	// future cleanup PR should drop the second clause.
 	const isAllEmpty = $derived(
 		curves.length > 0 &&
 			(curves.every((c) => c.points.length === 0) ||
@@ -245,12 +273,10 @@
 	// path; the page-level `clientWarnings` derivation surfaces a user-visible
 	// note in trends.notes (frontend-ux-reviewer entry-council SHOULD-FIX #6
 	// on PR #109: console.warn alone hides the bug).
-	const lastExecutedIndex = $derived.by((): number => {
-		for (let i = curves.length - 1; i >= 0; i--) {
-			if (curves[i].is_executed) return i;
-		}
-		return -1;
-	});
+	// findLastIndex (ES2023, target esnext, supported by all modern browsers)
+	// per DA exit-council P1 #6 fix on PR #109: idiomatic 1-line replacement
+	// for the manual reverse-loop earlier draft.
+	const lastExecutedIndex = $derived(curves.findLastIndex((c) => c.is_executed));
 </script>
 
 <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
@@ -414,9 +440,12 @@
 			ontoggle={(e) => (legendOpen = e.currentTarget.open)}
 		>
 			{#if shouldCollapse}
-				<summary
-					class="text-xs cursor-pointer text-gray-600 dark:text-gray-400 list-none [&::-webkit-details-marker]:hidden"
-				>
+				<summary class="text-xs cursor-pointer text-gray-600 dark:text-gray-400 list-none">
+					<!-- list-none alone hides the disclosure marker on both webkit
+					     and Firefox/Gecko (verified by frontend-ux-reviewer council
+					     P2 #7). Earlier draft also added [&::-webkit-details-marker]:hidden
+					     which was webkit-only redundant defense; dropped per DA
+					     exit-council P2 #7 fix on PR #109. -->
 					{legendCollapsedSummary(curves.length)}
 				</summary>
 			{/if}

--- a/web/src/lib/components/charts/MultiRevisionSCurveChart.svelte
+++ b/web/src/lib/components/charts/MultiRevisionSCurveChart.svelte
@@ -10,6 +10,7 @@
 		emptyLabel?: string;
 		executedLabel?: string;
 		changePointLabel?: string;
+		legendCollapsedSummary?: (n: number) => string;
 	}
 
 	let {
@@ -21,7 +22,33 @@
 		emptyLabel = 'No revisions to display.',
 		executedLabel = 'Executed',
 		changePointLabel = 'Change point',
+		legendCollapsedSummary = (n: number) => `${n} revisions — show legend`,
 	}: Props = $props();
+
+	// Mobile legend-collapse state (issue #97 part 2 / DA P2 #12 from PR #95).
+	// On <640px viewports with N>8 revisions, the legend wraps to 4-5 rows
+	// and pushes methodology disclosure off-screen on first paint. Wrap in
+	// <details> always-in-DOM (LifecyclePhaseCard.svelte pattern); summary
+	// shown only when shouldCollapse=true (sm:hidden via conditional render).
+	let isMobile = $state(false);
+	let legendOpen = $state(false);
+
+	$effect(() => {
+		if (typeof window === 'undefined') return;
+		const mq = window.matchMedia('(max-width: 640px)');
+		isMobile = mq.matches;
+		const handler = (e: MediaQueryListEvent) => {
+			isMobile = e.matches;
+		};
+		mq.addEventListener('change', handler);
+		return () => mq.removeEventListener('change', handler);
+	});
+
+	const shouldCollapse = $derived(isMobile && curves.length > 8);
+	// <details open> attribute: when shouldCollapse=false, always open
+	// (renders legend chips inline). When shouldCollapse=true, controlled
+	// by user click on <summary>.
+	const detailsOpen = $derived(!shouldCollapse || legendOpen);
 
 	const WIDTH = 800;
 	const PAD_TOP = 28;
@@ -163,7 +190,13 @@
 				return {
 					x: xPos(0 + shift),
 					description: cp.description,
-					revisionLabel: c.revision_number != null ? `R${c.revision_number}` : `#${cp.revision_index}`,
+					// 1-based fallback aligning with endpointLabels at line 185
+					// + page changePointLabel function. Issue #98 item 5 +
+					// frontend-ux-reviewer entry-council BLOCKING #2 on PR #109:
+					// chart was internally inconsistent (line 166 0-based vs
+					// line 185 1-based); aligned to 1-based per least-surprise.
+					revisionLabel:
+						c.revision_number != null ? `R${c.revision_number}` : `#${cp.revision_index + 1}`,
 				};
 			})
 			.filter((v): v is NonNullable<typeof v> => v !== null);
@@ -193,9 +226,31 @@
 	// points=[] (defensive backend output, e.g., CPM failed for all
 	// revisions). DA exit-council finding P2#7 — distinguish from
 	// "no revisions" empty state.
+	//
+	// Issue #98 item 2 (DA P3 #14 from PR #95) + frontend-ux-reviewer entry-
+	// council nice-to-have #11 on PR #109: extend to also cover the
+	// degenerate-X case where points are populated but all day_offsets=0
+	// (single-day project with multiple revisions all at d=0). Renders
+	// explicit empty-state instead of "D+0..D+1" axis with no curves.
 	const isAllEmpty = $derived(
-		curves.length > 0 && curves.every((c) => c.points.length === 0)
+		curves.length > 0 &&
+			(curves.every((c) => c.points.length === 0) ||
+				curves.every((c) => c.points.every((p) => p.day_offset === 0))),
 	);
+
+	// Multi-executed defensive z-order (issue #98 item 4 / DA P3 #16 from PR #95).
+	// Backend invariant: only the most recent revision should have is_executed=true.
+	// Defensive: find the LAST is_executed curve via findLast (ES2023). If the
+	// invariant is violated, the chart renders only that last curve's actual
+	// path; the page-level `clientWarnings` derivation surfaces a user-visible
+	// note in trends.notes (frontend-ux-reviewer entry-council SHOULD-FIX #6
+	// on PR #109: console.warn alone hides the bug).
+	const lastExecutedIndex = $derived.by((): number => {
+		for (let i = curves.length - 1; i >= 0; i--) {
+			if (curves[i].is_executed) return i;
+		}
+		return -1;
+	});
 </script>
 
 <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
@@ -274,13 +329,17 @@
 					{/if}
 				{/each}
 
-				<!-- Executed curve (heavy overlay on top of its planned counterpart) -->
-				{#each curves as c, i}
-					{@const d = buildActualPath(c, i)}
+				<!-- Executed curve (heavy overlay on top of its planned counterpart).
+				     Defensive z-order per issue #98 item 4: render only the LAST
+				     is_executed curve (backend invariant: only most-recent should be
+				     flagged). If multiple are flagged, the page-level clientWarnings
+				     surfaces a user-visible note. -->
+				{#if lastExecutedIndex >= 0}
+					{@const d = buildActualPath(curves[lastExecutedIndex], lastExecutedIndex)}
 					{#if d}
 						<path {d} fill="none" stroke="#3b82f6" stroke-width="3" opacity="0.95" />
 					{/if}
-				{/each}
+				{/if}
 
 				<!-- Change-point vertical markers -->
 				{#each changePointVisuals as cp}
@@ -344,39 +403,56 @@
 			</g>
 		</svg>
 
-		<!-- Legend (chips, flex-wrap for mobile) -->
-		<div class="mt-3 flex flex-wrap gap-x-4 gap-y-1 px-2 text-xs">
-			{#each curves as c, i}
-				<div class="flex items-center gap-1.5">
-					<span
-						class="inline-block w-3 h-0.5"
-						style="background-color: {curveColor(i, curves.length)}"
-					></span>
-					<span class="text-gray-600 dark:text-gray-400">
-						{c.revision_number != null ? `R${c.revision_number}` : `#${i + 1}`}
-						{#if c.data_date}
-							<span class="text-gray-400 dark:text-gray-500">
-								— {c.data_date}
-							</span>
-						{/if}
-					</span>
-				</div>
-			{/each}
-			{#if curves.some((c) => c.is_executed)}
-				<div class="flex items-center gap-1.5">
-					<span class="inline-block w-3 h-1" style="background-color: #3b82f6"></span>
-					<span class="text-gray-600 dark:text-gray-400">{executedLabel}</span>
-				</div>
+		<!-- Legend (chips, flex-wrap for mobile). Issue #97 part 2 / DA P2 #12
+		     mobile collapse: when shouldCollapse=true (mobile <640px AND
+		     curves.length > 8), wrapped in <details> with summary; on
+		     desktop or N≤8 the summary is omitted and legend renders inline.
+		     Always-in-DOM <details> per LifecyclePhaseCard precedent. -->
+		<details
+			class="mt-3"
+			open={detailsOpen}
+			ontoggle={(e) => (legendOpen = e.currentTarget.open)}
+		>
+			{#if shouldCollapse}
+				<summary
+					class="text-xs cursor-pointer text-gray-600 dark:text-gray-400 list-none [&::-webkit-details-marker]:hidden"
+				>
+					{legendCollapsedSummary(curves.length)}
+				</summary>
 			{/if}
-			{#if changePointVisuals.length > 0}
-				<div class="flex items-center gap-1.5">
-					<span
-						class="inline-block w-3 h-px border-t border-dashed"
-						style="border-color: #dc2626"
-					></span>
-					<span class="text-gray-600 dark:text-gray-400">{changePointLabel}</span>
-				</div>
-			{/if}
-		</div>
+			<div class="{shouldCollapse ? 'mt-2' : ''} flex flex-wrap gap-x-4 gap-y-1 px-2 text-xs">
+				{#each curves as c, i}
+					<div class="flex items-center gap-1.5">
+						<span
+							class="inline-block w-3 h-0.5"
+							style="background-color: {curveColor(i, curves.length)}"
+						></span>
+						<span class="text-gray-600 dark:text-gray-400">
+							{c.revision_number != null ? `R${c.revision_number}` : `#${i + 1}`}
+							{#if c.data_date}
+								<span class="text-gray-400 dark:text-gray-500">
+									— {c.data_date}
+								</span>
+							{/if}
+						</span>
+					</div>
+				{/each}
+				{#if curves.some((c) => c.is_executed)}
+					<div class="flex items-center gap-1.5">
+						<span class="inline-block w-3 h-1" style="background-color: #3b82f6"></span>
+						<span class="text-gray-600 dark:text-gray-400">{executedLabel}</span>
+					</div>
+				{/if}
+				{#if changePointVisuals.length > 0}
+					<div class="flex items-center gap-1.5">
+						<span
+							class="inline-block w-3 h-px border-t border-dashed"
+							style="border-color: #dc2626"
+						></span>
+						<span class="text-gray-600 dark:text-gray-400">{changePointLabel}</span>
+					</div>
+				{/if}
+			</div>
+		</details>
 	{/if}
 </div>

--- a/web/src/lib/i18n/en.ts
+++ b/web/src/lib/i18n/en.ts
@@ -1350,4 +1350,6 @@ export default {
 	'revision_trends.empty_no_revisions': 'No revisions to display. Upload a project to start trending.',
 	'revision_trends.empty_single_revision': 'Only one revision available — change-point and slope analyses require multiple revisions.',
 	'revision_trends.axis_not_calendar_disclosure': 'X-axis shows days from each revision\'s own data-date — revisions are NOT calendar-aligned. One or more curves is missing data_date metadata.',
+	'revision_trends.legend.collapsed_summary': '{n} revisions — show legend',
+	'revision_trends.multi_executed_warning': 'Backend invariant violated: more than one revision flagged is_executed=true. Chart renders only the latest. Report at github.com/VitorMRodovalho/meridianiq/issues.',
 } as Record<string, string>;

--- a/web/src/lib/i18n/es.ts
+++ b/web/src/lib/i18n/es.ts
@@ -1348,4 +1348,6 @@ export default {
 	'revision_trends.empty_no_revisions': 'No hay revisiones para mostrar. Suba un proyecto para comenzar la tendencia.',
 	'revision_trends.empty_single_revision': 'Solo hay una revisión disponible — los análisis de puntos de cambio y pendiente requieren múltiples revisiones.',
 	'revision_trends.axis_not_calendar_disclosure': 'El eje X muestra días desde la data-date de cada revisión — las revisiones NO están alineadas por calendario. Una o más curvas no tiene el metadato data_date.',
+	'revision_trends.legend.collapsed_summary': '{n} revisiones — mostrar leyenda',
+	'revision_trends.multi_executed_warning': 'Invariante del backend violada: más de una revisión marcada is_executed=true. El gráfico muestra solo la más reciente. Reportar en github.com/VitorMRodovalho/meridianiq/issues.',
 } as Record<string, string>;

--- a/web/src/lib/i18n/format.test.ts
+++ b/web/src/lib/i18n/format.test.ts
@@ -1,0 +1,92 @@
+// MIT License
+// Copyright (c) 2026 Vitor Maia Rodovalho
+//
+// Vitest unit tests for `formatNumber` helper — Cycle 5 W2 batch 2-A.
+// Issue #96 part 1 (DA P2 #8 from PR #95).
+
+import { describe, expect, it } from 'vitest';
+import { formatNumber } from './format';
+
+describe('formatNumber', () => {
+	describe('locale-specific decimal separators', () => {
+		it('en-US uses decimal POINT', () => {
+			expect(formatNumber(1.5, 'en')).toBe('1.5');
+			expect(formatNumber(-3.42, 'en', { maximumFractionDigits: 2 })).toBe('-3.42');
+		});
+
+		it('pt-BR uses decimal COMMA', () => {
+			expect(formatNumber(1.5, 'pt-BR')).toBe('1,5');
+			// Use ASCII hyphen-minus for negative values; Intl in pt-BR also uses '-'
+			expect(formatNumber(-3.42, 'pt-BR', { maximumFractionDigits: 2 })).toBe('-3,42');
+		});
+
+		it('es uses decimal COMMA', () => {
+			expect(formatNumber(1.5, 'es')).toBe('1,5');
+			expect(formatNumber(-3.42, 'es', { maximumFractionDigits: 2 })).toBe('-3,42');
+		});
+	});
+
+	describe('signDisplay: always (slope sign preservation)', () => {
+		it('en positive slope keeps + sign', () => {
+			expect(formatNumber(2.3, 'en', { maximumFractionDigits: 1, signDisplay: 'always' })).toBe(
+				'+2.3',
+			);
+		});
+
+		it('pt-BR positive slope keeps + sign with COMMA decimal', () => {
+			expect(formatNumber(2.3, 'pt-BR', { maximumFractionDigits: 1, signDisplay: 'always' })).toBe(
+				'+2,3',
+			);
+		});
+
+		it('zero with signDisplay always — frontend-ux-reviewer P0 #8 edge case', () => {
+			// Verify behavior is documented; users may dislike +0 but this is
+			// what Intl.NumberFormat produces. Documented for future preference change.
+			const result = formatNumber(0, 'en', { maximumFractionDigits: 1, signDisplay: 'always' });
+			expect(result).toBe('+0');
+		});
+	});
+
+	describe('non-finite value safety', () => {
+		it('NaN returns em-dash', () => {
+			expect(formatNumber(Number.NaN, 'en')).toBe('—');
+			expect(formatNumber(Number.NaN, 'pt-BR')).toBe('—');
+		});
+
+		it('positive Infinity returns em-dash', () => {
+			expect(formatNumber(Number.POSITIVE_INFINITY, 'en')).toBe('—');
+		});
+
+		it('negative Infinity returns em-dash', () => {
+			expect(formatNumber(Number.NEGATIVE_INFINITY, 'en')).toBe('—');
+		});
+
+		it('negative zero formats as "-0" per Intl.NumberFormat behavior', () => {
+			// -0 is finite per Number.isFinite. Intl.NumberFormat emits "-0"
+			// (preserving the negative-zero IEEE-754 distinction). Document
+			// the actual behavior: callers who want "+0" canonicalization
+			// should pass a normalized value (e.g., `value || 0`).
+			expect(formatNumber(-0, 'en')).toBe('-0');
+			expect(formatNumber(-0, 'pt-BR')).toBe('-0');
+		});
+	});
+
+	describe('default options', () => {
+		it('omitted options defaults to maximumFractionDigits: 1', () => {
+			expect(formatNumber(1.234567, 'en')).toBe('1.2');
+		});
+
+		it('multiple decimals truncate per maxFractionDigits', () => {
+			expect(formatNumber(1.234567, 'en', { maximumFractionDigits: 3 })).toBe('1.235');
+		});
+	});
+
+	describe('fallback path (invalid locale)', () => {
+		it('unknown locale string falls back to .toFixed', () => {
+			// Some Intl impls accept any tag; use a syntactically-invalid one
+			// to force the catch branch.
+			const result = formatNumber(2.5, '??invalid?', { maximumFractionDigits: 1 });
+			expect(result).toMatch(/2[.,]5/);
+		});
+	});
+});

--- a/web/src/lib/i18n/format.ts
+++ b/web/src/lib/i18n/format.ts
@@ -1,0 +1,40 @@
+// MIT License
+// Copyright (c) 2026 Vitor Maia Rodovalho
+//
+// Locale-aware number formatting helpers — Cycle 5 W2 batch 2-A.
+//
+// Usage MUST be markup-side (inside `{}` expression in template), NOT
+// script-side: the function does not subscribe to the `locale` store; the
+// reactivity comes from the markup re-rendering when `$locale` changes.
+// See frontend-ux-reviewer entry-council BLOCKING #1 on PR #109.
+//
+// Issue #96 part 1 (DA P2 #8 from PR #95): `.toFixed(1)` always emits
+// decimal POINT. pt-BR/es users expect decimal COMMA (`1,5` not `1.5`).
+// `Intl.NumberFormat` honors locale conventions automatically.
+
+import type { Locale } from './index';
+
+/**
+ * Format a numeric value per the active locale's conventions.
+ *
+ * Defensive: returns `'—'` for `NaN` and `±Infinity` to avoid rendering
+ * invalid math state.
+ *
+ * @param value - the numeric value to format
+ * @param locale - the active locale (`'en'` | `'pt-BR'` | `'es'`)
+ * @param options - `Intl.NumberFormatOptions` overrides (default
+ *   `{ maximumFractionDigits: 1 }`)
+ */
+export function formatNumber(
+	value: number,
+	locale: Locale | string = 'en',
+	options: Intl.NumberFormatOptions = { maximumFractionDigits: 1 },
+): string {
+	if (!Number.isFinite(value)) return '—';
+	try {
+		return new Intl.NumberFormat(locale, options).format(value);
+	} catch {
+		// Fallback if Intl rejects the locale string for any reason.
+		return value.toFixed(options.maximumFractionDigits ?? 1);
+	}
+}

--- a/web/src/lib/i18n/pt-BR.ts
+++ b/web/src/lib/i18n/pt-BR.ts
@@ -1348,4 +1348,6 @@ export default {
 	'revision_trends.empty_no_revisions': 'Nenhuma revisão para exibir. Faça upload de um projeto para começar a tendência.',
 	'revision_trends.empty_single_revision': 'Apenas uma revisão disponível — análises de ponto de mudança e inclinação requerem múltiplas revisões.',
 	'revision_trends.axis_not_calendar_disclosure': 'O eixo X mostra dias a partir da data-status de cada revisão — as revisões NÃO estão alinhadas por calendário. Uma ou mais curvas está sem o metadado data_date.',
+	'revision_trends.legend.collapsed_summary': '{n} revisões — mostrar legenda',
+	'revision_trends.multi_executed_warning': 'Invariante de backend violada: mais de uma revisão sinalizada is_executed=true. O gráfico mostra apenas a mais recente. Reportar em github.com/VitorMRodovalho/meridianiq/issues.',
 } as Record<string, string>;

--- a/web/src/routes/revision-trends/+page.svelte
+++ b/web/src/routes/revision-trends/+page.svelte
@@ -79,9 +79,11 @@
 	}
 
 	// Client-side derived warnings — frontend-ux-reviewer entry-council
-	// SHOULD-FIX #6 on PR #109: console.warn for multi-executed invariant
-	// violation is invisible to users + ops; surface alongside trends.notes
-	// so the bug is reportable rather than silently hidden.
+	// SHOULD-FIX #6 + DA exit-council P1 #5 on PR #109: console.warn for
+	// multi-executed invariant violation is invisible to users + ops;
+	// surface alongside trends.notes (user-visible) AND emit a console.warn
+	// for ops/Sentry breadcrumb capture (Sentry browser SDK auto-captures
+	// console.warn into breadcrumbs).
 	const clientWarnings = $derived.by((): string[] => {
 		if (trends == null) return [];
 		const out: string[] = [];
@@ -90,6 +92,18 @@
 			out.push($t('revision_trends.multi_executed_warning'));
 		}
 		return out;
+	});
+
+	// Ops capture: emit console.warn when client-side invariant violation is
+	// detected so the Sentry browser SDK breadcrumbs the event. Without this,
+	// the bug is only visible to the user reading the amber bullet — if they
+	// don't notice or report, the invariant violation goes unobserved.
+	$effect(() => {
+		if (clientWarnings.length === 0) return;
+		for (const w of clientWarnings) {
+			// eslint-disable-next-line no-console
+			console.warn('[revision-trends] client-detected invariant violation:', w);
+		}
 	});
 
 	// Methodology cite-or-fail. Frontend hardcodes the AACE 29R-03 reference
@@ -153,16 +167,22 @@
 	</div>
 
 	<!--
-		CLS guard per issue #98 item 1 / DA P2 #9. Wrapping skeleton + result
-		block in a min-h container reduces page-jump on result arrival. Tuned
-		for the empty-state and slope-band-only cases; full-content layout
-		(slope card + 360px chart + change-points list + methodology) exceeds
-		this min-height — frontend-ux-reviewer entry-council nice-to-have #9
-		acknowledged this only fixes the skeleton-to-empty transition.
+		CLS guard per issue #98 item 1 / DA P2 #9 + DA exit-council P0 #1 fix
+		on PR #109. Earlier draft used min-h-[420px] but default AnalysisSkeleton
+		(4 KPI cards + chart + table) renders ~626px — so 420px was non-binding,
+		and the CLS claim was illusory. Corrected approach:
+		(a) Pass scoped AnalysisSkeleton props matching the actual revision-trends
+		    layout (slope card + chart + change-points list, NO table) to size
+		    skeleton ≈ 600px.
+		(b) Wrapper at min-h-[600px] matches both skeleton and populated baseline
+		    (slope card 80px + chart 360px + lists 100-200px + methodology 40px ≈
+		    600-700px). Eliminates jump in empty-state and slope-band-only cases;
+		    full-content with many change-points may overflow the floor as
+		    additive expansion, not jump.
 	-->
-	<div class="min-h-[420px]">
+	<div class="min-h-[600px]">
 		{#if loading}
-			<AnalysisSkeleton />
+			<AnalysisSkeleton cards={1} showChart={true} showTable={false} />
 		{:else if errMsg}
 			<div
 				class="bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-900 rounded-lg p-4 mb-6"
@@ -190,8 +210,21 @@
 						{$t('revision_trends.slope_metric_label')}
 					</p>
 					<div class="flex items-baseline gap-3 flex-wrap">
+						<!--
+							MARKUP-SIDE: formatNumber($locale, ...) MUST be called inline
+							in markup (NOT hoisted to a $derived in <script>) to remain
+							reactive on locale change. Frontend-ux-reviewer entry-council
+							BLOCKING #1 on PR #109; tripwire comment per DA exit-council
+							P1 #3 fix on PR #109.
+
+							-0 normalization (DA exit-council P1 #4): pass `value || 0`
+							to canonicalize IEEE-754 -0 → +0 before formatting. Without
+							this, signDisplay:'always' renders "-0" for a slope of
+							exactly 0 which is internally inconsistent with the
+							"+/-/0 sign always" intent.
+						-->
 						<span class="text-2xl font-bold {slopeColorClass(sb)}">
-							{formatNumber(sb.slope_days_per_revision, $locale, {
+							{formatNumber(sb.slope_days_per_revision || 0, $locale, {
 								maximumFractionDigits: 1,
 								signDisplay: 'always',
 							})}

--- a/web/src/routes/revision-trends/+page.svelte
+++ b/web/src/routes/revision-trends/+page.svelte
@@ -2,7 +2,8 @@
 	import { getProjects, getRevisionTrends } from '$lib/api';
 	import type { RevisionTrendsResponse } from '$lib/types';
 	import { error as toastError } from '$lib/toast';
-	import { t } from '$lib/i18n';
+	import { t, locale } from '$lib/i18n';
+	import { formatNumber } from '$lib/i18n/format';
 	import AnalysisSkeleton from '$lib/components/AnalysisSkeleton.svelte';
 	import MultiRevisionSCurveChart from '$lib/components/charts/MultiRevisionSCurveChart.svelte';
 
@@ -68,11 +69,28 @@
 	// finding P1#2: chart and list previously used divergent identifiers
 	// when revision_number was sparse.
 	function changePointLabel(cp: { revision_index: number }): string {
-		if (trends == null) return `#${cp.revision_index}`;
+		// 1-based fallback aligning with chart endpointLabels (line 185) +
+		// chart changePointVisuals.revisionLabel. Issue #98 item 5 +
+		// frontend-ux-reviewer entry-council BLOCKING #2 on PR #109.
+		if (trends == null) return `#${cp.revision_index + 1}`;
 		const c = trends.curves[cp.revision_index];
 		if (c?.revision_number != null) return `R${c.revision_number}`;
-		return `#${cp.revision_index}`;
+		return `#${cp.revision_index + 1}`;
 	}
+
+	// Client-side derived warnings — frontend-ux-reviewer entry-council
+	// SHOULD-FIX #6 on PR #109: console.warn for multi-executed invariant
+	// violation is invisible to users + ops; surface alongside trends.notes
+	// so the bug is reportable rather than silently hidden.
+	const clientWarnings = $derived.by((): string[] => {
+		if (trends == null) return [];
+		const out: string[] = [];
+		const executedCount = trends.curves.filter((c) => c.is_executed).length;
+		if (executedCount > 1) {
+			out.push($t('revision_trends.multi_executed_warning'));
+		}
+		return out;
+	});
 
 	// Methodology cite-or-fail. Frontend hardcodes the AACE 29R-03 reference
 	// as a defensive fallback; if the backend response ships an empty
@@ -134,15 +152,26 @@
 		</div>
 	</div>
 
-	{#if loading}
-		<AnalysisSkeleton />
-	{:else if errMsg}
-		<div class="bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-900 rounded-lg p-4 mb-6">
-			<p class="text-red-700 dark:text-red-400 text-sm">{errMsg}</p>
-		</div>
-	{/if}
+	<!--
+		CLS guard per issue #98 item 1 / DA P2 #9. Wrapping skeleton + result
+		block in a min-h container reduces page-jump on result arrival. Tuned
+		for the empty-state and slope-band-only cases; full-content layout
+		(slope card + 360px chart + change-points list + methodology) exceeds
+		this min-height — frontend-ux-reviewer entry-council nice-to-have #9
+		acknowledged this only fixes the skeleton-to-empty transition.
+	-->
+	<div class="min-h-[420px]">
+		{#if loading}
+			<AnalysisSkeleton />
+		{:else if errMsg}
+			<div
+				class="bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-900 rounded-lg p-4 mb-6"
+			>
+				<p class="text-red-700 dark:text-red-400 text-sm">{errMsg}</p>
+			</div>
+		{/if}
 
-	{#if trends && !loading}
+		{#if trends && !loading}
 		{#if isEmpty}
 			<div
 				class="bg-white dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-700 p-8 mb-6 text-center"
@@ -162,14 +191,21 @@
 					</p>
 					<div class="flex items-baseline gap-3 flex-wrap">
 						<span class="text-2xl font-bold {slopeColorClass(sb)}">
-							{sb.slope_days_per_revision > 0 ? '+' : ''}{sb.slope_days_per_revision.toFixed(1)}
+							{formatNumber(sb.slope_days_per_revision, $locale, {
+								maximumFractionDigits: 1,
+								signDisplay: 'always',
+							})}
 						</span>
 						<span class="text-sm text-gray-600 dark:text-gray-400">
 							{$t('revision_trends.slope_unit')}
 						</span>
 						<span class="text-sm text-gray-500 dark:text-gray-500">
 							{$t('revision_trends.slope_ci_prefix')}
-							[{sb.ci_lower.toFixed(1)}, {sb.ci_upper.toFixed(1)}]
+							[{formatNumber(sb.ci_lower, $locale, { maximumFractionDigits: 1 })}, {formatNumber(
+								sb.ci_upper,
+								$locale,
+								{ maximumFractionDigits: 1 },
+							)}]
 						</span>
 						<span class="text-xs text-gray-400 dark:text-gray-500">
 							n={sb.horizon_revisions}
@@ -185,6 +221,8 @@
 				ariaLabel={$t('revision_trends.chart_aria_label')}
 				executedLabel={$t('revision_trends.executed_curve_label')}
 				changePointLabel={$t('revision_trends.change_point_label')}
+				legendCollapsedSummary={(n) =>
+					$t('revision_trends.legend.collapsed_summary').replace('{n}', String(n))}
 			/>
 
 			{#if isSingleRev && !hasExecuted}
@@ -224,13 +262,17 @@
 				{methodologyText}
 			</p>
 
-			{#if trends.notes.length > 0}
+			{#if trends.notes.length > 0 || clientWarnings.length > 0}
 				<ul class="text-xs text-gray-500 dark:text-gray-500 mt-2 list-disc pl-5 space-y-0.5">
 					{#each trends.notes as note}
 						<li>{note}</li>
 					{/each}
+					{#each clientWarnings as warning}
+						<li class="text-amber-700 dark:text-amber-400">{warning}</li>
+					{/each}
 				</ul>
 			{/if}
 		{/if}
-	{/if}
+		{/if}
+	</div>
 </main>


### PR DESCRIPTION
## Summary

Cycle 5 W2 batch 2-A per [ADR-0024 §'Wave plan W2'](docs/adr/0024-cycle-5-entry-z-shape-consolidation.md). Closes a SUBSET of issues #96/#97/#98 (Cycle 4 W3-B follow-ups). Deeper sub-scopes deferred to follow-up issues per scope discipline.

| Sub-scope | Closed here | Deferred to |
|---|---|---|
| #96 part 1 — locale-aware number formatting | ✅ | — |
| #96 parts 2+3 — backend description_key + params i18n | ❌ | [#107](https://github.com/VitorMRodovalho/meridianiq/issues/107) (schema-additive needs separate council) |
| #97 part 1 — SVG chart a11y pattern ADR | ❌ | [#106](https://github.com/VitorMRodovalho/meridianiq/issues/106) (ADR + 11-component rollout) |
| #97 part 2 — mobile legend collapse N>8 | ✅ | — |
| #98 item 1 — CLS fix | ✅ | — |
| #98 item 2 — xMax=0 degenerate-X | ✅ | — |
| #98 item 3 — HSL contrast | ❌ | [#108](https://github.com/VitorMRodovalho/meridianiq/issues/108) (WCAG-AA-measured palette) |
| #98 item 4 — multi-executed defensive z-order | ✅ | — |
| #98 item 5 — revision_index 1-based fallback | ✅ (all 3 sites aligned) | — |
| #98 item 6 — nav icon swap | ❌ | nice-to-have, no follow-up |

## Council process

**Frontend-ux-reviewer entry-council** per `feedback_entry_council_discipline.md` (just-codified post-PR-#104 where skipping cost 4 P0 findings on a 'small targeted P3 batch'). Caught 3 P0 + 5 P1 design issues BEFORE code:
- **P0 #1 reactive trap**: \`\$locale\` in script-side calls won't re-render on locale change. Fix: markup-side \`formatNumber(\$locale, ...)\` calls only.
- **P0 #2 revision_index 0-vs-1-based asymmetry**: chart line 166 (0-based) vs chart line 185 (1-based) vs page \`changePointLabel\` function (0-based). One-PR-or-don't-touch: aligned all 3 sites to 1-based per chart line 185 precedent (least-surprise).
- **P0 #3 HSL guess-tuned palette**: contrast-sensitive fix without contrast measurement is theatre. Deferred to issue #108 with WCAG-AA-measured-palette acceptance criteria.

**DA exit-council on this PR** per ADR-0018 Am.1 — runs at PR review time.

## Tests

- [x] \`npx vitest run\` → 39 passed (was 26; +13 \`formatNumber\` helper tests covering en/pt-BR/es decimal-separator + signDisplay always + NaN/Infinity em-dash + negative-zero documented + invalid-locale fallback)
- [x] \`npx svelte-check\` → 0 errors / 0 warnings
- [x] \`npm run build\` → green
- [x] \`python3 -m pytest tests/\` → 1663 passed (no backend changes; regression check)
- [x] Manual smoke: switching locale en→pt-BR→es re-renders slope + CI bounds with proper decimal separator

## Cross-references

- Parent: [ADR-0024 §'Wave plan W2'](docs/adr/0024-cycle-5-entry-z-shape-consolidation.md)
- Cycle 4 W3-B source PR: [#95](https://github.com/VitorMRodovalho/meridianiq/pull/95)
- Discipline: [feedback_entry_council_discipline.md](https://github.com/VitorMRodovalho/meridianiq/blob/main/CLAUDE.md) (codified post-PR-#104)

Closes #96 (part 1; backend follow-up at #107), #97 (part 2; a11y ADR follow-up at #106), #98 (5/6 items; HSL follow-up at #108).