### PR TITLE
feat(cycle5-w3d): #86 — structured error_code on confirm 4xx + frontend differentiation

### DIFF
--- a/src/api/routers/revisions.py
+++ b/src/api/routers/revisions.py
@@ -30,7 +30,7 @@ insert is logged-on-failure but does not roll back the tombstone.
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -130,19 +130,35 @@ def confirm_revision_of_endpoint(
 
     current = store.get_project_meta(project_id, user_id=user_id)
     if current is None:
-        raise HTTPException(status_code=404, detail=f"project {project_id} not found")
+        # Structured error detail per ADR / issue #86 (DA P3-5 from PR #83).
+        # Frontend pattern-matches on `error_code` to auto-collapse on
+        # missing-project class errors vs keep-visible on other 4xx.
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "error_code": "current_not_found",
+                "message": f"project {project_id} not found",
+            },
+        )
     parent = store.get_project_meta(body.parent_project_id, user_id=user_id)
     if parent is None:
         raise HTTPException(
-            status_code=404, detail=f"parent project {body.parent_project_id} not found"
+            status_code=404,
+            detail={
+                "error_code": "parent_not_found",
+                "message": f"parent project {body.parent_project_id} not found",
+            },
         )
     if not current.get("program_id") or current.get("program_id") != parent.get("program_id"):
         raise HTTPException(
             status_code=409,
-            detail=(
-                "current and parent are not in the same program — auto-grouping at upload "
-                "should have placed them together; refresh and retry, or open a support ticket"
-            ),
+            detail={
+                "error_code": "cross_program",
+                "message": (
+                    "current and parent are not in the same program — auto-grouping at upload "
+                    "should have placed them together; refresh and retry, or open a support ticket"
+                ),
+            },
         )
 
     # Compute content_hash from the stored XER bytes. Server-side computation
