### PR TITLE
fix(cycle6-prew0): security floor bumps + claude-sonnet-4-6 migration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,14 +36,14 @@ dependencies = [
     "python-dotenv>=1.2",
     "python-multipart",
     "sentry-sdk[fastapi]>=2.59",
-    "PyJWT[crypto]>=2.12",
+    "PyJWT[crypto]>=2.12.1",
     "defusedxml>=0.7",
 ]
 
 [project.optional-dependencies]
 api = ["fastapi>=0.136", "uvicorn[standard]>=0.46", "slowapi>=0.1.9", "psutil>=5.9"]
 export = ["pandas>=2.2", "openpyxl>=3.1"]
-reports = ["weasyprint>=62.0"]
+reports = ["weasyprint>=68.0"]
 ai = ["anthropic>=0.100"]
 ml = ["scikit-learn>=1.8"]
 mcp = ["mcp>=1.27"]

--- a/src/analytics/schedule_builder.py
+++ b/src/analytics/schedule_builder.py
@@ -60,7 +60,7 @@ User's project description:
 async def build_schedule(
     description: str,
     api_key: str | None = None,
-    model: str = "claude-sonnet-4-20250514",
+    model: str = "claude-sonnet-4-6",
 ) -> BuilderResult:
     """Build a schedule from a natural language project description.
 


### PR DESCRIPTION
## Summary

Bucket A from the 2026-05-17 45-day ecosystem scan — 3 P0 hygiene items resolved in one PR, **pre-W0 of Cycle 6** (Cycle 6 council not yet run; this is the unconditional security/deadline patch wave).

- `chore(deps)`: weasyprint>=68.0 + PyJWT>=2.12.1 — CVE-2025-68616 SSRF + CVE-2026-32597 crit-header bypass (both CVSS 7.5)
- `chore(api)`: schedule_builder default migrated from `claude-sonnet-4-20250514` (retired 2026-06-15) to `claude-sonnet-4-6`

## Issues closed

- Closes #126 — Claude model migration deadline 2026-06-15
- Closes #127 — weasyprint floor bump (CVE-2025-68616)
- Closes #128 — PyJWT floor bump (CVE-2026-32597)

## Entry-council findings (backend-reviewer)

Ran pre-edit per `feedback_entry_council_discipline.md` (mandatory on substantive scope, post-PR-#104 lesson). Verdict: proceed.

- Flagged `claude-sonnet-4-6` as potentially invalid — **RESOLVED** via Anthropic docs lookup. Literal is the current valid API ID for Sonnet 4.6 (same as existing prod usage in `src/analytics/nlp_query.py:192` and `tests/test_nlp_query.py:201,221`).
- Flagged WeasyPrint remote-URL surface — investigated `src/analytics/report_generator.py:1346` uses `HTML(string=...)` in-memory only. Defense-in-depth bump retained.
- Flagged PyJWT crit-bypass surface — `src/api/auth.py` uses explicit `algorithms=[...]` allowlist (mitigated at call site). Hygiene bump retained.

## Test plan

- [x] `pytest tests/test_schedule_builder.py tests/test_auth.py tests/test_export.py tests/test_nlp_query.py -q` → 50/50 pass locally
- [x] `ruff check` + `ruff format --check` clean on touched files
- [ ] CI full backend test suite
- [ ] CI frontend build (no frontend changes — should be no-op)
- [ ] **Production smoke test required pre-merge** (operator): one real Claude API call against `schedule_builder.build_schedule()` with a small description to confirm `claude-sonnet-4-6` returns parseable JSON. Current unit tests cover only the fallback path.

## Follow-ups (out of scope)

- Live integration test gated on `ANTHROPIC_API_KEY` env var for the Claude branch of `schedule_builder` (follow-up issue to file)
- 3 Dependabot moderate vulnerabilities on `main` reported on push (separate triage)
- DA exit-council on this PR per ADR-0018 Am.1 (will run before merge)

## Context

- Planning memo: `memory/project_v40_cycle_6_planning.md` §"Bucket A"
- 45-day ecosystem scan summary in PR-creating conversation