### PR TITLE
feat(cycle5-w3c): #85 — formatDate locale-aware helper + RevisionConfirmCard wire

### DIFF
--- a/web/src/lib/components/RevisionConfirmCard.svelte
+++ b/web/src/lib/components/RevisionConfirmCard.svelte
@@ -38,7 +38,8 @@
 
 	import { confirmRevisionOf, detectRevisionOf } from '$lib/api';
 	import { trackEvent } from '$lib/analytics';
-	import { t } from '$lib/i18n';
+	import { locale, t } from '$lib/i18n';
+	import { formatDate } from '$lib/i18n/format';
 	import { error as toastError, success } from '$lib/toast';
 
 	interface Props {
@@ -191,11 +192,13 @@
 		onSkipped?.();
 	}
 
-	function formatDate(iso: string | null): string {
-		if (!iso) return '—';
-		// Show only the date part (YYYY-MM-DD) — time-of-day is noise here.
-		return iso.slice(0, 10);
-	}
+	// Issue #85 (DA P3-2 from PR #83): legacy ``iso.slice(0, 10)`` returned
+	// raw YYYY-MM-DD. Replaced with ``formatDate(iso, $locale)`` from
+	// ``$lib/i18n/format`` — locale-aware (Apr 15, 2026 / 15 abr. 2026 /
+	// 15 abr 2026 across en/pt-BR/es) with ``timeZone: 'UTC'`` enforced
+	// for P6 data_date TZ-naive semantics. Called markup-side via
+	// ``formatDate(candidateDataDate, $locale)`` so $locale reactivity
+	// re-renders on locale switch.
 </script>
 
 {#if detectState === 'loading'}
@@ -249,7 +252,7 @@
 				>
 					{interpolate($t('revision.confirm_card_body'), {
 						name: candidateProjectName ?? '—',
-						date: formatDate(candidateDataDate),
+						date: formatDate(candidateDataDate, $locale),
 						count: String(candidateRevisionCount)
 					})}
 				</p>

--- a/web/src/lib/i18n/format.test.ts
+++ b/web/src/lib/i18n/format.test.ts
@@ -1,11 +1,12 @@
 // MIT License
 // Copyright (c) 2026 Vitor Maia Rodovalho
 //
-// Vitest unit tests for `formatNumber` helper — Cycle 5 W2 batch 2-A.
-// Issue #96 part 1 (DA P2 #8 from PR #95).
+// Vitest unit tests for `formatNumber` helper — Cycle 5 W2 batch 2-A
+// (issue #96 part 1 / DA P2 #8 from PR #95) — and `formatDate` helper
+// — Cycle 5 W3-C (issue #85 / DA P3-2 from PR #83).
 
 import { describe, expect, it } from 'vitest';
-import { formatNumber } from './format';
+import { formatDate, formatNumber } from './format';
 
 describe('formatNumber', () => {
 	describe('locale-specific decimal separators', () => {
@@ -87,6 +88,93 @@ describe('formatNumber', () => {
 			// to force the catch branch.
 			const result = formatNumber(2.5, '??invalid?', { maximumFractionDigits: 1 });
 			expect(result).toMatch(/2[.,]5/);
+		});
+	});
+});
+
+describe('formatDate', () => {
+	const ISO_2026_04_15 = '2026-04-15T00:00:00Z';
+
+	describe('locale-specific date conventions', () => {
+		it('en formats month-name short + numeric day + numeric year', () => {
+			// "Apr 15, 2026" with non-breaking space conventions.
+			const result = formatDate(ISO_2026_04_15, 'en');
+			expect(result).toMatch(/Apr/);
+			expect(result).toContain('15');
+			expect(result).toContain('2026');
+		});
+
+		it('pt-BR formats with day-month-year ordering + Portuguese month abbrev', () => {
+			// "15 de abr. de 2026" or similar; assert components rather than
+			// exact form because Intl behavior varies by ICU version.
+			const result = formatDate(ISO_2026_04_15, 'pt-BR');
+			expect(result).toMatch(/abr/i);
+			expect(result).toContain('15');
+			expect(result).toContain('2026');
+		});
+
+		it('es formats with day-month-year ordering + Spanish month abbrev', () => {
+			const result = formatDate(ISO_2026_04_15, 'es');
+			expect(result).toMatch(/abr/i);
+			expect(result).toContain('15');
+			expect(result).toContain('2026');
+		});
+	});
+
+	describe('timezone discipline (data_date is TZ-naive per P6 domain)', () => {
+		it('UTC midnight ISO renders as the same calendar day across runner TZs', () => {
+			// Without timeZone: 'UTC', this would shift to "Apr 14" in
+			// western-hemisphere runner TZs. The forced UTC clamps to the
+			// calendar day the ISO timestamp represents.
+			const result = formatDate('2026-04-15T00:00:00Z', 'en');
+			expect(result).toContain('15');
+			expect(result).not.toContain('14');
+		});
+
+		it('explicit positive offset still parses to the UTC calendar day', () => {
+			// 2026-04-15T01:00:00+01:00 == 2026-04-15T00:00:00Z → "Apr 15".
+			const result = formatDate('2026-04-15T01:00:00+01:00', 'en');
+			expect(result).toContain('15');
+		});
+	});
+
+	describe('null / invalid input safety', () => {
+		it('null returns em-dash', () => {
+			expect(formatDate(null, 'en')).toBe('—');
+		});
+
+		it('undefined returns em-dash', () => {
+			expect(formatDate(undefined, 'en')).toBe('—');
+		});
+
+		it('empty string returns em-dash', () => {
+			expect(formatDate('', 'en')).toBe('—');
+		});
+
+		it('unparseable string returns em-dash', () => {
+			expect(formatDate('not-a-date', 'en')).toBe('—');
+			expect(formatDate('garbage', 'pt-BR')).toBe('—');
+		});
+	});
+
+	describe('options override', () => {
+		it('numeric/numeric/numeric format respects override', () => {
+			const result = formatDate(ISO_2026_04_15, 'en', {
+				year: 'numeric',
+				month: '2-digit',
+				day: '2-digit',
+			});
+			expect(result).toContain('04');
+			expect(result).toContain('15');
+			expect(result).toContain('2026');
+		});
+	});
+
+	describe('fallback path (invalid locale)', () => {
+		it('unknown locale string falls back to YYYY-MM-DD slice', () => {
+			// Force the catch branch with a syntactically-invalid locale tag.
+			const result = formatDate(ISO_2026_04_15, '??invalid?');
+			expect(result).toBe('2026-04-15');
 		});
 	});
 });

--- a/web/src/lib/i18n/format.test.ts
+++ b/web/src/lib/i18n/format.test.ts
@@ -176,5 +176,53 @@ describe('formatDate', () => {
 			const result = formatDate(ISO_2026_04_15, '??invalid?');
 			expect(result).toBe('2026-04-15');
 		});
+
+		it('fallback returns the UTC calendar day for offset-bearing ISOs', () => {
+			// DA exit-council PR #115 P1 #1: the previous
+			// `iso.slice(0, 10)` fallback day-shifted for offset-bearing
+			// inputs. For 2026-04-15T22:00:00-04:00 the UTC instant is
+			// 2026-04-16T02:00:00Z so the UTC calendar day is the 16th —
+			// NOT the 15th from the original-string slice.
+			const result = formatDate('2026-04-15T22:00:00-04:00', '??invalid?');
+			expect(result).toBe('2026-04-16');
+		});
+	});
+
+	describe('ICU-stable numeric ground truth', () => {
+		// DA exit-council PR #115 P2 #5: locale tests above use month: 'short'
+		// (forgiving regex on "Apr"/"abr" etc.) which masks ICU drift. These
+		// numeric-format tests are ground truth — pin month: '2-digit' so an
+		// ICU update changing month-abbrev strings would fail the OTHER tests
+		// noisily while these still anchor the locale-routing contract.
+
+		it('en numeric format', () => {
+			const result = formatDate(ISO_2026_04_15, 'en', {
+				year: 'numeric',
+				month: '2-digit',
+				day: '2-digit',
+			});
+			// en-US convention is MM/DD/YYYY (with locale-specific separators).
+			expect(result).toMatch(/04[/.-]15[/.-]2026/);
+		});
+
+		it('pt-BR numeric format', () => {
+			const result = formatDate(ISO_2026_04_15, 'pt-BR', {
+				year: 'numeric',
+				month: '2-digit',
+				day: '2-digit',
+			});
+			// pt-BR convention is DD/MM/YYYY.
+			expect(result).toMatch(/15[/.-]04[/.-]2026/);
+		});
+
+		it('es numeric format', () => {
+			const result = formatDate(ISO_2026_04_15, 'es', {
+				year: 'numeric',
+				month: '2-digit',
+				day: '2-digit',
+			});
+			// es convention is DD/MM/YYYY.
+			expect(result).toMatch(/15[/.-]04[/.-]2026/);
+		});
 	});
 });