@@ -157,7 +173,10 @@ def confirm_revision_of_endpoint(
     if not xer_bytes:
         raise HTTPException(
             status_code=409,
-            detail="cannot compute content_hash — XER bytes missing from storage",
+            detail={
+                "error_code": "no_xer_bytes",
+                "message": "cannot compute content_hash — XER bytes missing from storage",
+            },
         )
     content_hash = compute_xer_content_hash(xer_bytes)
     if body.content_hash and body.content_hash != content_hash:
@@ -183,10 +202,23 @@ def confirm_revision_of_endpoint(
             user_id=user_id,
         )
     except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=403,
+            detail={"error_code": "permission_denied", "message": str(exc)},
+        ) from exc
     except ValueError as exc:
         # Cap violation (12+ active rows) OR UNIQUE collision under concurrency.
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
+        # The two cases share a 409 status; the message text disambiguates.
+        # Cap-reached message starts with "revision cap reached" per the
+        # store helper convention.
+        message = str(exc)
+        code: Literal["cap_reached", "unique_collision"] = (
+            "cap_reached" if "cap" in message.lower() else "unique_collision"
+        )
+        raise HTTPException(
+            status_code=409,
+            detail={"error_code": code, "message": message},
+        ) from exc
 
     return ConfirmRevisionOfResponse(
         revision_id=str(row["id"]),

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -1929,6 +1929,36 @@ class DetectRevisionOfResponse(BaseModel):
     candidate_revision_count: int = 0
     confidence: float = 0.0
     reasoning: str = "no candidate found"
+
+
+class ConfirmRevisionOfErrorDetail(BaseModel):
+    """Structured 4xx detail body for POST confirm-revision-of (issue #86,
+    Cycle 5 W3-D).
+
+    Frontend pattern-matches on ``error_code`` to differentiate UX:
+    ``current_not_found`` / ``parent_not_found`` auto-collapse the card
+    (project moved or candidate stale); ``cross_program`` / ``cap_reached``
+    / ``no_xer_bytes`` / ``unique_collision`` keep the card visible with
+    the human-readable ``message``.
+
+    DA exit-council on the original W3 batch entry-council finding: NO
+    ``transient_lookup`` code shipped — Supabase's pooler uses single-PG
+    snapshot isolation per request, so eventual-consistency 404s are
+    theoretical. Adding a retry path for an unobserved failure mode would
+    be premature. If telemetry ever surfaces a transient class, bump
+    schema_version and add the code in a future amendment.
+    """
+
+    error_code: Literal[
+        "current_not_found",
+        "parent_not_found",
+        "cross_program",
+        "no_xer_bytes",
+        "cap_reached",
+        "unique_collision",
+        "permission_denied",
+    ]
+    message: str
 
 
 class ConfirmRevisionOfRequest(BaseModel):

--- a/tests/test_revisions_router.py
+++ b/tests/test_revisions_router.py
@@ -335,9 +335,7 @@ def test_confirm_409_on_cap_exceeded(client: TestClient, fresh_store: InMemorySt
     assert "cap" in detail["message"].lower()
 
 
-def test_confirm_409_on_no_xer_bytes(
-    client: TestClient, fresh_store: InMemoryStore
-) -> None:
+def test_confirm_409_on_no_xer_bytes(client: TestClient, fresh_store: InMemoryStore) -> None:
     """When the upload's XER bytes are missing from storage, confirm cannot
     compute content_hash and must 409 with structured error_code
     ``no_xer_bytes`` (DA exit-council PR #116 P1 #1: pin the code so a
@@ -400,8 +398,7 @@ def test_confirm_409_on_unique_collision(
         # Real Postgres UNIQUE-violation message style; importantly does
         # NOT contain "cap" — the dispatch site routes to unique_collision.
         raise ValueError(
-            "duplicate key value violates unique constraint "
-            "revision_history_unique_active"
+            "duplicate key value violates unique constraint revision_history_unique_active"
         )
 
     monkeypatch.setattr(fresh_store, "insert_revision_history", _raise_unique_collision)

--- a/tests/test_revisions_router.py
+++ b/tests/test_revisions_router.py
@@ -335,6 +335,124 @@ def test_confirm_409_on_cap_exceeded(client: TestClient, fresh_store: InMemorySt
     assert "cap" in detail["message"].lower()
 
 
+def test_confirm_409_on_no_xer_bytes(
+    client: TestClient, fresh_store: InMemoryStore
+) -> None:
+    """When the upload's XER bytes are missing from storage, confirm cannot
+    compute content_hash and must 409 with structured error_code
+    ``no_xer_bytes`` (DA exit-council PR #116 P1 #1: pin the code so a
+    typo at the dispatch site fails CI).
+    """
+    parent = fresh_store.save_project(
+        upload_id="u-parent",
+        schedule=_schedule("PROJ-A", datetime(2026, 1, 1, tzinfo=timezone.utc)),
+        xer_bytes=b"parent",
+        user_id="user-w2-test",
+    )
+    # Child with NO xer_bytes — save_project default is empty bytes.
+    child = fresh_store.save_project(
+        upload_id="u-child-no-bytes",
+        schedule=_schedule("PROJ-A", datetime(2026, 2, 1, tzinfo=timezone.utc)),
+        xer_bytes=b"",  # explicit empty
+        user_id="user-w2-test",
+    )
+    token = _make_token()
+    resp = client.post(
+        f"/api/v1/projects/{child}/confirm-revision-of",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"parent_project_id": parent},
+    )
+    assert resp.status_code == 409
+    detail = resp.json()["detail"]
+    assert detail["error_code"] == "no_xer_bytes"
+    assert "content_hash" in detail["message"]
+
+
+def test_confirm_409_on_unique_collision(
+    client: TestClient, fresh_store: InMemoryStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the store helper raises a non-cap ValueError (e.g., the UNIQUE
+    NULLS NOT DISTINCT collision under concurrent confirms), the router
+    must dispatch to error_code ``unique_collision`` (NOT
+    ``cap_reached``). Pin the LITERAL via monkeypatch so a typo at the
+    dispatch site (revisions.py:215-217 ``"cap_reached" if "cap" in
+    message.lower() else "unique_collision"``) fails CI (DA exit-council
+    PR #116 P1 #1).
+
+    Concurrent-confirm race is hard to simulate deterministically in a
+    TestClient single-thread test — monkeypatch is the cheapest path to
+    pin the dispatch literal.
+    """
+    parent = fresh_store.save_project(
+        upload_id="u-parent",
+        schedule=_schedule("PROJ-A", datetime(2026, 1, 1, tzinfo=timezone.utc)),
+        xer_bytes=b"parent",
+        user_id="user-w2-test",
+    )
+    child = fresh_store.save_project(
+        upload_id="u-c",
+        schedule=_schedule("PROJ-A", datetime(2026, 2, 1, tzinfo=timezone.utc)),
+        xer_bytes=b"child",
+        user_id="user-w2-test",
+    )
+
+    def _raise_unique_collision(**kwargs: object) -> dict[str, object]:
+        # Real Postgres UNIQUE-violation message style; importantly does
+        # NOT contain "cap" — the dispatch site routes to unique_collision.
+        raise ValueError(
+            "duplicate key value violates unique constraint "
+            "revision_history_unique_active"
+        )
+
+    monkeypatch.setattr(fresh_store, "insert_revision_history", _raise_unique_collision)
+    token = _make_token()
+    resp = client.post(
+        f"/api/v1/projects/{child}/confirm-revision-of",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"parent_project_id": parent},
+    )
+    assert resp.status_code == 409
+    detail = resp.json()["detail"]
+    assert detail["error_code"] == "unique_collision"
+    assert "duplicate key" in detail["message"]
+
+
+def test_confirm_403_on_permission_denied(
+    client: TestClient, fresh_store: InMemoryStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the store helper raises PermissionError, the router must
+    surface 403 with structured error_code ``permission_denied`` (DA
+    exit-council PR #116 P1 #1: pin the code at the dispatch site).
+    """
+    parent = fresh_store.save_project(
+        upload_id="u-parent",
+        schedule=_schedule("PROJ-A", datetime(2026, 1, 1, tzinfo=timezone.utc)),
+        xer_bytes=b"parent",
+        user_id="user-w2-test",
+    )
+    child = fresh_store.save_project(
+        upload_id="u-child",
+        schedule=_schedule("PROJ-A", datetime(2026, 2, 1, tzinfo=timezone.utc)),
+        xer_bytes=b"child",
+        user_id="user-w2-test",
+    )
+
+    def _raise_permission_error(**kwargs: object) -> dict[str, object]:
+        raise PermissionError("RLS rejected the insert for user user-w2-test")
+
+    monkeypatch.setattr(fresh_store, "insert_revision_history", _raise_permission_error)
+    token = _make_token()
+    resp = client.post(
+        f"/api/v1/projects/{child}/confirm-revision-of",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"parent_project_id": parent},
+    )
+    assert resp.status_code == 403
+    detail = resp.json()["detail"]
+    assert detail["error_code"] == "permission_denied"
+    assert "RLS" in detail["message"]
+
+
 # ────────────────────────────────────────────────────────────
 # tombstone
 # ────────────────────────────────────────────────────────────

--- a/tests/test_revisions_router.py
+++ b/tests/test_revisions_router.py
@@ -141,6 +141,33 @@ def test_confirm_404_when_current_missing(client: TestClient, fresh_store: InMem
         json={"parent_project_id": "also-nonexistent"},
     )
     assert resp.status_code == 404
+    detail = resp.json()["detail"]
+    assert detail["error_code"] == "current_not_found"
+    assert "nonexistent" in detail["message"]
+
+
+def test_confirm_404_when_parent_missing(client: TestClient, fresh_store: InMemoryStore) -> None:
+    """Issue #86: parent_not_found differentiated from current_not_found
+    via structured error_code. Frontend auto-collapses on either, but
+    distinguishing them lets the UI eventually surface different toast
+    text + telemetry distinguishes "user's project moved" from "candidate
+    stale".
+    """
+    p1 = fresh_store.save_project(
+        upload_id="u1",
+        schedule=_schedule("PROJ-A", datetime(2026, 1, 1, tzinfo=timezone.utc)),
+        user_id="user-w2-test",
+    )
+    token = _make_token()
+    resp = client.post(
+        f"/api/v1/projects/{p1}/confirm-revision-of",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"parent_project_id": "missing-parent-id"},
+    )
+    assert resp.status_code == 404
+    detail = resp.json()["detail"]
+    assert detail["error_code"] == "parent_not_found"
+    assert "missing-parent-id" in detail["message"]
 
 
 def test_confirm_409_when_parent_in_different_program(
@@ -165,7 +192,9 @@ def test_confirm_409_when_parent_in_different_program(
         json={"parent_project_id": p1},
     )
     assert resp.status_code == 409
-    assert "not in the same program" in resp.json()["detail"]
+    detail = resp.json()["detail"]
+    assert detail["error_code"] == "cross_program"
+    assert "not in the same program" in detail["message"]
 
 
 def test_confirm_409_when_program_id_mutated_after_detect(
@@ -225,7 +254,9 @@ def test_confirm_409_when_program_id_mutated_after_detect(
         json={"parent_project_id": p1},
     )
     assert resp.status_code == 409
-    assert "not in the same program" in resp.json()["detail"]
+    detail = resp.json()["detail"]
+    assert detail["error_code"] == "cross_program"
+    assert "not in the same program" in detail["message"]
 
 
 def test_confirm_writes_revision_history_row(
@@ -299,7 +330,9 @@ def test_confirm_409_on_cap_exceeded(client: TestClient, fresh_store: InMemorySt
         json={"parent_project_id": parent},
     )
     assert resp.status_code == 409
-    assert "cap" in resp.json()["detail"].lower()
+    detail = resp.json()["detail"]
+    assert detail["error_code"] == "cap_reached"
+    assert "cap" in detail["message"].lower()
 
 
 # ────────────────────────────────────────────────────────────

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -61,6 +61,27 @@ function isColdStartError(res: Response | null, err: unknown): boolean {
 	return false;
 }
 
+/**
+ * Error subclass surfacing structured 4xx error_code from backend
+ * responses (issue #86 — Cycle 5 W3-D). Endpoints that return a
+ * `{detail: {error_code, message}}` body produce an `ApiError` with
+ * `errorCode` populated. Endpoints returning legacy string-detail
+ * bodies produce an `ApiError` with `errorCode: null` and the message
+ * preserved as-is, so callers that only care about `.message` stay
+ * source-compatible.
+ */
+export class ApiError extends Error {
+	readonly status: number;
+	readonly errorCode: string | null;
+
+	constructor(message: string, status: number, errorCode: string | null) {
+		super(message);
+		this.name = 'ApiError';
+		this.status = status;
+		this.errorCode = errorCode;
+	}
+}
+
 async function request<T>(url: string, init?: RequestInit): Promise<T> {
 	// Get session directly from Supabase (reads localStorage, no store timing dependency)
 	const { data: { session: currentSession } } = await supabase.auth.getSession();
@@ -87,8 +108,29 @@ async function request<T>(url: string, init?: RequestInit): Promise<T> {
 				return res.json();
 			}
 			if (!isColdStartError(res, null) || attempt === MAX_RETRIES) {
+				// Issue #86: parse FastAPI's structured `{detail: {error_code, message}}`
+				// body when present so callers can branch on machine-readable
+				// codes rather than fragile text-pattern matching. Legacy
+				// string-detail responses degrade to errorCode=null.
+				const status = res.status;
 				const text = await res.text();
-				throw new Error(text || `Request failed: ${res.status}`);
+				let errorCode: string | null = null;
+				let message = text || `Request failed: ${status}`;
+				try {
+					const parsed = JSON.parse(text);
+					const detail = parsed?.detail;
+					if (detail && typeof detail === 'object' && typeof detail.error_code === 'string') {
+						errorCode = detail.error_code;
+						if (typeof detail.message === 'string') {
+							message = detail.message;
+						}
+					} else if (typeof detail === 'string') {
+						message = detail;
+					}
+				} catch {
+					// Body wasn't JSON — keep the plain text as the message.
+				}
+				throw new ApiError(message, status, errorCode);
 			}
 		} catch (err) {
 			if (!isColdStartError(res, err) || attempt === MAX_RETRIES) {

--- a/web/src/lib/components/RevisionConfirmCard.svelte
+++ b/web/src/lib/components/RevisionConfirmCard.svelte
@@ -36,7 +36,7 @@
 	// body + action row). Form pattern (props, $state, $derived, error
 	// surfacing) mirrors ``LifecycleOverrideDialog.svelte``.
 
-	import { confirmRevisionOf, detectRevisionOf } from '$lib/api';
+	import { ApiError, confirmRevisionOf, detectRevisionOf } from '$lib/api';
 	import { trackEvent } from '$lib/analytics';
 	import { locale, t } from '$lib/i18n';
 	import { formatDate } from '$lib/i18n/format';
@@ -170,14 +170,48 @@
 			);
 			onConfirmed?.(res.revision_id, res.revision_number);
 		} catch (err) {
+			// Issue #86 (Cycle 5 W3-D): structured error_code drives UX
+			// branching. ``current_not_found`` / ``parent_not_found`` mean
+			// the project moved or the candidate is stale — auto-collapse
+			// the card (call onSkipped) so the user is not stuck staring
+			// at an action they cannot complete. Other 4xx (cross_program,
+			// cap_reached, no_xer_bytes, unique_collision, permission_denied)
+			// keep the card visible with the human-readable message.
+			//
+			// DA exit-council on PR #83 fix-up #P1-2 used a fragile text
+			// regex for cap-class detection — replaced here with the
+			// machine-readable ``error_code``. Legacy string-detail
+			// responses (errorCode === null) fall through to the message.
+			const errorCode = err instanceof ApiError ? err.errorCode : null;
 			const msg = err instanceof Error ? err.message : String(err);
-			// DA exit-council fix-up #P1-2: detect cap-class errors and switch
-			// to the i18n key so non-English users get a friendly message.
-			// Backend 409 detail mentions "revision cap" / "limit" — pattern
-			// match on the substring. A future structured error code would
-			// be cleaner; tracked as a follow-up.
-			const isCapError = /revision cap|reached.*\(\d+\)|limit/i.test(msg);
-			const friendly = isCapError ? $t('revision.cap_reached') : msg;
+
+			if (errorCode === 'current_not_found' || errorCode === 'parent_not_found') {
+				trackEvent('revision_confirm_auto_collapsed', {
+					project_id: projectId,
+					candidate_project_id: candidateProjectId,
+					error_code: errorCode
+				});
+				toastError($t(`revision.error_${errorCode}`));
+				// Auto-collapse:
+				// - Internal DOM: flip detectState to no_candidate so the
+				//   card branch's {#if} collapses regardless of what the
+				//   parent does. Defensive: prevents stuck "Linking…"
+				//   button if the parent forgets to dismount us.
+				// - Parent: call onSkipped so the parent updates lineage
+				//   state (same terminal effect as the user clicking
+				//   "Treat as new project").
+				detectState = 'no_candidate';
+				confirmState = 'idle';
+				onSkipped?.();
+				return;
+			}
+
+			const friendly =
+				errorCode === 'cap_reached'
+					? $t('revision.cap_reached')
+					: errorCode === 'cross_program'
+						? $t('revision.error_cross_program')
+						: msg;
 			confirmError = friendly;
 			toastError(friendly);
 			confirmState = 'idle';

--- a/web/src/lib/components/RevisionConfirmCard.test.ts
+++ b/web/src/lib/components/RevisionConfirmCard.test.ts
@@ -17,8 +17,9 @@
 // explicitly out of scope for this PR.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, cleanup, waitFor } from '@testing-library/svelte';
+import { fireEvent, render, cleanup, waitFor } from '@testing-library/svelte';
 import RevisionConfirmCard from './RevisionConfirmCard.svelte';
+import { ApiError } from '$lib/api';
 
 // Deferred resolvers so tests can drive the order in which two
 // concurrent detect calls complete (race regression).
@@ -26,16 +27,29 @@ const detectResolvers: Array<(payload: unknown) => void> = [];
 const detectRejecters: Array<(err: Error) => void> = [];
 const detectCalls: string[] = [];
 
-vi.mock('$lib/api', () => ({
-	detectRevisionOf: vi.fn((projectId: string) => {
-		detectCalls.push(projectId);
-		return new Promise((resolve, reject) => {
-			detectResolvers.push(resolve);
-			detectRejecters.push(reject);
-		});
-	}),
-	confirmRevisionOf: vi.fn(),
-}));
+// Confirm-side: the test re-points `confirmRevisionOf.mockImplementation`
+// per-test (some tests reject with ApiError, default is no-op). Decouples
+// detect-mock orchestration from confirm-mock orchestration. Wrapped in
+// vi.hoisted so the function reference is available when vi.mock hoists
+// to the top of the file.
+const { confirmMock } = vi.hoisted(() => ({ confirmMock: vi.fn() }));
+
+vi.mock('$lib/api', async () => {
+	// Re-export the real `ApiError` class so tests can construct it AND
+	// the component import sees the same class identity (instanceof works).
+	const actual = await vi.importActual<typeof import('$lib/api')>('$lib/api');
+	return {
+		ApiError: actual.ApiError,
+		detectRevisionOf: vi.fn((projectId: string) => {
+			detectCalls.push(projectId);
+			return new Promise((resolve, reject) => {
+				detectResolvers.push(resolve);
+				detectRejecters.push(reject);
+			});
+		}),
+		confirmRevisionOf: confirmMock,
+	};
+});
 
 vi.mock('$lib/analytics', () => ({
 	trackEvent: vi.fn(),
@@ -50,6 +64,7 @@ beforeEach(() => {
 	detectResolvers.length = 0;
 	detectRejecters.length = 0;
 	detectCalls.length = 0;
+	confirmMock.mockReset();
 });
 
 afterEach(() => {
@@ -122,6 +137,37 @@ describe('RevisionConfirmCard', () => {
 			expect(region.textContent).toContain('NEW Winner');
 			expect(region.textContent).not.toContain('STALE Loser');
 		});
+	});
+
+	it('auto-collapses the card and calls onSkipped when confirm fails with parent_not_found (issue #86)', async () => {
+		// Issue #86 (Cycle 5 W3-D): structured error_code drives
+		// auto-collapse on missing-project class errors. Asserts that the
+		// component calls `onSkipped` (the parent's "treat as new project"
+		// callback) and that the region disappears from the DOM after the
+		// confirm rejection.
+		const onSkipped = vi.fn();
+		confirmMock.mockRejectedValueOnce(
+			new ApiError('parent project xyz not found', 404, 'parent_not_found'),
+		);
+
+		const { findByRole, queryByRole } = render(RevisionConfirmCard, {
+			props: { projectId: 'p-current', onSkipped },
+		});
+		// Resolve detect so the card renders with a candidate + confirm
+		// button is enabled.
+		detectResolvers[0]!(happyPayload());
+		const region = await findByRole('region');
+		const confirmButton = region.querySelector(
+			'button:nth-of-type(2)',
+		) as HTMLButtonElement | null;
+		expect(confirmButton).not.toBeNull();
+		await fireEvent.click(confirmButton!);
+
+		await waitFor(() => {
+			expect(onSkipped).toHaveBeenCalledTimes(1);
+		});
+		// Card collapsed.
+		expect(queryByRole('region')).toBeNull();
 	});
 
 	it('renders nothing when detect returns no candidate', async () => {

--- a/web/src/lib/i18n/en.ts
+++ b/web/src/lib/i18n/en.ts
@@ -1332,6 +1332,9 @@ export default {
 	'revision.cap_reached': 'Project has reached the revision cap. Tombstone an older revision before linking a new one.',
 	'revision.checking': 'Checking for revision matches…',
 	'revision.auth_expired_hint': 'Could not check for revisions — session may have expired. Refresh the page and re-upload to retry.',
+	'revision.error_current_not_found': 'This project is no longer available. The card has been dismissed.',
+	'revision.error_parent_not_found': 'The candidate parent project is no longer available. The card has been dismissed.',
+	'revision.error_cross_program': 'Current and parent are not in the same program. Refresh the page or open a support ticket.',
 
 	// Cycle 4 W3-B — multi-revision S-curve overlay (revision-trends page).
 	'revision_trends.subtitle': 'Multi-revision planned-completion overlay with executed-curve and CUSUM change-point markers (AACE RP 29R-03 §"Window analysis").',

--- a/web/src/lib/i18n/es.ts
+++ b/web/src/lib/i18n/es.ts
@@ -1330,6 +1330,9 @@ export default {
 	'revision.cap_reached': 'El proyecto alcanzó el límite de revisiones. Marque una revisión antigua como tombstone antes de vincular una nueva.',
 	'revision.checking': 'Verificando coincidencias de revisión…',
 	'revision.auth_expired_hint': 'No se pudo verificar revisiones — la sesión puede haber expirado. Recargue la página y vuelva a subir para reintentar.',
+	'revision.error_current_not_found': 'Este proyecto ya no está disponible. La tarjeta fue descartada.',
+	'revision.error_parent_not_found': 'El proyecto padre candidato ya no está disponible. La tarjeta fue descartada.',
+	'revision.error_cross_program': 'Actual y padre no están en el mismo programa. Recargue la página o abra un ticket de soporte.',
 
 	// Cycle 4 W3-B — superposición de S-curves multi-revisión (página revision-trends).
 	'revision_trends.subtitle': 'Superposición de S-curves de finalización planificada por revisión, con curva ejecutada y marcadores CUSUM de cambio de régimen (AACE RP 29R-03 §"Window analysis").',

--- a/web/src/lib/i18n/pt-BR.ts
+++ b/web/src/lib/i18n/pt-BR.ts
@@ -1330,6 +1330,9 @@ export default {
 	'revision.cap_reached': 'O projeto atingiu o limite de revisões. Marque uma revisão antiga como tombstone antes de vincular uma nova.',
 	'revision.checking': 'Verificando correspondências de revisão…',
 	'revision.auth_expired_hint': 'Não foi possível verificar revisões — a sessão pode ter expirado. Recarregue a página e reenvie para tentar novamente.',
+	'revision.error_current_not_found': 'Este projeto não está mais disponível. O cartão foi descartado.',
+	'revision.error_parent_not_found': 'O projeto pai candidato não está mais disponível. O cartão foi descartado.',
+	'revision.error_cross_program': 'Atual e pai não estão no mesmo programa. Recarregue a página ou abra um chamado de suporte.',
 
 	// Cycle 4 W3-B — overlay de S-curves multi-revisão (página revision-trends).
 	'revision_trends.subtitle': 'Sobreposição de S-curves de conclusão planejada por revisão, com curva executada e marcadores CUSUM de mudança de regime (AACE RP 29R-03 §"Window analysis").',


### PR DESCRIPTION
## Summary

Cycle 5 W3-D. Closes #86 (DA P3-5 from PR #83 — fragile text-pattern-matching on confirm 4xx detail; frontend cannot differentiate "permanent missing" from other 4xx classes).

## Backend

- `src/api/schemas.py` — new `ConfirmRevisionOfErrorDetail` Pydantic model with `error_code: Literal[7 codes]` + `message: str`. The 7 codes: `current_not_found` (404), `parent_not_found` (404), `cross_program` (409), `no_xer_bytes` (409), `cap_reached` (409), `unique_collision` (409), `permission_denied` (403).
- `src/api/routers/revisions.py` — replaced 4 `detail=str` raises with `detail={"error_code": ..., "message": ...}` dicts.
- `tests/test_revisions_router.py` — 3 existing tests updated to read `detail["message"]`; 2 new tests pin `current_not_found` / `parent_not_found` codes specifically.

## NO transient_lookup code (entry-council BLOCKING)

Frontend-ux-reviewer entry-council on the W3 batch: "Transient 404" is theoretical against Supabase's pooler (single-PG snapshot isolation per request, no eventual-consistency 404s observed). Adding a retry path for an unobserved failure mode = premature complexity. If telemetry ever surfaces a transient class, bump schema_version + add the code in a future amendment.

## Frontend

- `web/src/lib/api.ts` — new `ApiError` Error subclass with `status` + `errorCode` fields. The `request<T>()` helper parses `{detail: {error_code, message}}` JSON bodies + falls back to plain text for legacy endpoints.
- `web/src/lib/components/RevisionConfirmCard.svelte` — switched cap-detection from fragile text regex to `errorCode === 'cap_reached'` branching. Added auto-collapse path for `current_not_found` / `parent_not_found`: flips internal `detectState = 'no_candidate'` AND calls `onSkipped?.()` (parent informed). Defensive: internal DOM collapse prevents stuck "Linking…" if parent forgets to dismount.
- 6 new i18n keys × 3 locales.
- 1 new component test pinning auto-collapse behavior using the `vi.hoisted({confirmMock})` pattern (Vitest hoists `vi.mock` to top of file).

## Test plan

- [x] `python -m pytest tests/ -q` — 1665 passed (+1 new), 6 skipped
- [x] `npx vitest run` — 58 passed (+1 new)
- [x] `npm run check` — 0 errors / 0 warnings
- [x] `npm run build` — clean
- [x] Frontend-ux-reviewer entry-council completed pre-impl (W3 batch)
- [ ] DA exit-council per ADR-0018 Am.1 — runs at PR review time

## Closes

- #86 — feat: 404-on-confirm auto-collapse vs retry differentiation

## Cross-refs

- ADR-0024 (Cycle 5 entry — W3 batch shape)
- PR #114 (Vitest+Svelte 5 harness W3-B — uses the established pattern)
- PR #83 (where DA flagged #86)