### PR TITLE
feat(cycle5-w3b): #87 — Vitest + @testing-library/svelte v5 component test harness

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -21,6 +21,8 @@
         "@sveltejs/kit": "^2.59.1",
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
         "@tailwindcss/vite": "^4.3.0",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/svelte": "^5.3.1",
         "@types/node": "^25.6.2",
         "jsdom": "^29.1.1",
         "svelte": "^5.55.5",
@@ -81,6 +83,41 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@bramus/specificity": {
       "version": "2.4.2",
@@ -3227,6 +3264,76 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/svelte": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/svelte/-/svelte-5.3.1.tgz",
+      "integrity": "sha512-8Ez7ZOqW5geRf9PF5rkuopODe5RGy3I9XR+kc7zHh26gBiktLaxTfKmhlGaSHYUOTQE7wFsLMN9xCJVCszw47w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@testing-library/dom": "9.x.x || 10.x.x",
+        "@testing-library/svelte-core": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "peerDependencies": {
+        "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0",
+        "vite": "*",
+        "vitest": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/svelte-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/svelte-core/-/svelte-core-1.0.0.tgz",
+      "integrity": "sha512-VkUePoLV6oOYwSUvX6ShA8KLnJqZiYMIbP2JW2t0GLWLkJxKGvuH5qrrZBV/X7cXFnLGuFQEC7RheYiZOW68KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -3237,6 +3344,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3429,6 +3543,29 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/aria-query": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
@@ -3592,6 +3729,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3606,6 +3753,13 @@
       "version": "5.8.0",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.0.tgz",
       "integrity": "sha512-2zA9pFEsnp7vWBZbXF5JAgAq0fsUIt/1XPbRiAmRV3lp/2C3upzH+sADiyy66aFCihoLEsrQHxNM5w1gIDfsBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3898,6 +4052,13 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jsdom": {
       "version": "29.1.1",
@@ -4246,6 +4407,16 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -4493,6 +4664,21 @@
         "url": "https://opencollective.com/preact"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "7.5.7",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.7.tgz",
@@ -4531,6 +4717,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
       "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/readdirp": {

--- a/web/package.json
+++ b/web/package.json
@@ -24,6 +24,8 @@
     "@sveltejs/kit": "^2.59.1",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@tailwindcss/vite": "^4.3.0",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/svelte": "^5.3.1",
     "@types/node": "^25.6.2",
     "jsdom": "^29.1.1",
     "svelte": "^5.55.5",

--- a/web/src/lib/components/RevisionConfirmCard.test.ts
+++ b/web/src/lib/components/RevisionConfirmCard.test.ts
@@ -1,0 +1,132 @@
+// MIT License
+// Copyright (c) 2026 Vitor Maia Rodovalho
+
+// Inaugural Vitest + @testing-library/svelte v5 component test for
+// MeridianIQ. Cycle 5 W3-B per ADR-0024 — issue #87 closure.
+//
+// ## Scope cap (frontend-ux-reviewer entry-council on #87)
+//
+// Exactly 3 tests on RevisionConfirmCard:
+//   1. happy path — detect returns a candidate, card renders with name
+//   2. **race regression** — rapid re-mount with new projectId; the
+//      stale resolution from the prior detect must NOT overwrite state
+//      (DA exit-council fix-up #P1-1 from PR #83 — `detectGen` counter)
+//   3. no-candidate — detect returns null, no card renders
+//
+// Other components, snapshot tests, lint integration, CI gating — all
+// explicitly out of scope for this PR.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/svelte';
+import RevisionConfirmCard from './RevisionConfirmCard.svelte';
+
+// Deferred resolvers so tests can drive the order in which two
+// concurrent detect calls complete (race regression).
+const detectResolvers: Array<(payload: unknown) => void> = [];
+const detectRejecters: Array<(err: Error) => void> = [];
+const detectCalls: string[] = [];
+
+vi.mock('$lib/api', () => ({
+	detectRevisionOf: vi.fn((projectId: string) => {
+		detectCalls.push(projectId);
+		return new Promise((resolve, reject) => {
+			detectResolvers.push(resolve);
+			detectRejecters.push(reject);
+		});
+	}),
+	confirmRevisionOf: vi.fn(),
+}));
+
+vi.mock('$lib/analytics', () => ({
+	trackEvent: vi.fn(),
+}));
+
+vi.mock('$lib/toast', () => ({
+	error: vi.fn(),
+	success: vi.fn(),
+}));
+
+beforeEach(() => {
+	detectResolvers.length = 0;
+	detectRejecters.length = 0;
+	detectCalls.length = 0;
+});
+
+afterEach(() => {
+	cleanup();
+});
+
+function happyPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		candidate_project_id: 'parent-1',
+		candidate_project_name: 'Project Alpha',
+		candidate_data_date: '2026-04-01T00:00:00Z',
+		candidate_revision_count: 2,
+		confidence: 0.9,
+		methodology: 'name+program',
+		...overrides,
+	};
+}
+
+describe('RevisionConfirmCard', () => {
+	it('renders the candidate name when detect succeeds (happy path)', async () => {
+		const { findByRole, queryByRole } = render(RevisionConfirmCard, {
+			props: { projectId: 'p-new' },
+		});
+		// Pre-resolve: card has not rendered yet (loading state shows the
+		// checking hint instead).
+		expect(queryByRole('region')).toBeNull();
+
+		// Resolve with a candidate payload.
+		detectResolvers[0]!(happyPayload());
+
+		// findByRole awaits the next render tick after $effect commits state.
+		const region = await findByRole('region');
+		expect(region.textContent).toContain('Project Alpha');
+	});
+
+	it('does NOT overwrite state when a stale detect resolves after a newer one (race regression)', async () => {
+		// Mount with projectId p-old — kicks off detect call #0.
+		const { rerender, findByRole } = render(RevisionConfirmCard, {
+			props: { projectId: 'p-old' },
+		});
+		expect(detectCalls).toEqual(['p-old']);
+
+		// Re-render with projectId p-new — kicks off detect call #1 via $effect.
+		await rerender({ projectId: 'p-new' });
+		expect(detectCalls).toEqual(['p-old', 'p-new']);
+
+		// Resolve the NEWER call first (the one that should win).
+		detectResolvers[1]!(happyPayload({ candidate_project_name: 'NEW Winner' }));
+		const region = await findByRole('region');
+		expect(region.textContent).toContain('NEW Winner');
+
+		// Now resolve the STALE call. The detectGen counter must reject this
+		// resolution (myGen !== detectGen) and leave the card showing
+		// "NEW Winner" — NOT "STALE Loser".
+		detectResolvers[0]!(happyPayload({ candidate_project_name: 'STALE Loser' }));
+
+		// Yield the microtask queue so the stale .then() runs.
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(region.textContent).toContain('NEW Winner');
+		expect(region.textContent).not.toContain('STALE Loser');
+	});
+
+	it('renders nothing when detect returns no candidate', async () => {
+		const { container, queryByRole } = render(RevisionConfirmCard, {
+			props: { projectId: 'p-orphan' },
+		});
+
+		detectResolvers[0]!(happyPayload({ candidate_project_id: null }));
+
+		// Wait for the loading hint to disappear — the only way to know the
+		// component finished its no-candidate transition. Then assert the
+		// terminal state: no region, no leftover status hint.
+		await waitFor(() => {
+			expect(container.querySelector('[role="status"]')).toBeNull();
+		});
+		expect(queryByRole('region')).toBeNull();
+	});
+});

--- a/web/src/lib/components/RevisionConfirmCard.test.ts
+++ b/web/src/lib/components/RevisionConfirmCard.test.ts
@@ -73,8 +73,14 @@ describe('RevisionConfirmCard', () => {
 		const { findByRole, queryByRole } = render(RevisionConfirmCard, {
 			props: { projectId: 'p-new' },
 		});
-		// Pre-resolve: card has not rendered yet (loading state shows the
-		// checking hint instead).
+		// DA exit-council PR #114 P1 #1+#3: pin BOTH the loading-hint
+		// presence (proves runDetect() actually fired) AND that the mock
+		// was hit (proves vi.mock alias resolution works). Without these,
+		// the queryByRole(region)===null assertion can pass for the
+		// wrong reason (e.g., $effect didn't fire OR the mock was no-op'd
+		// and the real detectRevisionOf is hanging on a network call).
+		expect(detectCalls).toEqual(['p-new']);
+		expect(queryByRole('status')).not.toBeNull();
 		expect(queryByRole('region')).toBeNull();
 
 		// Resolve with a candidate payload.
@@ -86,7 +92,13 @@ describe('RevisionConfirmCard', () => {
 	});
 
 	it('does NOT overwrite state when a stale detect resolves after a newer one (race regression)', async () => {
-		// Mount with projectId p-old — kicks off detect call #0.
+		// DA exit-council PR #114 P1 #2: this test pins ANY staleness-guard
+		// mechanism (e.g., the current ``detectGen`` counter at lines
+		// 87-117 of RevisionConfirmCard.svelte, OR a hypothetical
+		// ``capturedProjectId`` closure check). It does NOT introspect
+		// ``detectGen`` directly. A future refactor could replace the
+		// counter with an equivalent guard and still pass this test —
+		// that's by design (test pins behavior, not implementation).
 		const { rerender, findByRole } = render(RevisionConfirmCard, {
 			props: { projectId: 'p-old' },
 		});
@@ -101,23 +113,29 @@ describe('RevisionConfirmCard', () => {
 		const region = await findByRole('region');
 		expect(region.textContent).toContain('NEW Winner');
 
-		// Now resolve the STALE call. The detectGen counter must reject this
-		// resolution (myGen !== detectGen) and leave the card showing
-		// "NEW Winner" — NOT "STALE Loser".
+		// Now resolve the STALE call. The staleness guard must reject this
+		// resolution and leave the card showing "NEW Winner" — NOT
+		// "STALE Loser". Use waitFor instead of magic Promise.resolve()
+		// counts (DA P3 #9) — the assertion still holds for several ticks.
 		detectResolvers[0]!(happyPayload({ candidate_project_name: 'STALE Loser' }));
-
-		// Yield the microtask queue so the stale .then() runs.
-		await Promise.resolve();
-		await Promise.resolve();
-
-		expect(region.textContent).toContain('NEW Winner');
-		expect(region.textContent).not.toContain('STALE Loser');
+		await waitFor(() => {
+			expect(region.textContent).toContain('NEW Winner');
+			expect(region.textContent).not.toContain('STALE Loser');
+		});
 	});
 
 	it('renders nothing when detect returns no candidate', async () => {
 		const { container, queryByRole } = render(RevisionConfirmCard, {
 			props: { projectId: 'p-orphan' },
 		});
+		// DA exit-council PR #114 P2 #4: pin the loading→no-candidate
+		// TRANSITION (was visible, then disappeared) rather than just the
+		// terminal absence. Without this, waitFor(absence) could resolve
+		// immediately if the loading hint never rendered (e.g., $effect
+		// didn't fire). Pre-resolve assertion forces "loading hint WAS
+		// here" before we test "and now it's not".
+		expect(detectCalls).toEqual(['p-orphan']);
+		expect(container.querySelector('[role="status"]')).not.toBeNull();
 
 		detectResolvers[0]!(happyPayload({ candidate_project_id: null }));
 

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -2,13 +2,17 @@
 // Copyright (c) 2026 Vitor Maia Rodovalho
 
 // Vitest config separate from vite.config.ts so SvelteKit's dev plugin
-// does not participate in test resolution. Tests target plain .ts
-// composables — component tests are out of scope for this setup and
-// would require vitest-browser-svelte.
+// does not participate in test resolution. Covers (a) plain .ts
+// composables (e.g. ``useWebSocketProgress.test.ts``) and (b) Svelte 5
+// rune-based components via ``@testing-library/svelte`` v5 + jsdom
+// (Cycle 5 W3-B per ADR-0024 — issue #87 closure).
 
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+	plugins: [svelte()],
 	test: {
 		environment: 'jsdom',
 		include: ['src/**/*.test.ts'],
@@ -19,5 +23,11 @@ export default defineConfig({
 		// resolve to the client build rather than an SSR variant that
 		// does not carry the subscribe semantics we rely on.
 		conditions: ['browser'],
+		alias: {
+			// SvelteKit's $lib alias — provided by adapter at build time;
+			// vitest needs it explicitly. Pointing at src/lib means tests
+			// resolve $lib/api, $lib/i18n, etc. the same way the app does.
+			$lib: fileURLToPath(new URL('./src/lib', import.meta.url)),
+		},
 	},
 });


### PR DESCRIPTION
## Summary

Cycle 5 W3-B. Closes #87 (DA assumption from PR #83 — no Vitest tests for RevisionConfirmCard despite non-trivial mount/unmount state).

## Spike result

Frontend-ux-reviewer entry-council mandated a 30-min spike to pick between:
- **`vitest-browser-svelte`** (browser + Playwright, slower, full rune support)
- **`@testing-library/svelte` v5** (jsdom, faster, partial rune support per known status)

Spike result: `@testing-library/svelte@5.3.1` + Svelte 5.55.5 runes (`$state` / `$derived` / `$effect` / `$props`) compile and execute correctly under jsdom 29 + Vitest 4. Picked the simpler path; no Playwright dependency added.

## Hard scope cap (entry-council enforced)

**Ship:**
- 2 deps: `@testing-library/svelte ^5.3.1` + `@testing-library/dom ^10.4.1` (transitive of svelte lib but pinned for clarity)
- `vitest.config.ts`: `svelte()` plugin + `$lib` alias (SvelteKit-style module resolution under tests)
- `src/lib/components/RevisionConfirmCard.test.ts`: EXACTLY 3 tests

**Explicitly NOT shipped:**
- Tests for other components (LifecyclePhaseCard, ScheduleViewer, etc.)
- Snapshot tests (high noise / low signal)
- Lint integration / CI gating (defer; harness exists, follow-up issue can promote to required check)
- Mocking infrastructure beyond `vi.mock` + closure pattern

## The 3 tests

1. **`renders the candidate name when detect succeeds (happy path)`** — detect resolves with a candidate payload; assert the rendered region contains the candidate name.
2. **`does NOT overwrite state when a stale detect resolves after a newer one (race regression)`** — the inaugural test per entry-council. Mount with `projectId=p-old` → re-render with `projectId=p-new` → resolve NEWER call FIRST → resolve STALE call SECOND. Pins the `detectGen` counter from `RevisionConfirmCard.svelte:87-117` (DA exit-council fix-up #P1-1 from PR #83).
3. **`renders nothing when detect returns no candidate`** — detect resolves with `candidate_project_id: null`; assert no region + no leftover loading hint via `waitFor` on `[role="status"]` disappearance.

## Test patterns established (paved path for future component tests)

- Deferred resolvers (`detectResolvers: Array<(p: unknown) => void>`) so tests drive the order of two concurrent promises — race testing without timing flakiness.
- `cleanup()` from `@testing-library/svelte` in `afterEach` so each test gets a fresh DOM tree.
- `waitFor` for absence assertions (Svelte 5 effect-flush timing makes fixed `Promise.resolve()` counts brittle).
- Real `$lib/i18n` module — no mock; English defaults stable for `textContent` assertions.

## Test plan

- [x] `npx vitest run src/lib/components/RevisionConfirmCard.test.ts` — 3/3 pass
- [x] `npx vitest run` — 42/42 pass (no regression on existing 39 composable tests)
- [x] `npm run check` — 0 errors / 0 warnings (671 files)
- [x] `npm run build` — clean (3.03s)
- [x] CI green required before merge
- [x] Frontend-ux-reviewer entry-council on this PR per `feedback_entry_council_discipline.md` — completed pre-impl
- [ ] DA exit-council on this PR per ADR-0018 Am.1 — runs at PR review

## Closes

- #87 — ops Vitest component test harness for Svelte 5 components

## Cross-refs

- ADR-0024 (Cycle 5 entry — W3 batch shape)
- ADR-0018 Am.1 (DA-as-second-reviewer)
- PR #83 (where DA originally flagged this gap)