--- a/web/src/lib/i18n/format.ts
+++ b/web/src/lib/i18n/format.ts
@@ -1,7 +1,8 @@
 // MIT License
 // Copyright (c) 2026 Vitor Maia Rodovalho
 //
-// Locale-aware number formatting helpers — Cycle 5 W2 batch 2-A.
+// Locale-aware formatting helpers — Cycle 5 W2 batch 2-A (numbers) +
+// W3-C (dates).
 //
 // Usage MUST be markup-side (inside `{}` expression in template), NOT
 // script-side: the function does not subscribe to the `locale` store; the
@@ -11,6 +12,14 @@
 // Issue #96 part 1 (DA P2 #8 from PR #95): `.toFixed(1)` always emits
 // decimal POINT. pt-BR/es users expect decimal COMMA (`1,5` not `1.5`).
 // `Intl.NumberFormat` honors locale conventions automatically.
+//
+// Issue #85 (DA P3-2 from PR #83): `iso.slice(0, 10)` returns
+// `YYYY-MM-DD`. Acceptable for v1 unambiguous display, but operators
+// across en/pt-BR/es prefer locale-formatted dates. `Intl.DateTimeFormat`
+// honors locale conventions; data_date semantics are P6-domain
+// timezone-NAIVE so we force `timeZone: 'UTC'` to avoid the slice's
+// implicit-UTC-cut becoming day-shifted in local TZs (frontend-ux-reviewer
+// entry-council BLOCKING #5 on PR #115).
 
 import type { Locale } from './index';
 
