### PR TITLE
feat(cycle5-w3e): #84 — revision skip log + reconsider mechanism

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,9 +40,9 @@ mypy src/ --strict              # type check
 ## Architecture
 
 - **48 analysis engines** in `src/analytics/` + 1 export module in `src/export/` — each standalone, no cross-dependencies
-- **API**: FastAPI with 127 endpoints under `/api/v1/` across 25 routers, rate-limited critical endpoints
+- **API**: FastAPI with 129 endpoints under `/api/v1/` across 25 routers, rate-limited critical endpoints
 - **Frontend**: SvelteKit + Tailwind v4, 55 pages, Svelte 5 runes ($state, $derived, $effect), dark mode, i18n (en/pt-BR/es), keyboard shortcuts (?)
-- **Database**: Supabase PostgreSQL with RLS, 28 migrations in `supabase/migrations/`
+- **Database**: Supabase PostgreSQL with RLS, 29 migrations in `supabase/migrations/`
 - **Auth**: Supabase Auth (Google + LinkedIn + Microsoft OAuth), ES256 JWT
 - **Storage**: Supabase Storage for XER files and PDFs
 - **Deploy**: Fly.io (backend, port 8080) + Cloudflare Pages (frontend)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Every methodology is traceable to published standards: AACE Recommended Practice
 | Schedule formats | 2 (Primavera P6 XER + Microsoft Project XML) |
 | Tests passing | 1490 backend + 26 Vitest composables + Playwright E2E |
 | Frontend pages | 55 (Schedule Viewer, EVM S-Curve, Cost Integration, Health Score, NLP Query, Early Warning, Lifecycle Phase, Revision Trends, …) |
