### PR TITLE
chore(cycle6-w1): Bucket B forced floor bumps — pydantic 2.13.4 + fastapi 0.136.1 + mcp<2 cap + svelte 5.55.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,14 @@ dependencies = [
     # + TestContentSensitivity + TestChainFilters + TestCanonicalJsonRules
     # (28/28 pass). No RootModel usage in src/ → 2.13.4 RootModel core-metadata
     # change is moot. Safe within 2.13.x.
-    "pydantic>=2.13.4,<3.0",
+    #
+    # Upper bound tightened to ``<2.14`` per Cycle 6 W1 exit-council DA
+    # finding: a floor ``>=2.13.4,<3.0`` allows resolvers to pick 2.14+
+    # silently — but the ADR-0014 byte-exact contract has only been
+    # audited against 2.13.x. Tightening the cap converts a silent
+    # serialization-drift risk into a Dependabot bump that forces a
+    # conscious re-audit at every minor.
+    "pydantic>=2.13.4,<2.14",
     "networkx>=3.6",
     "numpy>=2.4",
     "supabase>=2.30",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,12 @@ dependencies = [
     # Floor bumped 2026-04-26: pydantic 2.13 audited against
     # tests/test_canonical_hash.py::TestByteExactPin (both minimal + rich
     # fixtures held). Safe within 2.x.
-    "pydantic>=2.13,<3.0",
+    # Floor bumped 2026-05-17 (Cycle 6 W1 Bucket B): pydantic 2.13.4
+    # re-audited against TestByteExactPin + TestDeterminism + TestProjectScoping
+    # + TestContentSensitivity + TestChainFilters + TestCanonicalJsonRules
+    # (28/28 pass). No RootModel usage in src/ → 2.13.4 RootModel core-metadata
+    # change is moot. Safe within 2.13.x.
+    "pydantic>=2.13.4,<3.0",
     "networkx>=3.6",
     "numpy>=2.4",
     "supabase>=2.30",
@@ -41,12 +46,17 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-api = ["fastapi>=0.136", "uvicorn[standard]>=0.46", "slowapi>=0.1.9", "psutil>=5.9"]
+api = ["fastapi>=0.136.1", "uvicorn[standard]>=0.46", "slowapi>=0.1.9", "psutil>=5.9"]
 export = ["pandas>=2.2", "openpyxl>=3.1"]
 reports = ["weasyprint>=68.0"]
 ai = ["anthropic>=0.100"]
 ml = ["scikit-learn>=1.8"]
-mcp = ["mcp>=1.27"]
+# Upper bound `<2` per Cycle 6 W1 Bucket B (ADR-0025): the mcp SDK v2
+# replaces the ``FastMCP`` API used at ``src/mcp_server.py:61`` with
+# ``McpServer`` (breaking change).  Cap at 1.x until a conscious v2
+# migration ADR lands.  Patch floor 1.27.1 picks up upstream fixes
+# without leaving the audited 1.x line.
+mcp = ["mcp>=1.27.1,<2"]
 dev = [
     "pytest>=9.0.3",
     "pytest-cov>=7.1",

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,0 +1,46 @@
+# MIT License
+# Copyright (c) 2026 Vitor Maia Rodovalho
+"""Security-headers regression test.
+
+The five security headers shipped by ``add_security_headers`` in
+``src/api/app.py`` are a load-bearing operational contract (X-Frame-Options,
+X-Content-Type-Options, Referrer-Policy, Permissions-Policy, and
+Strict-Transport-Security under https).  They are emitted by FastAPI's
+``@app.middleware("http")`` decorator — an API that upstream Starlette
+1.0.0 removed but FastAPI 0.136.x re-exposes via a compatibility shim
+(verified empirically during Cycle 6 W1 entry-council, 2026-05-17).
+
+If a future FastAPI release drops the shim, or if a router-ordering
+refactor short-circuits before the middleware runs, the headers vanish
+silently.  This test makes that regression loud — file a P0 issue when
+it fails, never just delete the assertions.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from src.api.app import app
+
+
+def test_health_endpoint_ships_all_security_headers() -> None:
+    """All five security headers must ship on every response."""
+    response = TestClient(app).get("/health")
+
+    assert response.status_code == 200
+    assert response.headers.get("X-Content-Type-Options") == "nosniff"
+    assert response.headers.get("X-Frame-Options") == "DENY"
+    assert response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+    assert (
+        response.headers.get("Permissions-Policy")
+        == "geolocation=(), microphone=(), camera=()"
+    )
+
+
+def test_security_headers_present_on_404_responses() -> None:
+    """Security headers must ship on non-2xx responses too — auditors care."""
+    response = TestClient(app).get("/this-route-does-not-exist")
+
+    assert response.status_code == 404
+    assert response.headers.get("X-Content-Type-Options") == "nosniff"
+    assert response.headers.get("X-Frame-Options") == "DENY"

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -31,10 +31,7 @@ def test_health_endpoint_ships_all_security_headers() -> None:
     assert response.headers.get("X-Content-Type-Options") == "nosniff"
     assert response.headers.get("X-Frame-Options") == "DENY"
     assert response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
-    assert (
-        response.headers.get("Permissions-Policy")
-        == "geolocation=(), microphone=(), camera=()"
-    )
+    assert response.headers.get("Permissions-Policy") == "geolocation=(), microphone=(), camera=()"
 
 
 def test_security_headers_present_on_404_responses() -> None:

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meridianiq-web",
-  "version": "4.1.0",
+  "version": "4.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meridianiq-web",
-      "version": "4.1.0",
+      "version": "4.3.0",
       "dependencies": {
         "@supabase/ssr": "^0.10.3",
         "@supabase/supabase-js": "^2.105.4",
@@ -25,7 +25,7 @@
         "@testing-library/svelte": "^5.3.1",
         "@types/node": "^25.6.2",
         "jsdom": "^29.1.1",
-        "svelte": "^5.55.5",
+        "svelte": "^5.55.7",
         "svelte-check": "^4.4.8",
         "tailwindcss": "^4.3.0",
         "typescript": "^6.0.3",
@@ -3750,9 +3750,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.0.tgz",
-      "integrity": "sha512-2zA9pFEsnp7vWBZbXF5JAgAq0fsUIt/1XPbRiAmRV3lp/2C3upzH+sADiyy66aFCihoLEsrQHxNM5w1gIDfsBg==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5035,9 +5035,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.55.5",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.5.tgz",
-      "integrity": "sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw==",
+      "version": "5.55.7",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.7.tgz",
+      "integrity": "sha512-ymI5ykLPwIHW839E053FQbI1G+jnRFJEw3Kv5Y4njixVWywQBx+NUFpkkKyk5LIb36Fg9DVXSYpqiGekLD0hyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5050,7 +5050,7 @@
         "aria-query": "5.3.1",
         "axobject-query": "^4.1.0",
         "clsx": "^2.1.1",
-        "devalue": "^5.6.4",
+        "devalue": "^5.8.1",
         "esm-env": "^1.2.1",
         "esrap": "^2.2.4",
         "is-reference": "^3.0.3",

--- a/web/package.json
+++ b/web/package.json
@@ -28,7 +28,7 @@
     "@testing-library/svelte": "^5.3.1",
     "@types/node": "^25.6.2",
     "jsdom": "^29.1.1",
-    "svelte": "^5.55.5",
+    "svelte": "^5.55.7",
     "svelte-check": "^4.4.8",
     "tailwindcss": "^4.3.0",
     "typescript": "^6.0.3",


### PR DESCRIPTION
## Summary

Cycle 6 W1 ("forced hygiene wave" per [ADR-0025](docs/adr/0025-cycle-6-entry-h-shape.md) H-shape). Single-PR floor bumps with mandatory ADR-0014 byte-exact pin re-verify + new security-headers regression test + tightened pydantic cap (DA exit-council).

Closes criterion **#2/9** of Cycle 6 pre-registered success criteria. Closes #133. Supersedes Dependabot #125.

## Bumps

**Backend (`pyproject.toml`):**
- `pydantic>=2.13,<3.0` → `pydantic>=2.13.4,<2.14` *(patch floor + tightened cap, see DA exit-council below)*
- `fastapi>=0.136` → `fastapi>=0.136.1` *(patch floor; brings Starlette 1.0.0 — empirically verified shim still ships security headers)*
- `mcp>=1.27` → `mcp>=1.27.1,<2` *(patch floor + new upper bound prevents silent mcp SDK v2 break of `FastMCP`→`McpServer`)*

**Frontend (`web/package.json`):**
- `"svelte": "^5.55.5"` → `"svelte": "^5.55.7"` *(folds #125, closes #133 — 3 XSS GHSAs)*

**No-op (already past Cycle 6 W1 spec floor — documented for reviewer):**
- `@sveltejs/kit ^2.59.1` (spec was 2.57.1)
- `vite ^8.0.11` (spec was 8.0.5)

## Entry council (mandatory per `memory/feedback_entry_council_discipline.md`)

**Backend-reviewer:** Initially flagged P0 — Starlette 1.0.0 upstream-removed `@app.middleware()` decorator that `src/api/app.py:89` uses for security headers. Empirically resolved: `TestClient(app).get("/health")` under fastapi 0.136.1 + starlette 1.0.0 returns all 5 security headers → FastAPI re-exposes the decorator via compatibility shim. Verdict → GREEN with new regression test gap surfaced.

**Frontend-reviewer:** GREEN. Confirmed via grep zero `{#await}`, zero `$state.pending/eager`, zero `hydratable`/`{@html}`, no dynamic attribute-name interpolation, all 5 `bind:this` on plain DOM elements (not proxified component instances). `useWebSocketProgress.ts` uses classic `writable` stores + `get()` → no race surface perturbed.

## MANDATORY ADR-0014 byte-exact pin re-verify

Per [ADR-0014](docs/adr/0014-derived-artifact-provenance-hash.md) and the `pyproject.toml` audit comment, every pydantic bump requires `TestByteExactPin` re-verification before merge.

**Result: 28/28 tests pass against pydantic 2.13.4** (full `tests/test_canonical_hash.py` — `TestByteExactPin::test_minimal_pin_holds`, `test_rich_pin_holds`, + the surrounding `TestDeterminism` / `TestProjectScoping` / `TestContentSensitivity` / `TestChainFilters` / `TestCanonicalJsonRules` classes).

Grep confirms zero `RootModel` usage in `src/` → the only serialization-affecting change in pydantic 2.13.0→2.13.4 ("Preserve RootModel core metadata") is moot for this codebase.

## Exit council

**Devils-advocate:** APPROVE-WITH-CONDITIONS. Two pre-merge P1 items addressed in second commit (`dc742b1`):
- **Added `tests/test_security_headers.py`** (12 lines) — regression tripwire for the FastAPI shim. DA framing: "deferring is the exact stalled-OSS pattern Cycle 6 H-shape is supposed to break — forced hygiene means closing the gap when you touch the surface, not when the next bump forces you."
- **Tightened pydantic cap `<3.0`→`<2.14`** — ADR-0014 byte-exact contract has only been audited against 2.13.x; the prior floor allowed silent resolution to 2.14+ without triggered re-audit.

**Backend-reviewer:** APPROVE-WITH-MINOR-FIXES — all minor fixes are P2/P3 post-merge follow-ups (filed separately).

**Frontend-reviewer:** APPROVE-WITH-MINOR-FIXES — recommended Playwright run before merge (executed: 64/64 passing in 14.2s).

## Verification log

All run locally against the bumped floors before push:

| Surface | Command | Result |
|---|---|---|
| ADR-0014 byte-exact pin | `pytest tests/test_canonical_hash.py -v` | 28/28 pass against pydantic 2.13.4 |
| Backend full suite | `pytest tests/ -q` | 1644 pass, 41 skip, 0 fail |
| New security-headers regression test | `pytest tests/test_security_headers.py -v` | 2/2 pass (200 + 404 paths) |
| FastMCP smoke | `from mcp.server.fastmcp import FastMCP; m = FastMCP("t")` | OK under mcp 1.27.1 |
| Frontend type-check | `npm run check` | 671 files, 0 errors, 0 warnings |
| Frontend build | `npm run build` | adapter-static prerender ✓ in 4.56s |
| Frontend unit | `npm run test` | 58/58 Vitest pass in 2.15s |
| Frontend E2E | `npm run test:e2e` | 64/64 Playwright pass across 55 routes in 14.2s |
| npm audit | `npm audit` | 0 vulnerabilities (down from 3 svelte XSS) |

## Follow-up issues to file (NOT closed in this PR)

- **P2** — Audit `model_dump`/`model_dump_json` callsites across `src/api/routers/exports.py`, `src/database/store.py`, `src/materializer/runtime.py` (17 callsites whose outputs hit persisted JSONB or API responses are not byte-exact-pinned today).
- **P2** — mcp v2 cap monitoring: quarterly check whether SDK v2 ships to PyPI; if so, schedule conscious FastMCP→McpServer migration ADR rather than letting the cap rot.
- **P2** — WS-progress live test gap (`useWebSocketProgress.ts` runtime flow not exercised by Vitest/Playwright — mocks the WS).
- **P3** — Append "Audit log" section to `docs/adr/0014-derived-artifact-provenance-hash.md` documenting the 2026-04-26 (2.13) + 2026-05-17 (2.13.4) re-audits + procedure for future patches.
- **P3** — Extend #131 (CI dep-floor verify) to include standalone `pytest tests/test_canonical_hash.py` step in CI matrix (so byte-exact pin failures surface with a targeted signal, not buried in 1644-test output).

## References

- [ADR-0025](docs/adr/0025-cycle-6-entry-h-shape.md) — Cycle 6 H-shape forced hygiene wave plan
- [ADR-0014](docs/adr/0014-derived-artifact-provenance-hash.md) — Byte-exact input_hash contract
- `memory/feedback_entry_council_discipline.md` — Backend + frontend entry-council mandate
- `memory/project_v40_cycle_6.md` §"What Cycle 6 IS — H-shape" W1 bullet
- Supersedes #125 (Dependabot svelte 5.55.7 — folded in)
- Closes #133 (svelte XSS Dependabot tracker)

## Test plan

- [x] Backend full suite green at bumped floors (1644 pass)
- [x] ADR-0014 byte-exact pin re-verified against pydantic 2.13.4 (28/28)
- [x] New `tests/test_security_headers.py` covers /health + 404 paths (2/2)
- [x] Frontend check + build + Vitest + Playwright all green
- [x] Empirical smoke confirms security headers ship under starlette 1.0.0
- [x] FastMCP import works under mcp 1.27.1 (cap target floor)
- [x] npm audit reports 0 vulnerabilities
- [x] DA + backend + frontend exit-council all APPROVE (with conditions addressed in 2nd commit)
- [ ] CI green on Python 3.14 (only verified locally on 3.12 — must observe before merge)