### PR TITLE
feat(cycle5-w4): hygiene wave — dep floors + 3 stub packages + dcma14 datetime fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,10 +44,24 @@ dependencies = [
 api = ["fastapi>=0.136", "uvicorn[standard]>=0.46", "slowapi>=0.1.9", "psutil>=5.9"]
 export = ["pandas>=2.2", "openpyxl>=3.1"]
 reports = ["weasyprint>=62.0"]
-ai = ["anthropic>=0.97"]
+ai = ["anthropic>=0.100"]
 ml = ["scikit-learn>=1.8"]
 mcp = ["mcp>=1.27"]
-dev = ["pytest>=9.0.3", "pytest-cov>=7.1", "ruff>=0.15.12", "mypy>=1.20", "httpx>=0.27", "slowapi>=0.1.9", "psutil>=5.9"]
+dev = [
+    "pytest>=9.0.3",
+    "pytest-cov>=7.1",
+    "ruff>=0.15.12",
+    "mypy>=1.20",
+    "httpx>=0.27",
+    "slowapi>=0.1.9",
+    "psutil>=5.9",
+    # Type stubs (Cycle 5 W4 hygiene). Reduces mypy --strict noise from
+    # untyped third-party imports without per-module ``# type: ignore``
+    # suppression.
+    "types-networkx>=3.6.1.20260508",
+    "types-openpyxl>=3.1.5.20260508",
+    "types-defusedxml>=0.7.0.20260504",
+]
 all = ["meridianiq[api,export,reports,ai,ml,mcp,dev]"]
 
 [tool.hatch.build.targets.wheel]

--- a/src/analytics/dcma14.py
+++ b/src/analytics/dcma14.py
@@ -93,6 +93,10 @@ class DCMA14Analyzer:
         self.schedule = schedule
         self.hours_per_day = hours_per_day
 
+        # Cycle 5 W4 hygiene: explicit attribute type so mypy --strict does
+        # not infer ``datetime`` from the first branch and reject the
+        # nullable assignments in the elif/else branches.
+        self.data_date: datetime | None
         if data_date:
             self.data_date = data_date
         elif schedule.projects:


### PR DESCRIPTION
## Summary

Cycle 5 W4 hygiene per ADR-0024.

### Dep floor bumps
- `anthropic`: 0.97 → 0.100 (current latest stable)

Other deps verified at current latest already (networkx 3.6, numpy 2.4, supabase 2.30, sentry-sdk 2.59, fastapi 0.136, pydantic 2.13, scikit-learn 1.8).

### Type stubs (NEW)
Added to `[dev]` extras to reduce mypy `--strict` noise:
- `types-networkx ≥ 3.6.1.20260508`
- `types-openpyxl ≥ 3.1.5.20260508`
- `types-defusedxml ≥ 0.7.0.20260504`

### dcma14 datetime fix
`DCMA14Analyzer.__init__` assigns `self.data_date` in 3 branches. mypy `--strict` inferred `datetime` from the first branch and rejected the nullable assignments in the others. Added explicit `self.data_date: datetime | None` annotation. **dcma14.py is now mypy `--strict` clean** at module level.

## Honest framing on the mypy strict count

The W4 memo target was "0 mypy `--strict` errors". Reality:

| | Pre-stubs | Post-stubs |
|---|---|---|
| Total errors | 306 | **350** |
| `import-untyped` | 12 | 4 (sklearn + weasyprint only) |
| `type-arg` | 92 | 97 (networkx generics now known) |
| `union-attr` | 22 | 53 (Optional returns now known) |
| `index` | 22 | 37 (networkx generic types now known) |

The **increase is expected hygiene** — stubs reveal substantive type issues that were previously masked. The W4 memo's "0 errors" target was over-optimistic; stubs uncover before they reduce.

Filed as **follow-up issue #121**: systematic mypy `--strict` cleanup across 5 categories, ≈ 5 incremental PRs. ADR-0024 W4 closes as "stubs in place" milestone, NOT "0 errors achieved".

## Test plan

- [x] `python -m pytest tests/ -q` — 1679 passed, 6 skipped (no regression)
- [x] `ruff check + format` — clean
- [x] `mypy src/analytics/dcma14.py --strict` — clean at module level
- [x] CI green required before merge
- [ ] DA exit-council per ADR-0018 Am.1 — runs at PR review time
- [ ] Backend-reviewer entry-council N/A (this is a hygiene PR with no schema/semantic/wrapper changes; entry-council on dep floors + stubs is overkill per the rule)

## Closes

- Cycle 5 W4 hygiene scope (ADR-0024 success criterion 6/9)

## Cross-refs

- ADR-0024 (Cycle 5 entry — W4 scope)
- Issue #121 — systematic mypy strict cleanup follow-up
- `.claude/rules/backend.md` (mypy strict on public functions — already enforced via existing type hints)