-| API endpoints | 127 across 25 routers |
+| API endpoints | 129 across 25 routers |
 | SVG chart components | 11 (incl. EVM S-Curve) + ScheduleViewer (hand-crafted, no chart.js) |
 | Released versions | v0.1.0 → v4.2.0 |
 | Live platform | [meridianiq.vitormr.dev](https://meridianiq.vitormr.dev) |
@@ -120,7 +120,7 @@ graph TB
     end
 
     subgraph "Compute Layer — Fly.io"
-        FASTAPI["FastAPI Container<br/>Analysis Engines (48)<br/>127 endpoints"]
+        FASTAPI["FastAPI Container<br/>Analysis Engines (48)<br/>129 endpoints"]
     end
 
     subgraph "Platform Layer — Supabase"
@@ -325,12 +325,12 @@ meridianiq/
 │   ├── database/         # Supabase client, config, store abstraction
 │   └── api/
 │       ├── app.py        # FastAPI entry point
-│       ├── routers/      # 127 endpoints across modular routers
+│       ├── routers/      # 129 endpoints across modular routers
 │       └── schemas.py    # Request/response models
 ├── web/                  # SvelteKit + Tailwind (55 pages)
 ├── tests/                # 1490+ backend tests
 ├── supabase/
-│   └── migrations/       # PostgreSQL schema migrations (28 files)
+│   └── migrations/       # PostgreSQL schema migrations (29 files)
 ├── .github/
 │   └── workflows/ci.yml  # CI/CD: test + lint + E2E + deploy
 ├── docs/                 # Discovery & definition documents

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,6 +1,6 @@
 # API Reference
 
-Generated from `src/api/app.py` — **127 endpoints** across **25 routers**. Interactive Swagger UI is served at `/docs` when the API is running; this document is a static browseable index.
+Generated from `src/api/app.py` — **129 endpoints** across **25 routers**. Interactive Swagger UI is served at `/docs` when the API is running; this document is a static browseable index.
 
 All paths are prefixed with the deployment base URL (e.g. `https://meridianiq.fly.dev`). Auth column: `none` (public), `optional` (degrades gracefully), `required` (returns 401 without bearer token).
 
@@ -31,7 +31,7 @@ Regenerate with: `python3 scripts/generate_api_reference.py`
 - [Observability](#observability) — 1 endpoints
 - [Organizations](#organizations) — 11 endpoints
 - [Plugins](#plugins) — 2 endpoints
-- [Revisions](#revisions) — 4 endpoints
+- [Revisions](#revisions) — 6 endpoints
 - [Ws](#ws) — 1 endpoints
 
 ## Upload
@@ -311,9 +311,11 @@ _Readiness and liveness_
 
 | Method | Path | Summary | Response | Auth |
 |---|---|---|---|---|
+| `POST` | `/api/v1/projects/{project_id}/clear-revision-skips` | Delete all skip rows for (project_id, current_user) — the | `ClearRevisionSkipsResponse` | required |
 | `POST` | `/api/v1/projects/{project_id}/confirm-revision-of` | Write a ``revision_history`` row anchoring the current upload as a | `ConfirmRevisionOfResponse` | required |
 | `POST` | `/api/v1/projects/{project_id}/detect-revision-of` | Return candidate parent project per the v1 heuristic. | `DetectRevisionOfResponse` | required |
 | `GET` | `/api/v1/projects/{project_id}/revision-trends` | Return the multi-revision S-curve overlay + change-points + slope band. | `RevisionTrendsResponse` | required |
+| `POST` | `/api/v1/projects/{project_id}/skip-revision-of` | Record that the user dismissed a revision-confirmation candidate. | `SkipRevisionOfResponse` | required |
 | `POST` | `/api/v1/revisions/{revision_id}/tombstone` | Soft-tombstone a revision_history row + write paired audit_log entry. | `TombstoneRevisionResponse` | required |
 
 ## Ws

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@
 
 MeridianIQ is a **modular monolith**: a single FastAPI application with clearly separated analysis engines, each implementing a specific published methodology and written to stay independent of every other engine. The frontend is a SvelteKit SPA served from Cloudflare Pages and talks to the backend via REST.
 
-As of **v4.2.0** (β-honest path-A discipline — Cycle 3 close-arc + Cycle 4 close): 48 analysis engines + 1 export module, 127 API endpoints across 25 routers, 55 SvelteKit pages, 11 hand-crafted SVG chart components, 28 Supabase migrations, 22 MCP tools, 15 PDF report types, 1652 tests.
+As of **v4.2.0** (β-honest path-A discipline — Cycle 3 close-arc + Cycle 4 close): 48 analysis engines + 1 export module, 129 API endpoints across 25 routers, 55 SvelteKit pages, 11 hand-crafted SVG chart components, 29 Supabase migrations, 22 MCP tools, 15 PDF report types, 1652 tests.
 
 ```mermaid
 graph TB
@@ -14,7 +14,7 @@ graph TB
     end
 
     subgraph "Compute — Fly.io"
-        API[FastAPI application<br/>127 endpoints · 25 routers<br/>Rate-limited · CORS whitelist<br/>Sentry telemetry]
+        API[FastAPI application<br/>129 endpoints · 25 routers<br/>Rate-limited · CORS whitelist<br/>Sentry telemetry]
         ENGINES[48 analysis engines<br/>+ 1 export module<br/>src/analytics/ + src/export/]
         MATERIALIZER[Async materializer<br/>asyncio.Task · Semaphore(1)<br/>ProcessPoolExecutor spawn<br/>src/materializer/]
         MCP[MCP server<br/>22 tools · stdio + http + sse<br/>src/mcp_server.py]
@@ -26,7 +26,7 @@ graph TB
 
     subgraph "Platform — Supabase"
         AUTH["Supabase Auth<br/>Google · LinkedIn · Microsoft<br/>ES256 JWT via JWKS"]
-        DB[("PostgreSQL<br/>28 migrations · RLS enforced<br/>projects (pending/ready/failed)<br/>activities · WBS · revision_history<br/>schedule_derived_artifacts<br/>erp_sources · cbs_elements<br/>cost_snapshots · audit")]
+        DB[("PostgreSQL<br/>29 migrations · RLS enforced<br/>projects (pending/ready/failed)<br/>activities · WBS · revision_history<br/>revision_skip_log · audit_log<br/>schedule_derived_artifacts · erp_sources<br/>cbs_elements · cost_snapshots")]
         STORAGE["Supabase Storage<br/>xer-files bucket · RLS"]
     end
 
@@ -87,7 +87,7 @@ web/
       stores/        auth (lazy init), theme, i18n
       api.ts         API client
 supabase/
-  migrations/        28 .sql files (RLS enforced on user-owned tables — see ADR-0017 for the deduplication of the 012/017 api_keys migrations; Cycle 3 W4 added the `_ENGINE_VERSION` sourcing chain via `src/__about__.py` per ADR-0014 §"Decision Outcome"; Cycle 4 W1 added `revision_history` per ADR-0022 + Amendment 1)
+  migrations/        29 .sql files (RLS enforced on user-owned tables — see ADR-0017 for the deduplication of the 012/017 api_keys migrations; Cycle 3 W4 added the `_ENGINE_VERSION` sourcing chain via `src/__about__.py` per ADR-0014 §"Decision Outcome"; Cycle 4 W1 added `revision_history` per ADR-0022 + Amendment 1; Cycle 5 W3-E added `revision_skip_log` per issue #84)
 scripts/
   generate_api_reference.py       → docs/api-reference.md
   generate_mcp_catalog.py         → docs/mcp-tools.md
@@ -296,7 +296,7 @@ Supports universal ERP fields per AACE RP 10S-90, ANSI/EIA-748, ISO 21511, with 
 
 ## Catalogs & references
 
-- [API Reference](api-reference.md) — auto-generated from FastAPI app (127 endpoints × 25 routers)
+- [API Reference](api-reference.md) — auto-generated from FastAPI app (129 endpoints × 25 routers)
 - [Methodologies](methodologies.md) — auto-generated from engine docstrings (48 engines + citations)
 - [MCP Tools](mcp-tools.md) — auto-generated from `@mcp.tool()` decorators (22 tools)
 - [Deploy Checklist](DEPLOY_CHECKLIST.md) — 5-phase procedure

--- a/src/api/routers/revisions.py
+++ b/src/api/routers/revisions.py
@@ -45,12 +45,15 @@ from ..deps import RATE_LIMIT_ANALYSIS, RATE_LIMIT_WRITE, get_store, limiter
 from ..revision_detection import compute_xer_content_hash, detect_candidate_parent
 from ..schemas import (
     ChangePointMarkerSchema,
+    ClearRevisionSkipsResponse,
     ConfirmRevisionOfRequest,
     ConfirmRevisionOfResponse,
     DetectRevisionOfResponse,
     RevisionCurvePoint,
     RevisionCurveSchema,
     RevisionTrendsResponse,
+    SkipRevisionOfRequest,
+    SkipRevisionOfResponse,
     SlopeBandSchema,
     TombstoneRevisionRequest,
     TombstoneRevisionResponse,
@@ -89,6 +92,25 @@ def detect_revision_of_endpoint(
     if not user_id:
         raise HTTPException(status_code=401, detail="Authentication required")
     snapshot = detect_candidate_parent(store, user_id=user_id, project_id=project_id)
+    # Cycle 5 W3-E (issue #84): filter out skipped candidates so users
+    # are not nagged with the same suggestion forever. Reconsider clears
+    # skips via POST clear-revision-skips. The heuristic itself is
+    # idempotent (same input → same candidate); skip-log is the layer
+    # that tracks user intent.
+    candidate_id = snapshot.get("candidate_project_id")
+    if candidate_id and store.is_revision_skipped(
+        project_id=project_id,
+        candidate_project_id=candidate_id,
+        user_id=user_id,
+    ):
+        return DetectRevisionOfResponse(
+            candidate_project_id=None,
+            candidate_project_name=None,
+            candidate_data_date=None,
+            candidate_revision_count=0,
+            confidence=0.0,
+            reasoning="filtered by user skip — POST clear-revision-skips to reconsider",
+        )
     return DetectRevisionOfResponse(**snapshot)
 
 
@@ -228,6 +250,103 @@ def confirm_revision_of_endpoint(
         data_date=row.get("data_date"),
         content_hash=row["content_hash"],
     )
+
+
+# ────────────────────────────────────────────────────────────
+# 2.5. skip-revision-of + clear-revision-skips (Cycle 5 W3-E — issue #84)
+# ────────────────────────────────────────────────────────────
+
+
+@router.post(
+    "/api/v1/projects/{project_id}/skip-revision-of",
+    response_model=SkipRevisionOfResponse,
+)
+@limiter.limit(RATE_LIMIT_WRITE)
+def skip_revision_of_endpoint(
+    request: Request,
+    project_id: str,
+    body: SkipRevisionOfRequest,
+    user: dict[str, Any] = Depends(require_auth),
+) -> SkipRevisionOfResponse:
+    """Record that the user dismissed a revision-confirmation candidate.
+
+    Idempotent: repeated calls with the same triple return ``recorded:
+    False`` (already-skipped). ``current_not_found`` /
+    ``parent_not_found`` 404s mirror the confirm endpoint's structured
+    error_code shape so frontend pattern-matching is consistent.
+    """
+    store = get_store()
+    user_id = user.get("id")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    if project_id == body.candidate_project_id:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error_code": "self_skip",
+                "message": "self-skip is meaningless — project cannot be its own revision parent",
+            },
+        )
+    current = store.get_project_meta(project_id, user_id=user_id)
+    if current is None:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "error_code": "current_not_found",
+                "message": f"project {project_id} not found",
+            },
+        )
+    candidate = store.get_project_meta(body.candidate_project_id, user_id=user_id)
+    if candidate is None:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "error_code": "parent_not_found",
+                "message": f"candidate project {body.candidate_project_id} not found",
+            },
+        )
+    recorded = store.record_revision_skip(
+        project_id=project_id,
+        candidate_project_id=body.candidate_project_id,
+        user_id=user_id,
+    )
+    return SkipRevisionOfResponse(
+        project_id=project_id,
+        candidate_project_id=body.candidate_project_id,
+        recorded=recorded,
+    )
+
+
+@router.post(
+    "/api/v1/projects/{project_id}/clear-revision-skips",
+    response_model=ClearRevisionSkipsResponse,
+)
+@limiter.limit(RATE_LIMIT_WRITE)
+def clear_revision_skips_endpoint(
+    request: Request,
+    project_id: str,
+    user: dict[str, Any] = Depends(require_auth),
+) -> ClearRevisionSkipsResponse:
+    """Delete all skip rows for (project_id, current_user) — the
+    "Confirm as revision of..." reconsider mechanism on the project-
+    detail page. After clearing, a subsequent detect call will surface
+    the same candidate the user previously skipped.
+    """
+    store = get_store()
+    user_id = user.get("id")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    current = store.get_project_meta(project_id, user_id=user_id)
+    if current is None:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "error_code": "current_not_found",
+                "message": f"project {project_id} not found",
+            },
+        )
+    cleared = store.clear_revision_skips(project_id=project_id, user_id=user_id)
+    return ClearRevisionSkipsResponse(project_id=project_id, cleared_count=cleared)
 
 
 # ────────────────────────────────────────────────────────────

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -1994,6 +1994,45 @@ class ConfirmRevisionOfResponse(BaseModel):
     content_hash: str
 
 
+class SkipRevisionOfRequest(BaseModel):
+    """Request body for POST /api/v1/projects/{id}/skip-revision-of
+    (Cycle 5 W3-E — issue #84).
+
+    Frontend calls this when the user clicks "Treat as new project" on
+    the revision-confirmation card. The skip persists across sessions;
+    detect endpoint filters skipped candidates so the same suggestion
+    doesn't nag forever.
+    """
+
+    candidate_project_id: str = Field(..., min_length=1)
+
+
+class SkipRevisionOfResponse(BaseModel):
+    """Response for POST /api/v1/projects/{id}/skip-revision-of.
+
+    ``recorded`` is False on idempotent no-op (the (project, candidate,
+    user) triple already exists in revision_skip_log per migration 029
+    UNIQUE). Frontend treats both shapes as success.
+    """
+
+    project_id: str
+    candidate_project_id: str
+    recorded: bool
+
+
+class ClearRevisionSkipsResponse(BaseModel):
+    """Response for POST /api/v1/projects/{id}/clear-revision-skips
+    (Cycle 5 W3-E — issue #84).
+
+    Reconsider mechanism: deletes all skip rows for (project_id,
+    current_user). After clearing, a subsequent detect call surfaces
+    the same candidate the user previously skipped.
+    """
+
+    project_id: str
+    cleared_count: int
+
+
 class TombstoneRevisionRequest(BaseModel):
     """Request body for POST /api/v1/revisions/{id}/tombstone.
 

--- a/src/database/store.py
+++ b/src/database/store.py
@@ -2867,16 +2867,35 @@ class SupabaseStore:
         number of rows deleted. The reconsider mechanism — frontend
         calls this when the user clicks "Confirm as revision of..." on
         the project-detail page.
+
+        DA exit-council PR #118 P1 #1: PostgREST DELETE without explicit
+        ``Prefer: return=representation`` returns an empty body —
+        ``len(res.data or [])`` would always be 0 in production while
+        InMemoryStore tests pass. Two-round-trip (SELECT-then-DELETE,
+        return SELECT count) avoids the silent dev/prod divergence +
+        dodges the supabase-py version-contract question. The cost is
+        an extra round-trip on a manual-button reconsider call (rare,
+        operator-paced) — acceptable.
         """
         try:
-            res = (
+            existing = (
+                self._client.table("revision_skip_log")
+                .select("id")
+                .eq("project_id", project_id)
+                .eq("user_id", user_id)
+                .execute()
+            )
+            count = len(existing.data or [])
+            if count == 0:
+                return 0
+            (
                 self._client.table("revision_skip_log")
                 .delete()
                 .eq("project_id", project_id)
                 .eq("user_id", user_id)
                 .execute()
             )
-            return len(res.data or [])
+            return count
         except Exception as exc:  # noqa: BLE001
             logger.warning("clear_revision_skips failed: %s", exc)
             return 0

--- a/src/database/store.py
+++ b/src/database/store.py
@@ -122,6 +122,13 @@ class InMemoryStore:
         # for the W2 detect heuristic. Persisted only in InMemoryStore for tests
         # (SupabaseStore reads from the projects table directly).
         self._project_meta: dict[str, dict[str, Any]] = {}
+        # Cycle 5 W3-E — issue #84 revision_skip_log. Per-user skip ledger
+        # for revision-confirmation candidates. Storage shape mirrors
+        # migration 029: list of {project_id, candidate_project_id,
+        # user_id, skipped_at} dicts. Detect endpoint filters skipped
+        # candidates so users are not nagged with the same suggestion
+        # forever; reconsider clears entries via clear_revision_skips.
+        self._revision_skip_log: list[dict[str, Any]] = []
 
     # -- programs --------------------------------------------------------
 
@@ -480,6 +487,91 @@ class InMemoryStore:
                 "original_baseline_lock_at": original_baseline_lock_at,
             }
         return None
+
+    # -- revision_skip_log (Cycle 5 W3-E — issue #84) -------------------
+
+    def record_revision_skip(
+        self,
+        project_id: str,
+        candidate_project_id: str,
+        user_id: str,
+    ) -> bool:
+        """Record that the user skipped a revision-confirmation candidate.
+
+        Returns True on first insert, False if the (project_id,
+        candidate_project_id, user_id) triple already exists (idempotent).
+        Raises ValueError on self-skip (project_id == candidate_project_id).
+        Mirrors migration 029 ``chk_revision_skip_not_self`` constraint
+        + ``ON CONFLICT DO NOTHING`` UPSERT semantics.
+        """
+        if project_id == candidate_project_id:
+            raise ValueError("self-skip is meaningless — project cannot be its own revision parent")
+        for row in self._revision_skip_log:
+            if (
+                row["project_id"] == project_id
+                and row["candidate_project_id"] == candidate_project_id
+                and row["user_id"] == user_id
+            ):
+                return False
+        self._revision_skip_log.append(
+            {
+                "project_id": project_id,
+                "candidate_project_id": candidate_project_id,
+                "user_id": user_id,
+                "skipped_at": datetime.now(UTC).isoformat(),
+            }
+        )
+        return True
+
+    def is_revision_skipped(
+        self,
+        project_id: str,
+        candidate_project_id: str,
+        user_id: str,
+    ) -> bool:
+        """Check whether a (project_id, candidate, user) skip exists."""
+        return any(
+            row["project_id"] == project_id
+            and row["candidate_project_id"] == candidate_project_id
+            and row["user_id"] == user_id
+            for row in self._revision_skip_log
+        )
+
+    def list_skipped_candidates(
+        self,
+        project_id: str,
+        user_id: str,
+    ) -> list[str]:
+        """Return all candidate_project_ids the user has skipped FOR
+        the given project. Used by the detect endpoint to filter
+        suggestions.
+        """
+        return [
+            row["candidate_project_id"]
+            for row in self._revision_skip_log
+            if row["project_id"] == project_id and row["user_id"] == user_id
+        ]
+
+    def clear_revision_skips(
+        self,
+        project_id: str,
+        user_id: str,
+    ) -> int:
+        """Delete all skip rows for (project_id, user_id). Returns the
+        number of rows deleted.
+
+        This is the load-bearing reconsider mechanism — frontend calls
+        this when the user clicks "Confirm as revision of..." on the
+        project-detail page after previously skipping. The migration
+        029 DELETE policy enforces RLS scope at the DB layer.
+        """
+        before = len(self._revision_skip_log)
+        self._revision_skip_log = [
+            row
+            for row in self._revision_skip_log
+            if not (row["project_id"] == project_id and row["user_id"] == user_id)
+        ]
+        return before - len(self._revision_skip_log)
 
     # -- upload / project ------------------------------------------------
 
@@ -2688,6 +2780,106 @@ class SupabaseStore:
             "audit_log_id": audit_id,
             "original_baseline_lock_at": original_baseline_lock_at,
         }
+
+    # -- revision_skip_log (Cycle 5 W3-E — issue #84) -------------------
+
+    def record_revision_skip(
+        self,
+        project_id: str,
+        candidate_project_id: str,
+        user_id: str,
+    ) -> bool:
+        """Record a revision-confirmation skip. Returns True on first
+        insert, False on idempotent no-op (UNIQUE collision).
+
+        Migration 029 enforces ``UNIQUE (project_id, candidate_project_id,
+        user_id)`` + ``CHECK (project_id <> candidate_project_id)``;
+        the helper raises ValueError on self-skip BEFORE the round-trip.
+        """
+        if project_id == candidate_project_id:
+            raise ValueError("self-skip is meaningless — project cannot be its own revision parent")
+        try:
+            self._client.table("revision_skip_log").insert(
+                {
+                    "project_id": project_id,
+                    "candidate_project_id": candidate_project_id,
+                    "user_id": user_id,
+                }
+            ).execute()
+            return True
+        except Exception as exc:  # noqa: BLE001
+            # PostgREST encodes UNIQUE violations as 23505. Treat as
+            # idempotent no-op (caller's intent: "ensure skipped").
+            if "23505" in str(exc) or "duplicate" in str(exc).lower():
+                return False
+            logger.warning("record_revision_skip failed: %s", exc)
+            raise
+
+    def is_revision_skipped(
+        self,
+        project_id: str,
+        candidate_project_id: str,
+        user_id: str,
+    ) -> bool:
+        """Check whether a (project_id, candidate, user) skip exists."""
+        try:
+            res = (
+                self._client.table("revision_skip_log")
+                .select("id")
+                .eq("project_id", project_id)
+                .eq("candidate_project_id", candidate_project_id)
+                .eq("user_id", user_id)
+                .limit(1)
+                .execute()
+            )
+            return bool(res.data)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("is_revision_skipped failed: %s", exc)
+            return False
+
+    def list_skipped_candidates(
+        self,
+        project_id: str,
+        user_id: str,
+    ) -> list[str]:
+        """Return all candidate_project_ids the user has skipped FOR
+        the given project. Used by the detect endpoint to filter.
+        """
+        try:
+            res = (
+                self._client.table("revision_skip_log")
+                .select("candidate_project_id")
+                .eq("project_id", project_id)
+                .eq("user_id", user_id)
+                .execute()
+            )
+            return [str(r["candidate_project_id"]) for r in (res.data or [])]
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("list_skipped_candidates failed: %s", exc)
+            return []
+
+    def clear_revision_skips(
+        self,
+        project_id: str,
+        user_id: str,
+    ) -> int:
+        """Delete all skip rows for (project_id, user_id). Returns the
+        number of rows deleted. The reconsider mechanism — frontend
+        calls this when the user clicks "Confirm as revision of..." on
+        the project-detail page.
+        """
+        try:
+            res = (
+                self._client.table("revision_skip_log")
+                .delete()
+                .eq("project_id", project_id)
+                .eq("user_id", user_id)
+                .execute()
+            )
+            return len(res.data or [])
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("clear_revision_skips failed: %s", exc)
+            return 0
 
     # -- legacy aliases for app.py compatibility -------------------------
 

--- a/supabase/migrations/029_revision_skip_log.sql
+++ b/supabase/migrations/029_revision_skip_log.sql
@@ -1,0 +1,135 @@
+-- 029_revision_skip_log.sql
+--
+-- Cycle 5 W3-E — issue #84 (DA P2-3 from PR #83): persistent skip log
+-- for revision-confirmation candidates.
+--
+-- Problem (per frontend-ux-reviewer entry-council on the W3 batch):
+--   After the user clicks "Treat as new project" on the revision-
+--   confirmation card, there's no UI to reconsider. The card lives only
+--   on the upload result page; refresh kills the card. Worse, without
+--   server-side skip persistence, every visit to the project surfaces
+--   the SAME candidate suggestion forever — `detect_candidate_parent`
+--   returns the same heuristic match on every re-detect.
+--
+-- Solution:
+--   1. Persist the skip — one row per (project_id, candidate_project_id,
+--      user_id) tuple. Detect endpoint filters out skipped candidates.
+--   2. Project-detail page exposes "Confirm as revision of..." action
+--      that clears skips for the current project + re-runs detect, so
+--      the user can reconsider explicitly.
+--
+-- Adds:
+--   1. ``revision_skip_log`` table — append-only skip ledger. UNIQUE
+--      tuple prevents duplicate entries; clear-skips endpoint deletes
+--      rows so reconsider is a destructive action (no soft-delete).
+--   2. RLS quadruple SELECT / INSERT / UPDATE / DELETE on
+--      ``revision_skip_log`` mirroring migration 028 pattern. UPDATE
+--      policy is present for symmetry but practically unused — skips
+--      are write-once / delete-on-reconsider; mutating ``skipped_at``
+--      would be a data-integrity bug.
+--   3. B-tree index on ``(project_id, user_id)`` supporting the
+--      detect-endpoint filter ("is THIS candidate skipped FOR this
+--      project + user").
+--
+-- Append-only? NOT in this table:
+--   ``revision_skip_log`` is a transient ledger (not a domain history)
+--   — clearing skips on reconsider is the documented user-facing path.
+--   No append-only trigger; DELETE policy is the load-bearing
+--   reconsider mechanism.
+--
+-- ⚠ STAGING-FIRST APPLY:
+--   Apply to staging Supabase first per the migration 028 precedent.
+--   Verify:
+--     1. ``revision_skip_log`` table exists with all 5 columns
+--     2. RLS quadruple is in place (4 policies)
+--     3. UNIQUE constraint enforces dedup
+--     4. RLS-bounded delete works under reconsider call
+
+-- ================================================================
+-- 1. revision_skip_log table
+-- ================================================================
+
+CREATE TABLE IF NOT EXISTS public.revision_skip_log (
+    id                      BIGSERIAL PRIMARY KEY,
+    project_id              UUID NOT NULL REFERENCES public.projects(id) ON DELETE CASCADE,
+    candidate_project_id    UUID NOT NULL REFERENCES public.projects(id) ON DELETE CASCADE,
+    user_id                 UUID NOT NULL,
+    skipped_at              TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    -- Prevent duplicate skips for the same (project_id, candidate_id, user_id)
+    -- triple. Repeated skip calls from the frontend are idempotent (UPSERT
+    -- semantics handled at app layer; ON CONFLICT DO NOTHING in the store
+    -- helper).
+    CONSTRAINT uq_revision_skip_log_triple UNIQUE (project_id, candidate_project_id, user_id),
+
+    -- Self-skip is meaningless (project cannot be its own revision parent).
+    CONSTRAINT chk_revision_skip_not_self CHECK (project_id <> candidate_project_id)
+);
+
+COMMENT ON TABLE public.revision_skip_log IS
+    'Per-user skip ledger for revision-confirmation candidates. Cycle 5 W3-E per issue #84. One row per (project_id, candidate_project_id, user_id) — detect endpoint filters skipped candidates so users are not nagged with the same suggestion forever. Reconsider clears rows for a project (no soft-delete; DELETE policy is the load-bearing reconsider mechanism).';
+
+COMMENT ON CONSTRAINT chk_revision_skip_not_self ON public.revision_skip_log IS
+    'A project cannot be its own revision parent — self-skip rows would be defects. Cheap defense-in-depth.';
+
+-- ================================================================
+-- 2. Indices
+-- ================================================================
+
+-- Hot read path: detect-endpoint filter ("is candidate skipped FOR this
+-- project + user"). The UNIQUE constraint above also enforces
+-- (project_id, candidate_project_id, user_id) which would serve queries
+-- on the full triple, but the filter query reads (project_id, user_id)
+-- to fetch ALL skipped candidates for a project. Separate B-tree index
+-- on the partial key supports that read pattern at low write-amplification
+-- cost (skip writes are rare — operator-paced UI clicks, not bulk).
+CREATE INDEX IF NOT EXISTS idx_revision_skip_log_project_user
+    ON public.revision_skip_log (project_id, user_id);
+
+-- ================================================================
+-- 3. RLS quadruple
+-- ================================================================
+--
+-- Pattern from migrations 023 + 028. All four policies bind the
+-- subject to projects.user_id = auth.uid() — skip rows are owned by
+-- the user who skipped (NOT the project owner, in case future multi-
+-- tenant features expose shared projects).
+
+ALTER TABLE public.revision_skip_log ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "rsl_select_own" ON public.revision_skip_log;
+CREATE POLICY "rsl_select_own" ON public.revision_skip_log
+    FOR SELECT USING (
+        user_id = auth.uid()
+        AND project_id IN (SELECT id FROM public.projects WHERE user_id = auth.uid())
+    );
+
+DROP POLICY IF EXISTS "rsl_insert_own" ON public.revision_skip_log;
+CREATE POLICY "rsl_insert_own" ON public.revision_skip_log
+    FOR INSERT WITH CHECK (
+        user_id = auth.uid()
+        AND project_id IN (SELECT id FROM public.projects WHERE user_id = auth.uid())
+        AND candidate_project_id IN (SELECT id FROM public.projects WHERE user_id = auth.uid())
+    );
+
+DROP POLICY IF EXISTS "rsl_update_own" ON public.revision_skip_log;
+CREATE POLICY "rsl_update_own" ON public.revision_skip_log
+    FOR UPDATE USING (
+        user_id = auth.uid()
+        AND project_id IN (SELECT id FROM public.projects WHERE user_id = auth.uid())
+    ) WITH CHECK (
+        user_id = auth.uid()
+        AND project_id IN (SELECT id FROM public.projects WHERE user_id = auth.uid())
+    );
+
+DROP POLICY IF EXISTS "rsl_delete_own" ON public.revision_skip_log;
+CREATE POLICY "rsl_delete_own" ON public.revision_skip_log
+    FOR DELETE USING (
+        user_id = auth.uid()
+        AND project_id IN (SELECT id FROM public.projects WHERE user_id = auth.uid())
+    );
+
+-- ================================================================
+-- 4. Reload PostgREST schema cache
+-- ================================================================
+NOTIFY pgrst, 'reload schema';

--- a/tests/test_revisions_router.py
+++ b/tests/test_revisions_router.py
@@ -58,6 +58,8 @@ def fresh_store() -> InMemoryStore:
         store._upload_revision = {}
         store._project_owners = {}
         store._audit_log = []
+        # Cycle 5 W3-E (issue #84): revision_skip_log
+        store._revision_skip_log = []
     return store  # type: ignore[return-value]
 
 
@@ -412,6 +414,257 @@ def test_confirm_409_on_unique_collision(
     detail = resp.json()["detail"]
     assert detail["error_code"] == "unique_collision"
     assert "duplicate key" in detail["message"]
+
+
+# ────────────────────────────────────────────────────────────
+# Cycle 5 W3-E (issue #84) — skip / clear-skips endpoints + detect-filter
+# ────────────────────────────────────────────────────────────
+
+
+def test_skip_revision_of_records_skip(client: TestClient, fresh_store: InMemoryStore) -> None:
+    """POST skip-revision-of records the (project, candidate, user)
+    triple and surfaces the recorded=True flag."""
+    p1 = fresh_store.save_project(
+        upload_id="u1",
+        schedule=_schedule("PROJ-A", datetime(2026, 1, 1, tzinfo=timezone.utc)),
+        user_id="user-w2-test",
+    )
+    p2 = fresh_store.save_project(
+        upload_id="u2",
+        schedule=_schedule("PROJ-A", datetime(2026, 2, 1, tzinfo=timezone.utc)),
+        user_id="user-w2-test",
+    )
+    token = _make_token()
+    resp = client.post(
+        f"/api/v1/projects/{p2}/skip-revision-of",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"candidate_project_id": p1},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["project_id"] == p2
+    assert body["candidate_project_id"] == p1
+    assert body["recorded"] is True
+    # In-memory check: skip-log row exists.
+    assert fresh_store.is_revision_skipped(
+        project_id=p2, candidate_project_id=p1, user_id="user-w2-test"
+    )
+
+
+def test_skip_revision_of_idempotent(client: TestClient, fresh_store: InMemoryStore) -> None:
+    """Repeated skip calls return recorded=False on the second call."""
+    p1 = fresh_store.save_project(
+        upload_id="u1",
+        schedule=_schedule("PROJ-A", datetime(2026, 1, 1, tzinfo=timezone.utc)),
+        user_id="user-w2-test",
+    )
+    p2 = fresh_store.save_project(
+        upload_id="u2",
+        schedule=_schedule("PROJ-A", datetime(2026, 2, 1, tzinfo=timezone.utc)),
+        user_id="user-w2-test",
+    )
+    token = _make_token()
+    resp1 = client.post(
+        f"/api/v1/projects/{p2}/skip-revision-of",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"candidate_project_id": p1},
+    )
+    assert resp1.json()["recorded"] is True
+    resp2 = client.post(
+        f"/api/v1/projects/{p2}/skip-revision-of",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"candidate_project_id": p1},
+    )
+    assert resp2.status_code == 200
+    assert resp2.json()["recorded"] is False
+
+
+def test_skip_revision_of_400_on_self_skip(client: TestClient, fresh_store: InMemoryStore) -> None:
+    """Self-skip is meaningless — surfaces structured error_code 'self_skip'."""
+    p = fresh_store.save_project(
+        upload_id="u1",
+        schedule=_schedule("PROJ-A", datetime(2026, 1, 1, tzinfo=timezone.utc)),
+        user_id="user-w2-test",
+    )
+    token = _make_token()
+    resp = client.post(
+        f"/api/v1/projects/{p}/skip-revision-of",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"candidate_project_id": p},
+    )
+    assert resp.status_code == 400
+    detail = resp.json()["detail"]
+    assert detail["error_code"] == "self_skip"
+
+
+def test_skip_revision_of_404_on_missing_current(
+    client: TestClient, fresh_store: InMemoryStore
+) -> None:
+    token = _make_token()
+    resp = client.post(
+        "/api/v1/projects/nonexistent/skip-revision-of",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"candidate_project_id": "also-nonexistent"},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["detail"]["error_code"] == "current_not_found"
+
+
+def test_skip_revision_of_404_on_missing_candidate(
+    client: TestClient, fresh_store: InMemoryStore
+) -> None:
+    p = fresh_store.save_project(
+        upload_id="u1",
+        schedule=_schedule("PROJ-A", datetime(2026, 1, 1, tzinfo=timezone.utc)),
+        user_id="user-w2-test",
+    )
+    token = _make_token()
+    resp = client.post(
+        f"/api/v1/projects/{p}/skip-revision-of",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"candidate_project_id": "missing-candidate"},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["detail"]["error_code"] == "parent_not_found"
+
+
+def test_detect_filters_skipped_candidate(client: TestClient, fresh_store: InMemoryStore) -> None:
+    """After skipping, detect must NOT surface the same candidate
+    (issue #84 — the load-bearing user-facing behavior)."""
+    p1 = fresh_store.save_project(
+        upload_id="u1",
+        schedule=_schedule("PROJ-A", datetime(2026, 1, 1, tzinfo=timezone.utc)),
+        user_id="user-w2-test",
+    )
+    p2 = fresh_store.save_project(
+        upload_id="u2",
+        schedule=_schedule("PROJ-A", datetime(2026, 2, 1, tzinfo=timezone.utc)),
+        user_id="user-w2-test",
+    )
+    token = _make_token()
+    # Pre-skip: detect surfaces p1.
+    resp_before = client.post(
+        f"/api/v1/projects/{p2}/detect-revision-of",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp_before.json()["candidate_project_id"] == p1
+
+    # Record the skip.
+    client.post(
+        f"/api/v1/projects/{p2}/skip-revision-of",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"candidate_project_id": p1},
+    )
+
+    # Post-skip: detect filters out the candidate.
+    resp_after = client.post(
+        f"/api/v1/projects/{p2}/detect-revision-of",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    body = resp_after.json()
+    assert body["candidate_project_id"] is None
+    assert "skip" in body["reasoning"]
+
+
+def test_clear_revision_skips_returns_count(client: TestClient, fresh_store: InMemoryStore) -> None:
+    """Clear endpoint deletes all skips for the project + returns count."""
+    p1 = fresh_store.save_project(
+        upload_id="u1",
+        schedule=_schedule("PROJ-A", datetime(2026, 1, 1, tzinfo=timezone.utc)),
+        user_id="user-w2-test",
+    )
+    p2 = fresh_store.save_project(
+        upload_id="u2",
+        schedule=_schedule("PROJ-A", datetime(2026, 2, 1, tzinfo=timezone.utc)),
+        user_id="user-w2-test",
+    )
+    token = _make_token()
+    # Skip then clear.
+    client.post(
+        f"/api/v1/projects/{p2}/skip-revision-of",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"candidate_project_id": p1},
+    )
+    resp = client.post(
+        f"/api/v1/projects/{p2}/clear-revision-skips",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["project_id"] == p2
+    assert body["cleared_count"] == 1
+    # Idempotent: a second clear returns 0.
+    resp2 = client.post(
+        f"/api/v1/projects/{p2}/clear-revision-skips",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp2.json()["cleared_count"] == 0
+
+
+def test_detect_resurfaces_after_clear(client: TestClient, fresh_store: InMemoryStore) -> None:
+    """After clear-revision-skips, detect surfaces the candidate again
+    — the reconsider mechanism end-to-end."""
+    p1 = fresh_store.save_project(
+        upload_id="u1",
+        schedule=_schedule("PROJ-A", datetime(2026, 1, 1, tzinfo=timezone.utc)),
+        user_id="user-w2-test",
+    )
+    p2 = fresh_store.save_project(
+        upload_id="u2",
+        schedule=_schedule("PROJ-A", datetime(2026, 2, 1, tzinfo=timezone.utc)),
+        user_id="user-w2-test",
+    )
+    token = _make_token()
+    client.post(
+        f"/api/v1/projects/{p2}/skip-revision-of",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"candidate_project_id": p1},
+    )
+    # Skip filters detect.
+    assert (
+        client.post(
+            f"/api/v1/projects/{p2}/detect-revision-of",
+            headers={"Authorization": f"Bearer {token}"},
+        ).json()["candidate_project_id"]
+        is None
+    )
+    # Clear restores.
+    client.post(
+        f"/api/v1/projects/{p2}/clear-revision-skips",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert (
+        client.post(
+            f"/api/v1/projects/{p2}/detect-revision-of",
+            headers={"Authorization": f"Bearer {token}"},
+        ).json()["candidate_project_id"]
+        == p1
+    )
+
+
+def test_clear_revision_skips_404_on_missing_project(
+    client: TestClient, fresh_store: InMemoryStore
+) -> None:
+    token = _make_token()
+    resp = client.post(
+        "/api/v1/projects/nonexistent/clear-revision-skips",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["detail"]["error_code"] == "current_not_found"
+
+
+def test_skip_unauth_returns_401(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/projects/p1/skip-revision-of",
+        json={"candidate_project_id": "p2"},
+    )
+    assert resp.status_code == 401
+
+
+def test_clear_unauth_returns_401(client: TestClient) -> None:
+    resp = client.post("/api/v1/projects/p1/clear-revision-skips")
+    assert resp.status_code == 401
 
 
 def test_confirm_403_on_permission_denied(

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1409,6 +1409,44 @@ export async function confirmRevisionOf(
 }
 
 /**
+ * Record a revision-confirmation skip (Cycle 5 W3-E — issue #84).
+ *
+ * Idempotent: repeated calls with the same triple return ``recorded:
+ * false``. Triggers structured 4xx error_code on missing project /
+ * candidate / self-skip — frontend reads ``ApiError.errorCode``.
+ */
+export async function skipRevisionOf(
+	projectId: string,
+	candidateProjectId: string
+): Promise<{ project_id: string; candidate_project_id: string; recorded: boolean }> {
+	return request<{ project_id: string; candidate_project_id: string; recorded: boolean }>(
+		`/api/v1/projects/${projectId}/skip-revision-of`,
+		{
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ candidate_project_id: candidateProjectId })
+		}
+	);
+}
+
+/**
+ * Clear all revision-confirmation skips for a project + current user
+ * (Cycle 5 W3-E — issue #84). Reconsider mechanism: the project-detail
+ * page calls this when the user clicks "Confirm as revision of...".
+ *
+ * After clearing, a subsequent ``detectRevisionOf`` call re-surfaces
+ * the candidate the user previously skipped.
+ */
+export async function clearRevisionSkips(
+	projectId: string
+): Promise<{ project_id: string; cleared_count: number }> {
+	return request<{ project_id: string; cleared_count: number }>(
+		`/api/v1/projects/${projectId}/clear-revision-skips`,
+		{ method: 'POST' }
+	);
+}
+
+/**
  * Soft-tombstone a revision_history row + write paired audit_log entry.
  *
  * Idempotent — re-tombstone returns the existing tombstoned_at without

--- a/web/src/lib/components/RevisionConfirmCard.svelte
+++ b/web/src/lib/components/RevisionConfirmCard.svelte
@@ -218,7 +218,16 @@
 		}
 	}
 
+	let skipping = $state(false);
+
 	async function handleSkip(): Promise<void> {
+		// DA exit-council PR #118 P1 #2: disable the button during the
+		// in-flight skipRevisionOf to prevent double-click duplicate
+		// POSTs AND prevent parent dismount from racing the await
+		// continuation. The await completes (success or failure)
+		// BEFORE onSkipped fires + dismounts the component.
+		if (skipping) return;
+		skipping = true;
 		trackEvent('revision_skipped', {
 			project_id: projectId,
 			candidate_project_id: candidateProjectId
@@ -237,6 +246,9 @@
 			}
 		}
 		onSkipped?.();
+		// skipping intentionally NOT reset — onSkipped triggers dismount
+		// in the parent. If a future caller leaves the component mounted,
+		// they should reset skipping themselves.
 	}
 
 	// Issue #85 (DA P3-2 from PR #83): legacy ``iso.slice(0, 10)`` returned
@@ -324,7 +336,7 @@
 			<button
 				type="button"
 				onclick={handleSkip}
-				disabled={confirmState === 'submitting'}
+				disabled={confirmState === 'submitting' || skipping}
 				aria-describedby="revision-confirm-help"
 				class="px-3 py-1.5 text-sm rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800 text-gray-700 dark:text-gray-200 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-amber-500"
 			>

--- a/web/src/lib/components/RevisionConfirmCard.svelte
+++ b/web/src/lib/components/RevisionConfirmCard.svelte
@@ -36,7 +36,7 @@
 	// body + action row). Form pattern (props, $state, $derived, error
 	// surfacing) mirrors ``LifecycleOverrideDialog.svelte``.
 
-	import { ApiError, confirmRevisionOf, detectRevisionOf } from '$lib/api';
+	import { ApiError, confirmRevisionOf, detectRevisionOf, skipRevisionOf } from '$lib/api';
 	import { trackEvent } from '$lib/analytics';
 	import { locale, t } from '$lib/i18n';
 	import { formatDate } from '$lib/i18n/format';
@@ -218,11 +218,24 @@
 		}
 	}
 
-	function handleSkip(): void {
+	async function handleSkip(): Promise<void> {
 		trackEvent('revision_skipped', {
 			project_id: projectId,
 			candidate_project_id: candidateProjectId
 		});
+		// Cycle 5 W3-E (issue #84): record the skip server-side so detect
+		// stops surfacing this candidate. Reconsider via the project-detail
+		// page's "Confirm as revision of..." action which calls
+		// clear-revision-skips. Best-effort — if the skip-record call
+		// fails (network blip), we still call onSkipped so the UI dismisses
+		// the card; user can re-skip on next visit.
+		if (candidateProjectId) {
+			try {
+				await skipRevisionOf(projectId, candidateProjectId);
+			} catch (err) {
+				console.warn('skipRevisionOf failed (best-effort):', err);
+			}
+		}
 		onSkipped?.();
 	}
 

--- a/web/src/lib/components/RevisionConfirmCard.test.ts
+++ b/web/src/lib/components/RevisionConfirmCard.test.ts
@@ -48,6 +48,15 @@ vi.mock('$lib/api', async () => {
 			});
 		}),
 		confirmRevisionOf: confirmMock,
+		// Cycle 5 W3-E (issue #84): handleSkip now calls skipRevisionOf
+		// best-effort. No-op stub is safe — auto-collapse path doesn't
+		// hit Skip button, and the inaugural skip-button test is left
+		// to a follow-up.
+		skipRevisionOf: vi.fn(async () => ({
+			project_id: 'p',
+			candidate_project_id: 'c',
+			recorded: true,
+		})),
 	};
 });
 

--- a/web/src/lib/i18n/en.ts
+++ b/web/src/lib/i18n/en.ts
@@ -1335,6 +1335,9 @@ export default {
 	'revision.error_current_not_found': 'This project is no longer available. The card has been dismissed.',
 	'revision.error_parent_not_found': 'The candidate parent project is no longer available. The card has been dismissed.',
 	'revision.error_cross_program': 'Current and parent are not in the same program. Refresh the page or open a support ticket.',
+	'revision.reconsider_button': 'Confirm as revision of…',
+	'revision.reconsidering': 'Re-checking for revision matches…',
+	'revision.reconsider_no_prior_skip': 'No prior skip on this project — re-running detection.',
 
 	// Cycle 4 W3-B — multi-revision S-curve overlay (revision-trends page).
 	'revision_trends.subtitle': 'Multi-revision planned-completion overlay with executed-curve and CUSUM change-point markers (AACE RP 29R-03 §"Window analysis").',

--- a/web/src/lib/i18n/es.ts
+++ b/web/src/lib/i18n/es.ts
@@ -1333,6 +1333,9 @@ export default {
 	'revision.error_current_not_found': 'Este proyecto ya no está disponible. La tarjeta fue descartada.',
 	'revision.error_parent_not_found': 'El proyecto padre candidato ya no está disponible. La tarjeta fue descartada.',
 	'revision.error_cross_program': 'Actual y padre no están en el mismo programa. Recargue la página o abra un ticket de soporte.',
+	'revision.reconsider_button': 'Confirmar como revisión de…',
+	'revision.reconsidering': 'Re-verificando coincidencias de revisión…',
+	'revision.reconsider_no_prior_skip': 'Sin descarte previo en este proyecto — re-ejecutando detección.',
 
 	// Cycle 4 W3-B — superposición de S-curves multi-revisión (página revision-trends).
 	'revision_trends.subtitle': 'Superposición de S-curves de finalización planificada por revisión, con curva ejecutada y marcadores CUSUM de cambio de régimen (AACE RP 29R-03 §"Window analysis").',

--- a/web/src/lib/i18n/pt-BR.ts
+++ b/web/src/lib/i18n/pt-BR.ts
@@ -1333,6 +1333,9 @@ export default {
 	'revision.error_current_not_found': 'Este projeto não está mais disponível. O cartão foi descartado.',
 	'revision.error_parent_not_found': 'O projeto pai candidato não está mais disponível. O cartão foi descartado.',
 	'revision.error_cross_program': 'Atual e pai não estão no mesmo programa. Recarregue a página ou abra um chamado de suporte.',
+	'revision.reconsider_button': 'Confirmar como revisão de…',
+	'revision.reconsidering': 'Re-verificando correspondências de revisão…',
+	'revision.reconsider_no_prior_skip': 'Sem dispensa anterior neste projeto — re-executando detecção.',
 
 	// Cycle 4 W3-B — overlay de S-curves multi-revisão (página revision-trends).
 	'revision_trends.subtitle': 'Sobreposição de S-curves de conclusão planejada por revisão, com curva executada e marcadores CUSUM de mudança de regime (AACE RP 29R-03 §"Window analysis").',

--- a/web/src/routes/projects/[id]/+page.svelte
+++ b/web/src/routes/projects/[id]/+page.svelte
@@ -1,13 +1,17 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { page } from '$app/state';
-	import { getProject, getValidation, getCriticalPath, getFloatDistribution, getMilestones, getProjectHealth, getProjectAlerts, getDelayPrediction, generateReport, downloadReport, getAvailableReports, exportExcel, exportJSON, exportCSV } from '$lib/api';
+	import { getProject, getValidation, getCriticalPath, getFloatDistribution, getMilestones, getProjectHealth, getProjectAlerts, getDelayPrediction, generateReport, downloadReport, getAvailableReports, exportExcel, exportJSON, exportCSV, clearRevisionSkips } from '$lib/api';
+	import { t } from '$lib/i18n';
+	import { error as toastError, success } from '$lib/toast';
+	import { trackEvent } from '$lib/analytics';
 	import PieChart from '$lib/components/charts/PieChart.svelte';
 	import BarChart from '$lib/components/charts/BarChart.svelte';
 	import GaugeChart from '$lib/components/charts/GaugeChart.svelte';
 	import ScatterChart from '$lib/components/charts/ScatterChart.svelte';
 	import ScheduleViewer from '$lib/components/ScheduleViewer/ScheduleViewer.svelte';
 	import LifecyclePhaseCard from '$lib/components/LifecyclePhaseCard.svelte';
+	import RevisionConfirmCard from '$lib/components/RevisionConfirmCard.svelte';
 	import type { ScheduleViewData } from '$lib/components/ScheduleViewer/types';
 	import type {
 		ProjectDetailResponse,
@@ -54,6 +58,35 @@
 	let excelExporting = $state(false);
 	let exportDropdownOpen = $state(false);
 	let exportingFormat = $state('');
+
+	// Cycle 5 W3-E (issue #84): revision reconsider mechanism. When user
+	// clicks "Confirm as revision of...", clear the persistent skip log
+	// + mount the RevisionConfirmCard which re-runs detect (now without
+	// skip filter, so the previously-dismissed candidate resurfaces).
+	let revisionReconsiderShown = $state(false);
+	let revisionReconsiderLoading = $state(false);
+
+	async function handleReconsiderRevision(): Promise<void> {
+		revisionReconsiderLoading = true;
+		try {
+			const result = await clearRevisionSkips(projectId);
+			trackEvent('revision_reconsider_started', {
+				project_id: projectId,
+				cleared_count: result.cleared_count
+			});
+			if (result.cleared_count === 0) {
+				// No skips to clear — user gets the card mounted anyway so
+				// they can confirm or skip without prior history.
+				success($t('revision.reconsider_no_prior_skip'));
+			}
+			revisionReconsiderShown = true;
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			toastError(msg);
+		} finally {
+			revisionReconsiderLoading = false;
+		}
+	}
 
 	async function handleExcelExport() {
 		excelExporting = true;
@@ -407,6 +440,38 @@
 		<div class="mb-6">
 			<LifecyclePhaseCard {projectId} />
 		</div>
+
+		<!-- Revision Reconsider (Cycle 5 W3-E — issue #84):
+		     If the user previously skipped a revision-confirmation candidate
+		     for this project, the detect endpoint now filters that candidate
+		     out forever. The "Confirm as revision of..." button clears the
+		     skip log so a subsequent detect call resurfaces the suggestion. -->
+		{#if !revisionReconsiderShown}
+			<div class="mb-6">
+				<button
+					type="button"
+					onclick={handleReconsiderRevision}
+					disabled={revisionReconsiderLoading}
+					class="px-4 py-2 text-sm rounded border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-950/40 hover:bg-amber-100 dark:hover:bg-amber-900/40 text-amber-900 dark:text-amber-200 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-amber-500"
+				>
+					{revisionReconsiderLoading
+						? $t('revision.reconsidering')
+						: $t('revision.reconsider_button')}
+				</button>
+			</div>
+		{:else}
+			<div class="mb-6">
+				<RevisionConfirmCard
+					{projectId}
+					onConfirmed={() => {
+						revisionReconsiderShown = false;
+					}}
+					onSkipped={() => {
+						revisionReconsiderShown = false;
+					}}
+				/>
+			</div>
+		{/if}
 
 		<!-- Tabs -->
 		<div class="border-b border-gray-200 dark:border-gray-700 mb-6">


### PR DESCRIPTION
## Summary

Cycle 5 W3-E (LARGEST scope of W3). Closes #84 (DA P2-3 from PR #83 — no UI to reconsider after skipping revision-confirmation card).

Single-PR delivery per user choice. 875 insertions / 3 deletions across 12 files.

## Migration #029 — revision_skip_log

Per-user skip ledger with:
- `(project_id, candidate_project_id, user_id)` UNIQUE triple (idempotent re-skip)
- `CHECK (project_id <> candidate_project_id)` defends against self-skip
- RLS quadruple — DELETE is the load-bearing reconsider mechanism
- B-tree index `(project_id, user_id)` for the detect-filter hot path

⚠ **STAGING-FIRST APPLY required** (mirrors migration 028 ceremony per docstring).

## Backend

- `src/database/store.py` — 4 new methods on both `InMemoryStore` + `SupabaseStore`:
  - `record_revision_skip` (idempotent, raises ValueError on self-skip)
  - `is_revision_skipped` / `list_skipped_candidates`
  - `clear_revision_skips` (reconsider — returns deleted count)
- `src/api/routers/revisions.py`:
  - Detect endpoint **NEW filter**: returns no-candidate if heuristic suggestion is in skip log
  - 2 new endpoints: `POST skip-revision-of` + `POST clear-revision-skips`
- `src/api/schemas.py` — 3 new Pydantic models
- `tests/test_revisions_router.py` — 11 new regression tests

## Frontend

- `web/src/lib/api.ts` — `skipRevisionOf`, `clearRevisionSkips` with `ApiError` structured-error surfacing
- `web/src/lib/components/RevisionConfirmCard.svelte` — `handleSkip` now calls `skipRevisionOf` best-effort
- `web/src/routes/projects/[id]/+page.svelte` — "Confirm as revision of…" button. Click clears skips for current project + mounts RevisionConfirmCard which re-runs detect (without skip filter)
- 3 new i18n keys × 3 locales

## Test plan

- [x] `python -m pytest tests/ -q` — 1679 passed (+11 new), 6 skipped
- [x] `npx vitest run` — 58 passed (no regression)
- [x] `npm run check` — 0 errors / 0 warnings (671 files)
- [x] `npm run build` — clean
- [x] `ruff check + format` — clean
- [x] Frontend-ux-reviewer entry-council completed pre-impl
- [ ] DA exit-council per ADR-0018 Am.1 — runs at PR review time
- [ ] Operator: STAGING-FIRST migration apply before prod (mirrors 028 ceremony)

## What this does NOT include (deferred)

- Inaugural Vitest test for the Skip-button path (mock now includes `skipRevisionOf` stub; track as follow-up)
- Telemetry on "user clicked reconsider after skipping" — partially shipped (`revision_reconsider_started` event), full funnel deferred
- Migration of legacy pages' inline `formatDate` to `$lib/i18n/format` (out-of-scope per #85 PR description)

## Closes

- #84 — feat: path back from skip on project detail page

## Cross-refs

- ADR-0024 (Cycle 5 entry — W3 batch shape)
- ADR-0018 Am.1 (DA-as-second-reviewer)
- PR #83 (where DA originally flagged #84)
- Migration 028 (revision_history — RLS quadruple precedent)
- Issue #117 (typed-exception refactor follow-up from PR #116)