### PR TITLE
test(cycle5-w3a): #82 — regression pin for confirm 409 across program_id mutation

### DIFF
--- a/tests/test_revisions_router.py
+++ b/tests/test_revisions_router.py
@@ -171,40 +171,53 @@ def test_confirm_409_when_parent_in_different_program(
 def test_confirm_409_when_program_id_mutated_after_detect(
     client: TestClient, fresh_store: InMemoryStore
 ) -> None:
-    """Confirm-time program_id check still fires when program_id mutates
-    BETWEEN a detect call and a confirm call (issue #82, DA P3-15 from
-    PR #78).
+    """Contract probe on the ``get_project_meta.program_id`` read path
+    used by ``confirm-revision-of`` (issue #82, DA P3-15 from PR #78).
 
-    Backend-reviewer entry-council on issue #82 (Cycle 5 W3-A): the detect
-    endpoint is stateless and confirm reads ``program_id`` fresh from the
-    store at submission time, so this case is structurally indistinguishable
-    from ``test_confirm_409_when_parent_in_different_program`` — the detect
-    call is a no-op for the assertion. This test is documented as a
-    REGRESSION PIN against any future refactor that introduces a
-    detect-cached ``program_id`` token confirm trusts. No production API
-    re-groups projects today; the mutation goes through ``_project_meta``
-    direct poke as the future-API stand-in.
+    Distinct from ``test_confirm_409_when_parent_in_different_program``
+    in setup shape: that test pre-creates two projects in DIFFERENT
+    programs (PROJ-A vs PROJ-B), then asserts 409. This test pre-creates
+    two projects in the SAME auto-grouped program (both PROJ-A), runs
+    detect (stateless 200), MUTATES p2's ``program_id`` post-detect, and
+    asserts confirm now 409s. Without the mutation the path would 200 —
+    the mutation is the load-bearing step.
+
+    What this pins:
+        ``confirm-revision-of`` reads ``program_id`` from the live store
+        at submission time (via ``get_project_meta``) — not from a value
+        cached at detect time. A refactor introducing a detect-cached
+        token would have to leave this path intact OR explicitly opt out
+        of contract.
+
+    What this does NOT pin (DA exit-council on PR #113 P1 #2):
+        No production API re-groups projects today. The store-level
+        mutation here is artificial; if a future re-grouping API ships,
+        a real-coverage test should land alongside it (touching
+        ``_upload_program`` + ``_programs`` per the actual API surface,
+        not just ``_project_meta``).
     """
+    user_id = "user-w2-test"
     p1 = fresh_store.save_project(
         upload_id="u1",
         schedule=_schedule("PROJ-A", datetime(2026, 1, 1, tzinfo=timezone.utc)),
-        user_id="user-w2-test",
+        user_id=user_id,
     )
     p2 = fresh_store.save_project(
         upload_id="u2",
         schedule=_schedule("PROJ-A", datetime(2026, 2, 1, tzinfo=timezone.utc)),
-        user_id="user-w2-test",
+        user_id=user_id,
     )
     token = _make_token()
-    # Detect: stateless read; returns candidate (or none). No state captured.
+    # Detect: stateless read; no state captured by the response.
     client.post(
         f"/api/v1/projects/{p2}/detect-revision-of",
         headers={"Authorization": f"Bearer {token}"},
     )
-    # Mutate: simulate a future support-ticket re-grouping API moving p2 to a
-    # different program. No production call site exists today; this poke is
-    # the future-API stand-in.
-    fresh_store._project_meta[p2]["program_id"] = "different-program"  # noqa: SLF001
+    # Mutate: schema-shaped program_id (real prog-NNNN value created via
+    # get_or_create_program) so the test's stand-in matches the actual
+    # FK shape program_id has in production. DA exit-council PR #113 P2 #4.
+    other_program_id = fresh_store.get_or_create_program(user_id, "OTHER-PROG")
+    fresh_store._project_meta[p2]["program_id"] = other_program_id  # noqa: SLF001
     # Confirm: re-reads program_id from store, sees mismatch, 409s.
     resp = client.post(
         f"/api/v1/projects/{p2}/confirm-revision-of",

--- a/tests/test_revisions_router.py
+++ b/tests/test_revisions_router.py
@@ -168,6 +168,53 @@ def test_confirm_409_when_parent_in_different_program(
     assert "not in the same program" in resp.json()["detail"]
 
 
+def test_confirm_409_when_program_id_mutated_after_detect(
+    client: TestClient, fresh_store: InMemoryStore
+) -> None:
+    """Confirm-time program_id check still fires when program_id mutates
+    BETWEEN a detect call and a confirm call (issue #82, DA P3-15 from
+    PR #78).
+
+    Backend-reviewer entry-council on issue #82 (Cycle 5 W3-A): the detect
+    endpoint is stateless and confirm reads ``program_id`` fresh from the
+    store at submission time, so this case is structurally indistinguishable
+    from ``test_confirm_409_when_parent_in_different_program`` — the detect
+    call is a no-op for the assertion. This test is documented as a
+    REGRESSION PIN against any future refactor that introduces a
+    detect-cached ``program_id`` token confirm trusts. No production API
+    re-groups projects today; the mutation goes through ``_project_meta``
+    direct poke as the future-API stand-in.
+    """
+    p1 = fresh_store.save_project(
+        upload_id="u1",
+        schedule=_schedule("PROJ-A", datetime(2026, 1, 1, tzinfo=timezone.utc)),
+        user_id="user-w2-test",
+    )
+    p2 = fresh_store.save_project(
+        upload_id="u2",
+        schedule=_schedule("PROJ-A", datetime(2026, 2, 1, tzinfo=timezone.utc)),
+        user_id="user-w2-test",
+    )
+    token = _make_token()
+    # Detect: stateless read; returns candidate (or none). No state captured.
+    client.post(
+        f"/api/v1/projects/{p2}/detect-revision-of",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    # Mutate: simulate a future support-ticket re-grouping API moving p2 to a
+    # different program. No production call site exists today; this poke is
+    # the future-API stand-in.
+    fresh_store._project_meta[p2]["program_id"] = "different-program"  # noqa: SLF001
+    # Confirm: re-reads program_id from store, sees mismatch, 409s.
+    resp = client.post(
+        f"/api/v1/projects/{p2}/confirm-revision-of",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"parent_project_id": p1},
+    )
+    assert resp.status_code == 409
+    assert "not in the same program" in resp.json()["detail"]
+
+
 def test_confirm_writes_revision_history_row(
     client: TestClient, fresh_store: InMemoryStore
 ) -> None:


### PR DESCRIPTION
## Summary

Cycle 5 W3-A. Closes #82 (DA P3-15 from PR #78).

Backend-reviewer entry-council on #82 recommended close-as-`not_planned` OR 5-LoC parametrize variant. User chose variant. **Initial docstring claim was wrong** — DA exit-council on `600fd1b` found the test setup defied the docstring's framing. Fixed in `1019590`.

## What this test actually does (post-DA fix)

- Both projects start in the SAME auto-grouped program (`get_or_create_program` keys on user_id + proj_short_name; both `PROJ-A` lands them together)
- Detect call is stateless; returns candidate suggestion, captures no state
- Mutation poke: `_project_meta[p2]["program_id"]` set to a real schema-shaped `prog-NNNN` (created via `get_or_create_program(user_id, "OTHER-PROG")`)
- Confirm re-reads `program_id` from store → sees mismatch → 409s

**Without the mutation, confirm would 200.** The mutation is the load-bearing step.

## What this pins

- `confirm-revision-of` reads `program_id` from the live store at submission time (via `get_project_meta`), not from a value cached at detect time
- A future refactor introducing detect-cached state must either preserve this contract OR explicitly opt out

## What this does NOT pin

- No production API re-groups projects today; the store-level mutation is artificial
- A real future re-grouping API would touch `_upload_program` + `_programs` too (per DA P1 #2 finding)

## DA exit-council fix-ups (commit `1019590`)

- **P1 #1** Rewrote docstring honestly. Removed "structurally indistinguishable" + "regression pin against future detect-cached refactor" framing — both were wrong about what the test does.
- **P1 #2** Removed "future-API stand-in" claim. Replaced with explicit "what this pins / what this does NOT pin" sections.
- **P2 #4** Replaced literal `"different-program"` with schema-shaped `prog-NNNN` via `get_or_create_program(user_id, "OTHER-PROG")` — copy-paste-into-Supabase-integration-test safe.

P2 #3 (`# noqa: SLF001` brittle to ruff config tighten) and P3 #5/#6 (test cost vs. value, fresh_store omits revision_history reset) explicitly accepted as ongoing-hygiene; not addressed in this PR.

## Test plan

- [x] `python -m pytest tests/test_revisions_router.py::test_confirm_409_when_program_id_mutated_after_detect tests/test_revisions_router.py::test_confirm_409_when_parent_in_different_program -v` — both pass
- [x] `ruff check tests/test_revisions_router.py` — clean
- [x] mypy: no new errors
- [x] DA exit-council on `600fd1b` — completed (3 P1 + 2 P2/P3 findings; P1s addressed inline)

## Closes

- #82 — race condition test for detect-confirm with program_id mutation

## Cross-refs

- Backend-reviewer entry-council on issue #82 (recommended close-as-`not_planned`; user chose variant)
- DA exit-council on PR #113 commit `600fd1b` (found docstring sycophantic; P1s fixed)
- ADR-0018 Amendment 1 (DA-as-second-reviewer protocol)