@@ -36,5 +45,50 @@ export function formatNumber(
 	} catch {
 		// Fallback if Intl rejects the locale string for any reason.
 		return value.toFixed(options.maximumFractionDigits ?? 1);
+	}
+}
+
+/**
+ * Format an ISO-8601 datetime string per the active locale's date
+ * conventions. The output drops the time-of-day; data_date semantics
+ * are calendar-day-only.
+ *
+ * **Timezone discipline**: data_date in P6 is timezone-naive by domain
+ * convention. We force `timeZone: 'UTC'` so an ISO string ending in
+ * `Z` (or any explicit offset) is interpreted as the calendar day at
+ * UTC, NOT shifted to the viewer's local TZ. Without this, a viewer
+ * in UTC-3 looking at `2026-04-15T00:00:00Z` would see "Apr 14" — the
+ * exact bug the legacy `iso.slice(0, 10)` shortcut also avoided.
+ *
+ * Defensive:
+ * - `null` / `undefined` / `''` → `'—'`
+ * - Unparseable strings → `'—'`
+ * - Intl rejection → fallback to the legacy `iso.slice(0, 10)` shape
+ *
+ * @param iso - ISO-8601 datetime string (`'2026-04-15T00:00:00Z'`)
+ *   or `null` / `undefined`
+ * @param locale - the active locale (`'en'` | `'pt-BR'` | `'es'`)
+ * @param options - `Intl.DateTimeFormatOptions` overrides (default
+ *   `{ year: 'numeric', month: 'short', day: 'numeric' }`)
+ */
+export function formatDate(
+	iso: string | null | undefined,
+	locale: Locale | string = 'en',
+	options: Intl.DateTimeFormatOptions = {
+		year: 'numeric',
+		month: 'short',
+		day: 'numeric',
+	},
+): string {
+	if (!iso) return '—';
+	const parsed = new Date(iso);
+	if (Number.isNaN(parsed.getTime())) return '—';
+	try {
+		return new Intl.DateTimeFormat(locale, { ...options, timeZone: 'UTC' }).format(parsed);
+	} catch {
+		// Fallback if Intl rejects the locale string for any reason —
+		// preserves the legacy `YYYY-MM-DD` shape so consumers don't
+		// suddenly get an empty string in failure modes.
+		return iso.slice(0, 10);
 	}
 }

