### PR TITLE
fix(cycle5-w2b): #100 architecture polish — ADR-0022 corrigendum + Amendment 3 + 4 small fixes

### DIFF
--- a/docs/adr/0022-cycle-4-entry-beta-honest.md
+++ b/docs/adr/0022-cycle-4-entry-beta-honest.md
@@ -430,3 +430,11 @@ The fixture design at W3-C close (PR #99 + this Amendment) is:
 
 - Amendment is documentation-only. No code change in this ADR; the corresponding code changes ship in PR #111.
 - Future fixture design changes (e.g., extending to 12 corners on Cycle 5+ corpus growth) require Amendment 4 + matching test updates + locked F1 re-baseline.
+
+### Honest framing of retroactive narrowing (DA exit-council PR #111 P2 #7)
+
+PR #99 shipped before this Amendment was authored. The original line 165 (now corrected via the inline corrigendum) said "3 noise levels × 3 ground-truth-CP positions × 2 baseline patterns (8 total after dedup)" — mathematically vacuous because 18 ≠ 8 by any dedup. The pre-registration discipline at PR #99 merge time was therefore weaker than the Amendment retroactively records.
+
+Confirmation that the 8 shipped corners equal the 2³ specification was performed at Amendment 3 authorship time (2026-05-09), not at PR #99 merge time. The 8 shipped corners do match the 2³ corner subset {σ ∈ 0.1, 0.4} × {CP ∈ 3, 7} × {baseline ∈ A, B} — verified by `test_fixture_design_covers_orthogonal_corners` (committed in PR #99). This is good fortune, not pre-registered design.
+
+For Cycle 5+ pre-registration discipline: any new locked spec must be authored AS the locked spec, not retrofitted via amendment after delivery.

--- a/docs/adr/0022-cycle-4-entry-beta-honest.md
+++ b/docs/adr/0022-cycle-4-entry-beta-honest.md
@@ -162,7 +162,7 @@ W2 budget: **2-2.5 waves** (bumped from 1.5-2 to honestly accommodate the tombst
 
 **W4 fixture authoring (DA HB-D fix — moved here from W4 to prevent circular tuning)**:
 - Author 8 synthetic schedule-revision sequences in `tools/calibration_harness/fixtures/optimism_synth/` with planted regime-changes
-- Spec: 3 noise levels × 3 ground-truth-CP positions × 2 baseline patterns (8 total after dedup)
+- Spec: noise σ × ground-truth-CP position × baseline pattern, 2³ corner subset of the {0.1, 0.2, 0.4} × {3, 5, 7} × {A, B} factorial (= 8 corner cells; middle σ=0.2 + middle CP=5 dropped per Amendment 3 below). Earlier draft of this line read "(8 total after dedup)" which was mathematically incorrect (3×3×2 = 18, not 8 by deduplication); corrigendum per backend-reviewer entry-council BLOCKING #3 on PR #111.
 - Hash-lock: SHA256 of fixture set committed to `tools/calibration_harness/fixtures/optimism_synth.lock` at W3 close
 - W4 evaluation MUST verify the hash matches before running sub-gate C — if hash drifts (fixtures retuned), evaluation aborts and ADR-0023 documents that the gate was tampered with
 
@@ -399,3 +399,34 @@ The endpoint computes the next revision_number as `MAX(revision_number) + 1` ove
 - `src/api/routers/revisions.py` endpoint contract
 - `tests/test_revisions_router.py` regression tests pinning the contract
 - `docs/operator-runbooks/cycle4.md` §"W2-INC-01" tombstone procedure
+
+## Amendment 3 — W3-C fixture design rationale (2026-05-09, W2-B PR-#111)
+
+### Context
+
+W3-C delivery (PR #99) shipped 8 hash-locked synthetic fixtures (`tools/calibration_harness/fixtures/optimism_synth/corner_*.json`) per the W3 fixture authoring spec above (line 165). The DA exit-council on PR #99 surfaced two recordkeeping gaps that this Amendment closes:
+
+1. **2³ corner subset rationale** — original spec line read "3 noise levels × 3 ground-truth-CP positions × 2 baseline patterns" implying 18 cells dedup'd to 8. The actual delivery dropped the middle σ=0.2 and middle CP=5, keeping the 2³ corners {σ ∈ 0.1, 0.4} × {CP ∈ 3, 7} × {baseline ∈ A, B} = 8 corners. Corrigendum applied inline at line 165 above; rationale recorded here.
+
+2. **N=12 revisions per fixture** — implementation choice not documented in the ADR. Driven by `revision_trends.cusum_change_points` `_MIN_REVISIONS_FOR_CUSUM = 5` floor: with CP=7, post-CP shift count = 12-7-1 = 4 revisions of post-CP signal which the engine can detect at 3σ threshold given the +5 days/rev sustained drift magnitude. Hand-verified at W3-C generation time.
+
+### Decision
+
+The fixture design at W3-C close (PR #99 + this Amendment) is:
+
+- **2³ corner factorial**: {σ ∈ 0.1, 0.4} × {ground_truth_CP ∈ 3, 7} × {baseline_pattern ∈ A, B} = 8 fixtures. Middle σ=0.2 and middle CP=5 cells dropped because main-effects + interactions are fully captured at corners for the sub-gate C F1 evaluation rule (cluster-span match within tolerance=1).
+- **N=12 revisions per fixture**: chosen so CP=7 has ≥4 post-CP shifts vs the engine's `_MIN_REVISIONS_FOR_CUSUM=5` floor. CP=3 fixtures have ≥8 post-CP shifts (more sensitivity headroom).
+- **Pattern A vs Pattern B baselines**: A is "stable → drift" (pre_cp_rate=0, post_cp_rate=5); B is "slow drift → fast drift" (pre_cp_rate=1, post_cp_rate=5). Drift magnitudes are CALIBRATION ASSUMPTIONS (not literature-derived); see `tools/calibration_harness/fixtures/optimism_synth/_generator.py::_PATTERN_DRIFT_RATES` for in-line documentation per backend-reviewer entry-council SHOULD-FIX #1 on PR #111.
+- **Locked sub-gate C F1 baseline**: pinned in `tests/test_optimism_synth_fixtures.py::_LOCKED_SUB_GATE_C_F1` as the authoritative pin (test fails CI on drift). This Amendment **does NOT duplicate the F1 value** to avoid future drift between ADR text and code per backend-reviewer entry-council finding NICE-TO-HAVE #3 on PR #111. Operator who needs the value reads the test.
+
+### Cross-references
+
+- `tools/calibration_harness/fixtures/optimism_synth/_generator.py` (CORNERS tuple + `_PATTERN_DRIFT_RATES` dict)
+- `tests/test_optimism_synth_fixtures.py` (`_LOCKED_SUB_GATE_C_F1` constant + `test_generator_is_deterministic` with Python-version-skip guard)
+- W3-C PR #99 (original fixture delivery + hash-lock)
+- W2-B PR #111 (this Amendment + tamper-test rename + adapter smoke + `_cli` rename + Pattern docstring)
+
+### Reversibility
+
+- Amendment is documentation-only. No code change in this ADR; the corresponding code changes ship in PR #111.
+- Future fixture design changes (e.g., extending to 12 corners on Cycle 5+ corpus growth) require Amendment 4 + matching test updates + locked F1 re-baseline.

--- a/tests/test_calibration_harness.py
+++ b/tests/test_calibration_harness.py
@@ -389,6 +389,35 @@ class TestRegistry:
         assert "construction" in a.label_set
         assert "unknown" in a.label_set
 
+    def test_lifecycle_phase_adapter_lazy_imports_resolve(self) -> None:
+        """Smoke: under the W3-C package layout (``tools/calibration_harness``
+        as a package, NOT a single module), ``_LifecyclePhaseV1Adapter``'s
+        lazy imports of ``src.parser.xer_reader.XERReader`` +
+        ``src.analytics.lifecycle_phase`` still resolve.
+
+        Issue #100 item 5 / DA P3 #16 + backend-reviewer entry-council
+        SHOULD-FIX #2 on PR #111: constructor + property reads alone
+        DON'T fire the lazy import. Force resolution by directly
+        ``importlib.import_module``-ing the lazy-imported modules
+        (matches what the adapter's ``parse_and_classify`` would trigger).
+        """
+        import importlib
+
+        # Adapter constructor + property smoke — verifies the registry path
+        # works under the package layout.
+        a = get_adapter("lifecycle_phase")
+        assert a.engine_name == "lifecycle_phase"
+        # Force-import the modules the adapter lazy-imports inside
+        # ``parse_and_classify``. If the package conversion broke either
+        # import path, these calls raise ``ModuleNotFoundError``.
+        xer_reader_mod = importlib.import_module("src.parser.xer_reader")
+        assert hasattr(xer_reader_mod, "XERReader"), (
+            "src.parser.xer_reader lacks XERReader; W3-C package conversion"
+            " may have broken the import chain"
+        )
+        lifecycle_phase_mod = importlib.import_module("src.analytics.lifecycle_phase")
+        assert hasattr(lifecycle_phase_mod, "infer_lifecycle_phase")
+
     def test_w4_protocol_matches_amendment_1(self) -> None:
         """Pin the canonical W4 numbers — the protocol shipped publicly
         as the example for ADR-0020 and downstream engines will copy

--- a/tests/test_calibration_harness.py
+++ b/tests/test_calibration_harness.py
@@ -383,40 +383,20 @@ class TestRegistry:
             get_protocol("non-existent-protocol")
 
     def test_lifecycle_phase_adapter_metadata(self) -> None:
+        # Issue #100 item 5 / DA P3 #16 + backend-reviewer entry-council
+        # SHOULD-FIX #2 on PR #111: ``get_adapter("lifecycle_phase")``
+        # invokes ``_LifecyclePhaseV1Adapter()`` which fires the lazy
+        # imports of ``src.parser.xer_reader.XERReader`` and
+        # ``src.analytics.lifecycle_phase`` inside ``__init__``. A
+        # ``ModuleNotFoundError`` from a broken W3-C package conversion
+        # would surface here. DA exit-council PR #111 P1 #3: an additional
+        # ``importlib.import_module`` smoke test was rejected as redundant
+        # (the constructor IS the import-chain assertion).
         a = get_adapter("lifecycle_phase")
         assert a.engine_name == "lifecycle_phase"
         assert a.unknown_label == "unknown"
         assert "construction" in a.label_set
         assert "unknown" in a.label_set
-
-    def test_lifecycle_phase_adapter_lazy_imports_resolve(self) -> None:
-        """Smoke: under the W3-C package layout (``tools/calibration_harness``
-        as a package, NOT a single module), ``_LifecyclePhaseV1Adapter``'s
-        lazy imports of ``src.parser.xer_reader.XERReader`` +
-        ``src.analytics.lifecycle_phase`` still resolve.
-
-        Issue #100 item 5 / DA P3 #16 + backend-reviewer entry-council
-        SHOULD-FIX #2 on PR #111: constructor + property reads alone
-        DON'T fire the lazy import. Force resolution by directly
-        ``importlib.import_module``-ing the lazy-imported modules
-        (matches what the adapter's ``parse_and_classify`` would trigger).
-        """
-        import importlib
-
-        # Adapter constructor + property smoke — verifies the registry path
-        # works under the package layout.
-        a = get_adapter("lifecycle_phase")
-        assert a.engine_name == "lifecycle_phase"
-        # Force-import the modules the adapter lazy-imports inside
-        # ``parse_and_classify``. If the package conversion broke either
-        # import path, these calls raise ``ModuleNotFoundError``.
-        xer_reader_mod = importlib.import_module("src.parser.xer_reader")
-        assert hasattr(xer_reader_mod, "XERReader"), (
-            "src.parser.xer_reader lacks XERReader; W3-C package conversion"
-            " may have broken the import chain"
-        )
-        lifecycle_phase_mod = importlib.import_module("src.analytics.lifecycle_phase")
-        assert hasattr(lifecycle_phase_mod, "infer_lifecycle_phase")
 
     def test_w4_protocol_matches_amendment_1(self) -> None:
         """Pin the canonical W4 numbers — the protocol shipped publicly

--- a/tests/test_optimism_synth_fixtures.py
+++ b/tests/test_optimism_synth_fixtures.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import json
 import shutil
+import sys
 from pathlib import Path
 
 import numpy as np
@@ -58,6 +59,18 @@ _LOCK_PATH = _FIXTURES_DIR.parent / "optimism_synth.lock"
 # (the lock test catches that first). The literal value below is THE
 # pre-registered W4 sub-gate C result against the current engine.
 _LOCKED_SUB_GATE_C_F1: float = 0.769231
+
+# Python-version provenance pin for the determinism contract. Issue #100
+# item 2 / DA P2 #8 + backend-reviewer entry-council BLOCKING #2 on PR #111:
+# json.dumps + numpy float-formatting are byte-stable WITHIN a Python minor
+# version but may drift across versions. The committed
+# `optimism_synth.lock` was authored under THIS interpreter version. When
+# CI moves to a newer Python (e.g., 3.13 → 3.14), `test_generator_is_deterministic`
+# is SKIPPED with a clear message rather than failing for a non-tampering
+# reason. Operator ceremony on Python bump: re-run the generator on the
+# new interpreter, verify the lock is still semantically correct, update
+# this constant + the lock + the locked F1 baseline if needed.
+_PYTHON_AUTHORED_AT: tuple[int, int] = (3, 12)
 
 
 def test_eight_corner_fixtures_committed() -> None:
@@ -92,7 +105,21 @@ def test_generator_is_deterministic(tmp_path: Path) -> None:
     Catches NumPy float-formatting drift between minor versions, JSON
     library changes, or accidental edits to ``_generator.py`` that
     would silently change the locked content.
+
+    Issue #100 item 2 / DA P2 #8 + backend-reviewer entry-council
+    BLOCKING #2 on PR #111: skipped on Python interpreter versions
+    other than the one the lock was authored on. Cross-Python json.dumps
+    byte-stability is NOT guaranteed; a CI move to a newer Python would
+    fail this test for a non-tampering reason. Skip + ceremony engages.
     """
+    if sys.version_info[:2] != _PYTHON_AUTHORED_AT:
+        pytest.skip(
+            f"determinism lock authored on Python {_PYTHON_AUTHORED_AT[0]}.{_PYTHON_AUTHORED_AT[1]}; "
+            f"runner is {sys.version_info.major}.{sys.version_info.minor}. "
+            f"Cross-version json.dumps + numpy float-formatting byte-stability is not "
+            f"guaranteed. Operator: re-run _generator.py on new Python + verify lock + "
+            f"update _PYTHON_AUTHORED_AT."
+        )
     expected_hashes = parse_fixture_lock(_LOCK_PATH)
     regenerated_hashes = regenerate_all(
         out_dir=tmp_path / "fixtures",
@@ -133,12 +160,19 @@ def test_tamper_detection_on_byte_flip(tmp_path: Path) -> None:
         verify_optimism_synth_hash_lock(fixtures_dir=work_dir, lock_path=work_lock)
 
 
-def test_tamper_detection_on_extra_file(tmp_path: Path) -> None:
-    """Adding an unlocked fixture triggers FixtureHashMismatch.
+def test_tamper_detection_on_extra_file_within_legitimate_range(tmp_path: Path) -> None:
+    """Adding an unlocked fixture WITHIN the legitimate filename range
+    triggers FixtureHashMismatch.
 
-    Catches a "I added a new corner without updating the lock"
-    tampering pattern (e.g., someone planting an easy fixture to
-    inflate sub-gate C F1).
+    Catches the "I added a new corner without updating the lock" tampering
+    pattern with a stronger filename: ``corner_05_v2.json`` is
+    numerically WITHIN the {01..12} range that future fixture rotations
+    might extend to, so the test cannot pass for the wrong reason if
+    Cycle 5+ extends to 12 corners. Issue #100 item 4 / DA P2 #9 fix on
+    PR #99: previous test planted ``corner_99.json`` which is
+    out-of-range and would still pass at 12 corners by trivial
+    numerical-bound check rather than by the intended "lock vs disk"
+    invariant.
     """
     work_dir = tmp_path / "work"
     work_dir.mkdir()
@@ -147,9 +181,12 @@ def test_tamper_detection_on_extra_file(tmp_path: Path) -> None:
     work_lock = tmp_path / "work.lock"
     shutil.copy2(_LOCK_PATH, work_lock)
 
-    # Plant an extra corner.
-    extra = work_dir / "corner_99.json"
-    extra.write_text(json.dumps({"fixture_id": "corner_99", "schema_version": 1}), encoding="utf-8")
+    # Plant an extra corner using the v2-suffix attack (within numeric range
+    # of legitimate corners but not in the lock). Filename: corner_05_v2.json.
+    extra = work_dir / "corner_05_v2.json"
+    extra.write_text(
+        json.dumps({"fixture_id": "corner_05_v2", "schema_version": 1}), encoding="utf-8"
+    )
 
     with pytest.raises(FixtureHashMismatch, match="missing_lock"):
         verify_optimism_synth_hash_lock(fixtures_dir=work_dir, lock_path=work_lock)

--- a/tests/test_optimism_synth_fixtures.py
+++ b/tests/test_optimism_synth_fixtures.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import json
 import shutil
 import sys
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -64,12 +65,24 @@ _LOCKED_SUB_GATE_C_F1: float = 0.769231
 # item 2 / DA P2 #8 + backend-reviewer entry-council BLOCKING #2 on PR #111:
 # json.dumps + numpy float-formatting are byte-stable WITHIN a Python minor
 # version but may drift across versions. The committed
-# `optimism_synth.lock` was authored under THIS interpreter version. When
-# CI moves to a newer Python (e.g., 3.13 → 3.14), `test_generator_is_deterministic`
-# is SKIPPED with a clear message rather than failing for a non-tampering
-# reason. Operator ceremony on Python bump: re-run the generator on the
-# new interpreter, verify the lock is still semantically correct, update
-# this constant + the lock + the locked F1 baseline if needed.
+# `optimism_synth.lock` was authored under THIS interpreter version (Python
+# 3.12 — the development host's available interpreter at PR #99 W3-C
+# authoring time, 2026-05-09). CI runs Python 3.14 (canonical CI per
+# CLAUDE.md), so on every CI run `test_generator_is_deterministic`
+# CURRENTLY SKIPS — the operator follow-up issue tracks regenerating the
+# lock under Python 3.14 (the canonical CI Python) so determinism fires
+# in CI. DA exit-council PR #111 P1 #1 + DA P2 #5+#6: skip emits a
+# ``UserWarning`` so pytest's warning summary surfaces the gap on every
+# CI run rather than silently passing. Operator ceremony on regen:
+#
+#     1. Run ``python -m tools.calibration_harness.fixtures.optimism_synth._generator --force``
+#        on the target Python version.
+#     2. Verify ``test_locked_f1_relationship_to_sub_gate_c_threshold``
+#        + ``test_evaluate_cusum_f1_locked_baseline_against_committed_fixtures``
+#        still pass (engine F1 ≥ 0.75 and matches ``_LOCKED_SUB_GATE_C_F1``).
+#     3. Update ``_PYTHON_AUTHORED_AT`` to the new ``(major, minor)``.
+#     4. If F1 changes (engine bumped or numerical drift), bump
+#        ``_LOCKED_SUB_GATE_C_F1`` + amend ADR-0022 §"W4 sub-gate C".
 _PYTHON_AUTHORED_AT: tuple[int, int] = (3, 12)
 
 
@@ -113,13 +126,28 @@ def test_generator_is_deterministic(tmp_path: Path) -> None:
     fail this test for a non-tampering reason. Skip + ceremony engages.
     """
     if sys.version_info[:2] != _PYTHON_AUTHORED_AT:
-        pytest.skip(
-            f"determinism lock authored on Python {_PYTHON_AUTHORED_AT[0]}.{_PYTHON_AUTHORED_AT[1]}; "
-            f"runner is {sys.version_info.major}.{sys.version_info.minor}. "
-            f"Cross-version json.dumps + numpy float-formatting byte-stability is not "
-            f"guaranteed. Operator: re-run _generator.py on new Python + verify lock + "
-            f"update _PYTHON_AUTHORED_AT."
+        message = (
+            f"determinism lock authored on Python {_PYTHON_AUTHORED_AT[0]}."
+            f"{_PYTHON_AUTHORED_AT[1]}; runner is {sys.version_info.major}."
+            f"{sys.version_info.minor}. Cross-version json.dumps + numpy "
+            f"float-formatting byte-stability is not guaranteed. Lock-parity "
+            f"test (test_committed_fixtures_match_lock) still fires every "
+            f"CI run and catches fixture-on-disk tampering; this skip means "
+            f"only generator-CODE tampering is uncaught until the operator "
+            f"regenerates under the canonical CI Python. See _PYTHON_AUTHORED_AT "
+            f"docstring for ceremony."
         )
+        # DA exit-council PR #111 P1 #1: surface the skip in pytest's warning
+        # summary so CI logs flag the gap on every run, not just on first
+        # encounter. Without this, the skip is silent in pytest's default
+        # reporter (single 's' marker) and the W4 sub-gate C "tamper-proof
+        # fixtures" claim becomes theatrical.
+        warnings.warn(
+            f"optimism_synth determinism test SKIPPED in CI: {message}",
+            UserWarning,
+            stacklevel=2,
+        )
+        pytest.skip(message)
     expected_hashes = parse_fixture_lock(_LOCK_PATH)
     regenerated_hashes = regenerate_all(
         out_dir=tmp_path / "fixtures",
@@ -160,7 +188,7 @@ def test_tamper_detection_on_byte_flip(tmp_path: Path) -> None:
         verify_optimism_synth_hash_lock(fixtures_dir=work_dir, lock_path=work_lock)
 
 
-def test_tamper_detection_on_extra_file_within_legitimate_range(tmp_path: Path) -> None:
+def test_tamper_detection_on_extra_file_in_range(tmp_path: Path) -> None:
     """Adding an unlocked fixture WITHIN the legitimate filename range
     triggers FixtureHashMismatch.
 
@@ -173,6 +201,15 @@ def test_tamper_detection_on_extra_file_within_legitimate_range(tmp_path: Path) 
     out-of-range and would still pass at 12 corners by trivial
     numerical-bound check rather than by the intended "lock vs disk"
     invariant.
+
+    DA exit-council PR #111 P2 #4: planted file is a COPY of an existing
+    fixture (renamed) rather than a stub. If future hardening of
+    ``verify_optimism_synth_hash_lock`` reads fixture CONTENT before
+    checking lock parity (legitimate hardening), a stub
+    ``{"fixture_id": ..., "schema_version": 1}`` would raise ``KeyError``
+    on missing ``finish_days`` BEFORE the ``missing_lock`` invariant
+    fires. A real-content copy keeps the test diagnosing the right
+    invariant under plausible hardening.
     """
     work_dir = tmp_path / "work"
     work_dir.mkdir()
@@ -181,12 +218,13 @@ def test_tamper_detection_on_extra_file_within_legitimate_range(tmp_path: Path) 
     work_lock = tmp_path / "work.lock"
     shutil.copy2(_LOCK_PATH, work_lock)
 
-    # Plant an extra corner using the v2-suffix attack (within numeric range
-    # of legitimate corners but not in the lock). Filename: corner_05_v2.json.
-    extra = work_dir / "corner_05_v2.json"
-    extra.write_text(
-        json.dumps({"fixture_id": "corner_05_v2", "schema_version": 1}), encoding="utf-8"
-    )
+    # Plant an extra corner using the v2-suffix attack: copy an existing
+    # legitimate fixture under a new name, simulating "I duplicated a
+    # corner without updating the lock". Filename: corner_05_v2.json
+    # (within numeric range; not in lock).
+    extra_src = work_dir / "corner_05.json"
+    extra_dst = work_dir / "corner_05_v2.json"
+    shutil.copy2(extra_src, extra_dst)
 
     with pytest.raises(FixtureHashMismatch, match="missing_lock"):
         verify_optimism_synth_hash_lock(fixtures_dir=work_dir, lock_path=work_lock)

--- a/tools/calibration_harness/__init__.py
+++ b/tools/calibration_harness/__init__.py
@@ -874,10 +874,11 @@ def get_protocol(name: str) -> CalibrationProtocol:
 def cli(argv: list[str] | None = None) -> int:
     """Public CLI entry point. Renamed from ``_cli`` per issue #100 / DA P2 #11
     on PR #99: ``__main__.py`` is the documented public entry; cross-package
-    private import was convention-broken. Backend-reviewer entry-council on
-    PR #111: gates submodule (``gates/revision_trends_w4.py::_cli``) NOT
-    renamed — that one is genuinely private to the harness sub-tool and not
-    invoked outside the gates package."""
+    private import was convention-broken. DA exit-council on PR #111 P1 #2:
+    the gate-level ``revision_trends_w4::cli`` was ALSO renamed in the same
+    PR (originally claimed "private to the harness sub-tool" but actually
+    cross-package-imported by ``gates/__main__.py`` + the test suite — the
+    asymmetry was a docstring fiction)."""
     import argparse
 
     parser = argparse.ArgumentParser(

--- a/tools/calibration_harness/__init__.py
+++ b/tools/calibration_harness/__init__.py
@@ -871,7 +871,13 @@ def get_protocol(name: str) -> CalibrationProtocol:
 # --------------------------------------------------------------------------- #
 
 
-def _cli(argv: list[str] | None = None) -> int:
+def cli(argv: list[str] | None = None) -> int:
+    """Public CLI entry point. Renamed from ``_cli`` per issue #100 / DA P2 #11
+    on PR #99: ``__main__.py`` is the documented public entry; cross-package
+    private import was convention-broken. Backend-reviewer entry-council on
+    PR #111: gates submodule (``gates/revision_trends_w4.py::_cli``) NOT
+    renamed — that one is genuinely private to the harness sub-tool and not
+    invoked outside the gates package."""
     import argparse
 
     parser = argparse.ArgumentParser(
@@ -985,4 +991,4 @@ def _cli(argv: list[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(_cli())
+    sys.exit(cli())

--- a/tools/calibration_harness/__main__.py
+++ b/tools/calibration_harness/__main__.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 
 import sys
 
-from tools.calibration_harness import _cli
+from tools.calibration_harness import cli
 
 
 if __name__ == "__main__":
-    sys.exit(_cli())
+    sys.exit(cli())

--- a/tools/calibration_harness/fixtures/optimism_synth/_generator.py
+++ b/tools/calibration_harness/fixtures/optimism_synth/_generator.py
@@ -67,8 +67,17 @@ _NOISE_DAYS_PER_SIGMA = 10.0  # σ=0.1 → std=1 day, σ=0.4 → std=4 days
 # "step from slow drift to fast drift". The +5 magnitude is calibrated to
 # exceed the 3σ CUSUM gate with the chosen σ noise levels at N=12, NOT
 # to match observed schedule-slip rates from production projects.
-# Literature-derived defaults pending Cycle 5+ corpus growth per ADR-0023
-# §"Cycle 5+ preconditions" reactivation conditions.
+#
+# DA exit-council PR #111 P2 #8: two distinct deferral tracks here, on
+# DIFFERENT timelines:
+#   - **Literature-derived defaults** (e.g., AACE/CII/Construction Industry
+#     Institute survey papers on revision-to-revision schedule slip rates)
+#     are NOT corpus-dependent. Could ship as a Cycle 4.5 / Cycle 5 W0
+#     standalone literature search. No empirical corpus needed.
+#   - **Empirical-corpus-derived defaults** require sub-gate A passing
+#     (N≥30 LGPD-cleared completed projects per ADR-0022 §6) — operator-
+#     paced, ≥6mo realistic timeline. See ADR-0023 §"Cycle 5+ preconditions
+#     for re-evaluation" for the reactivation gate.
 _PATTERN_DRIFT_RATES: dict[str, dict[str, float]] = {
     "A": {"pre_cp_rate": 0.0, "post_cp_rate": 5.0},  # stable → drift
     "B": {"pre_cp_rate": 1.0, "post_cp_rate": 5.0},  # slow drift → fast drift

--- a/tools/calibration_harness/fixtures/optimism_synth/_generator.py
+++ b/tools/calibration_harness/fixtures/optimism_synth/_generator.py
@@ -59,6 +59,16 @@ _NOISE_DAYS_PER_SIGMA = 10.0  # σ=0.1 → std=1 day, σ=0.4 → std=4 days
 # (5 − pre_rate) × post_cp_count vs noise std, which exceeds the 3σ gate
 # even at σ=0.4 with N=8 revisions. Hand-verified at W3-C generation time
 # against ``revision_trends.cusum_change_points`` (line 289).
+#
+# **All four rates below are CALIBRATION ASSUMPTIONS, not derived from
+# empirical corpus** (issue #100 item 6 / DA P3 #13 + backend-reviewer
+# entry-council SHOULD-FIX #1 on PR #111). Pattern A pre=0, post=5 chosen
+# as "step from stable to clear drift". Pattern B pre=1, post=5 chosen as
+# "step from slow drift to fast drift". The +5 magnitude is calibrated to
+# exceed the 3σ CUSUM gate with the chosen σ noise levels at N=12, NOT
+# to match observed schedule-slip rates from production projects.
+# Literature-derived defaults pending Cycle 5+ corpus growth per ADR-0023
+# §"Cycle 5+ preconditions" reactivation conditions.
 _PATTERN_DRIFT_RATES: dict[str, dict[str, float]] = {
     "A": {"pre_cp_rate": 0.0, "post_cp_rate": 5.0},  # stable → drift
     "B": {"pre_cp_rate": 1.0, "post_cp_rate": 5.0},  # slow drift → fast drift

--- a/tools/calibration_harness/gates/__main__.py
+++ b/tools/calibration_harness/gates/__main__.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 
 import sys
 
-from tools.calibration_harness.gates.revision_trends_w4 import _cli
+from tools.calibration_harness.gates.revision_trends_w4 import cli
 
 
 if __name__ == "__main__":
-    sys.exit(_cli())
+    sys.exit(cli())

--- a/tools/calibration_harness/gates/revision_trends_w4.py
+++ b/tools/calibration_harness/gates/revision_trends_w4.py
@@ -622,10 +622,15 @@ def load_calibration_pairs(path: Path) -> list[CalibrationPair]:
 # --------------------------------------------------------------------------- #
 
 
-def _cli(argv: list[str] | None = None) -> int:
-    # NOTE: ``.claude/rules/backend.md`` requires "no print()" in application
-    # code. CLI tools are the documented exception (operator-facing stdout) —
-    # mirrors the existing harness CLI ``tools/calibration_harness/__init__.py::_cli``.
+def cli(argv: list[str] | None = None) -> int:
+    """Public CLI entry point. Renamed from ``_cli`` per DA exit-council
+    on PR #111 P1 #2: ``gates/__main__.py`` and tests both cross-package-import
+    this symbol, so the leading-underscore "private" name was a docstring
+    fiction. Symmetric with the top-level ``cli`` rename per the same
+    convention. NOTE: ``.claude/rules/backend.md`` requires "no print()"
+    in application code; CLI tools are the documented exception (operator-
+    facing stdout) — mirrors ``tools/calibration_harness/__init__.py::cli``.
+    """
     parser = argparse.ArgumentParser(
         prog="python -m tools.calibration_harness.gates.revision_trends_w4",
         description=(
@@ -746,4 +751,4 @@ def _cli(argv: list[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(_cli())
+    sys.exit(cli())


### PR DESCRIPTION
## Summary

Cycle 5 W2 batch 2-B closes issue #100 (architecture/tools polish from Cycle 4 W3 fixture-set DA review). 6 sub-items per backend-reviewer entry-council revised scope:

- **B-1** `_cli` → `cli` rename (top-level — and during DA exit-council fix-up, gate-level too for symmetry)
- **B-2** Cross-Python skip-guard via `_PYTHON_AUTHORED_AT` constant on `test_generator_is_deterministic` (replacing redundant byte-stability test proposal)
- **B-3** ADR-0022 line 165 corrigendum + Amendment 3 documenting 2³ corner subset rationale + N=12 revisions choice
- **S-1** Pattern A+B drift rate docstring widened to flag CALIBRATION ASSUMPTIONS
- **S-2** Adapter smoke test (deleted post-DA exit-council as redundant — `test_lifecycle_phase_adapter_metadata` already exercises the lazy-import chain)
- **Tamper-test rename** `corner_99.json` → `corner_05_v2.json` (within-range attack)

## DA exit-council fix-ups (commit `98300c0`)

- **P1 #1** Silent CI skip on `test_generator_is_deterministic` (lock authored on Python 3.12, CI runs 3.14): added `warnings.warn` so pytest's warning summary surfaces the gap on every CI run. Operator follow-up tracked in **issue #112** (regenerate lock under Python 3.14).
- **P1 #2** Gate-level `_cli` "genuinely private" claim was a docstring fiction (cross-package-imported by `gates/__main__.py`); extended rename to `gates/revision_trends_w4.py::cli` for symmetry. All 3 CLI entry points verified working.
- **P1 #3** Adapter smoke test was redundant module-existence check (`__init__` fires the lazy imports inline, `get_adapter()` already exercises that chain); deleted as dead mass.
- **P2 #4** Tamper test stub fixture replaced with `shutil.copy2` of legitimate fixture (robust to plausible verify-hardening that reads content before lock parity).
- **P3 #9** Verbose test name `_within_legitimate_range` → `_in_range` (matches sibling tamper-test suffix convention).
- **P2 #7** Amendment 3 §"Honest framing of retroactive narrowing" added — flags PR #99 shipped before the spec was tightened.
- **P2 #8** Generator docstring split literature-derived (no corpus dep) vs empirical-corpus-derived (sub-gate A precondition) deferral tracks.

## Test plan

- [x] `python -m pytest tests/ -q` — 1663 passed, 6 skipped, 70 warnings (incl. new UserWarning surfacing the determinism skip)
- [x] `ruff check tools/ tests/` — clean
- [x] All 3 CLI entry points verified post-rename (`tools.calibration_harness`, `tools.calibration_harness.gates`, `tools.calibration_harness.gates.revision_trends_w4`)
- [x] CI green on `98300c0` (Backend, Frontend, E2E, gitleaks all pass)
- [x] **DA exit-council on this PR** per ADR-0018 Am.1 — completed; 3 P1 + 3 P2/P3 findings addressed inline

## Closes

- #100 — Cycle 4 W3 fixture-set DA review architecture polish

## Cross-refs

- #112 — operator follow-up: regenerate lock under Python 3.14
- ADR-0022 Amendment 3 (this PR adds + extends with §"Honest framing")
- ADR-0018 Amendment 1 (DA-as-second-reviewer protocol)