--- a/web/src/lib/i18n/format.ts
+++ b/web/src/lib/i18n/format.ts
@@ -53,28 +53,37 @@ export function formatNumber(
  * conventions. The output drops the time-of-day; data_date semantics
  * are calendar-day-only.
  *
- * **Timezone discipline**: data_date in P6 is timezone-naive by domain
- * convention. We force `timeZone: 'UTC'` so an ISO string ending in
- * `Z` (or any explicit offset) is interpreted as the calendar day at
- * UTC, NOT shifted to the viewer's local TZ. Without this, a viewer
- * in UTC-3 looking at `2026-04-15T00:00:00Z` would see "Apr 14" — the
- * exact bug the legacy `iso.slice(0, 10)` shortcut also avoided.
+ * **Timezone discipline (NOT overridable)**: data_date in P6 is
+ * timezone-naive by domain convention. The helper forces
+ * `timeZone: 'UTC'` so an ISO string ending in `Z` (or any explicit
+ * offset) is interpreted as the calendar day at UTC, NOT shifted to the
+ * viewer's local TZ. Without this, a viewer in UTC-3 looking at
+ * `2026-04-15T00:00:00Z` would see "Apr 14".
+ *
+ * The `options` parameter type uses `Omit<..., 'timeZone'>` so the
+ * compiler rejects any caller attempt to pass `timeZone` (DA exit-council
+ * PR #115 P1 #2: silent spread-order override would have lied). Future
+ * non-UTC use cases (e.g., contract-local TZ rendering) need a separate
+ * helper, NOT a `timeZone` option here.
  *
  * Defensive:
  * - `null` / `undefined` / `''` → `'—'`
  * - Unparseable strings → `'—'`
- * - Intl rejection → fallback to the legacy `iso.slice(0, 10)` shape
+ * - Intl rejection → fallback to UTC-canonical `YYYY-MM-DD` via
+ *   `parsed.toISOString().slice(0, 10)` (NOT `iso.slice(0, 10)` —
+ *   DA P1 #1: offset-bearing ISOs day-shift on the original-string slice)
  *
  * @param iso - ISO-8601 datetime string (`'2026-04-15T00:00:00Z'`)
  *   or `null` / `undefined`
  * @param locale - the active locale (`'en'` | `'pt-BR'` | `'es'`)
- * @param options - `Intl.DateTimeFormatOptions` overrides (default
- *   `{ year: 'numeric', month: 'short', day: 'numeric' }`)
+ * @param options - `Intl.DateTimeFormatOptions` overrides MINUS the
+ *   `timeZone` field (the helper enforces UTC). Default
+ *   `{ year: 'numeric', month: 'short', day: 'numeric' }`.
  */
 export function formatDate(
 	iso: string | null | undefined,
 	locale: Locale | string = 'en',
-	options: Intl.DateTimeFormatOptions = {
+	options: Omit<Intl.DateTimeFormatOptions, 'timeZone'> = {
 		year: 'numeric',
 		month: 'short',
 		day: 'numeric',
@@ -87,8 +96,13 @@ export function formatDate(
 		return new Intl.DateTimeFormat(locale, { ...options, timeZone: 'UTC' }).format(parsed);
 	} catch {
 		// Fallback if Intl rejects the locale string for any reason —
-		// preserves the legacy `YYYY-MM-DD` shape so consumers don't
-		// suddenly get an empty string in failure modes.
-		return iso.slice(0, 10);
+		// emit the UTC-canonical YYYY-MM-DD via toISOString. DA exit-
+		// council PR #115 P1 #1: the previous `iso.slice(0, 10)` was
+		// day-shifted for offset-bearing inputs (e.g.,
+		// 2026-04-15T22:00:00-04:00 sliced to '2026-04-15' but the UTC
+		// day is 2026-04-16 — same instant, different day). Using
+		// `parsed.toISOString().slice(0, 10)` returns the UTC day
+		// regardless of input offset.
+		return parsed.toISOString().slice(0, 10);
 	}
 }


### PR DESCRIPTION
## Summary

Cycle 5 W3-C. Closes #85 (DA P3-2 from PR #83 — `formatDate` returned raw `YYYY-MM-DD`; operators across en/pt-BR/es prefer locale-formatted dates).

## Changes

- `$lib/i18n/format.ts` — new `formatDate(iso, locale, options)` helper. Ported from the `formatNumber` precedent (Cycle 5 W2 batch 2-A / PR #109). Default options: `{year: 'numeric', month: 'short', day: 'numeric'}`.
- `RevisionConfirmCard.svelte` — replaced inline `formatDate(iso)` (which returned `iso.slice(0, 10)`) with `formatDate(candidateDataDate, $locale)` called markup-side so `$locale` reactivity re-renders on locale switch.

## Timezone discipline (entry-council BLOCKING)

Frontend-ux-reviewer entry-council BLOCKING #5 on the W3 batch: P6 `data_date` is TZ-NAIVE by domain convention. `Intl.DateTimeFormat` defaults to viewer-local TZ — a UTC midnight ISO `2026-04-15T00:00:00Z` viewed in UTC-3 would render as "Apr 14". The legacy `iso.slice(0, 10)` shortcut also avoided this (cut the string before TZ math could shift the day). The new helper forces `timeZone: 'UTC'` to preserve calendar-day semantics. Pinned by 2 dedicated tests (`UTC midnight ISO` + `explicit positive offset`).

## Defensive contract

- `null` / `undefined` / `''` → `'—'` (legacy behavior preserved)
- Unparseable strings → `'—'` (**NEW** — legacy returned the garbage slice)
- Intl rejection on invalid locale → fallback to `iso.slice(0, 10)` shape (preserves legacy YYYY-MM-DD output as graceful degradation)

## Output samples (Apr 15, 2026)

- `en` → "Apr 15, 2026"
- `pt-BR` → "15 de abr. de 2026" (or similar; Intl exact form varies by ICU)
- `es` → "15 abr 2026"

## Scope discipline

Other pages (`org/[id]`, `programs/[id]`, `forensic/`, `forensic/[id]`) each have their own local `formatDate` doing different things. **NOT refactoring those** in this PR — #85 is specifically about the revision confirmation card. Out-of-scope migrations track as a future hygiene issue.

## Test plan

- [x] `npx vitest run src/lib/i18n/format.test.ts` — 24/24 pass (12 existing formatNumber + 12 new formatDate)
- [x] `npx vitest run` — 53/53 pass (no regression on other suites)
- [x] `npm run check` — 0 errors / 0 warnings (671 files)
- [x] `npm run build` — clean
- [x] Frontend-ux-reviewer entry-council completed pre-impl as part of W3 batch entry-council
- [ ] DA exit-council per ADR-0018 Am.1 — runs at PR review time

## Closes

- #85 — feat: per-locale date formatting in revision confirmation card

## Cross-refs

- ADR-0024 (Cycle 5 entry — W3 batch shape)
- PR #109 (formatNumber precedent — markup-side reactivity rule)
- PR #83 (where DA flagged #85)