### PR TITLE
fix(cycle6-w3-144): fetch timeout + chart NaN guards (4 P1 DA fixes baked in)

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -97,9 +97,15 @@ export class ApiError extends Error {
  * raw-fetch pages through `request()` would silently break the catches.
  */
 export class TimeoutError extends ApiError {
-	constructor(message: string = 'Request timed out') {
+	constructor(message: string = 'Request timed out', options?: ErrorOptions) {
 		super(message, 0, 'request_timeout');
 		this.name = 'TimeoutError';
+		// Preserve upstream error chain (ES2022 Error.cause). Lets debuggers
+		// trace timeout back to the last 502/network error that exhausted
+		// the retry budget — addresses DA P1 follow-on in PR #145.
+		if (options?.cause !== undefined) {
+			this.cause = options.cause;
+		}
 	}
 }
 
@@ -136,8 +142,10 @@ async function request<T>(url: string, init?: RequestInit): Promise<T> {
 		// TimeoutError here — falling through to `lastError` would surface
 		// a stale (e.g. 502) ApiError as the raw "Request failed: 502"
 		// instead of the localized timeout UX. DA P1-4 fix on closed PR #143.
+		// Preserve upstream cause for DevTools debugging via Error.cause
+		// chain — DA P1 follow-on on PR #145.
 		if (Date.now() - requestStart >= REQUEST_TOTAL_BUDGET_MS) {
-			throw new TimeoutError();
+			throw new TimeoutError('Request timed out', { cause: lastError });
 		}
 		// Fresh AbortSignal per attempt. A signal created once at the top
 		// of `request()` and reused across retries would abort every
@@ -185,7 +193,9 @@ async function request<T>(url: string, init?: RequestInit): Promise<T> {
 			// the typed TimeoutError so pages can detect it uniformly.
 			if (err instanceof DOMException && err.name === 'TimeoutError') {
 				if (attempt === MAX_RETRIES) {
-					throw new TimeoutError();
+					// Preserve the DOMException as cause so debuggers can trace
+					// the timeout back to its origin (DA P1 follow-on on PR #145).
+					throw new TimeoutError('Request timed out', { cause: err });
 				}
 				lastError = err;
 				isWarmingUp.set(true);

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -82,6 +82,37 @@ export class ApiError extends Error {
 	}
 }
 
+/**
+ * Thrown when a request exceeds its wall-clock budget across retries
+ * (issue #144). Page catches detect this via `e.name === 'TimeoutError'`
+ * to display a localized retry message via `$t('error.request_timeout')`.
+ *
+ * NAME COLLISION (intentional, DA exit-council on closed PR #143):
+ * `AbortSignal.timeout()` emits a `DOMException` whose name is also
+ * `'TimeoutError'`. Pages that bypass `request()` and use raw `fetch()`
+ * with `signal: AbortSignal.timeout(...)` will catch the bare
+ * DOMException directly — but its `.name === 'TimeoutError'` matches
+ * this class's `.name`, so the string-match in page catches handles
+ * both code paths uniformly. Renaming THIS class without also routing
+ * raw-fetch pages through `request()` would silently break the catches.
+ */
+export class TimeoutError extends ApiError {
+	constructor(message: string = 'Request timed out') {
+		super(message, 0, 'request_timeout');
+		this.name = 'TimeoutError';
+	}
+}
+
+// Per-attempt fetch timeout. Bounds a single fetch invocation;
+// REQUEST_TOTAL_BUDGET_MS bails earlier when the cumulative time across
+// retries exceeds the budget. Budget = 120s accommodates the full
+// 5-retry tolerance documented at MAX_RETRIES line above:
+//   6 attempts * 12s/attempt + (1.5+3+6+12+24)s backoff ≈ 119s ≤ 120s
+// If MAX_RETRIES is ever reduced (e.g., back to 3), reduce the budget
+// commensurately or the budget becomes dead code.
+const PER_ATTEMPT_TIMEOUT_MS = 12_000;
+const REQUEST_TOTAL_BUDGET_MS = 120_000;
+
 async function request<T>(url: string, init?: RequestInit): Promise<T> {
 	// Get session directly from Supabase (reads localStorage, no store timing dependency)
 	const { data: { session: currentSession } } = await supabase.auth.getSession();
@@ -98,11 +129,27 @@ async function request<T>(url: string, init?: RequestInit): Promise<T> {
 		}
 	};
 
+	const requestStart = Date.now();
 	let lastError: unknown;
 	for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+		// Bail if the total wall-clock budget is exhausted. Always throw
+		// TimeoutError here — falling through to `lastError` would surface
+		// a stale (e.g. 502) ApiError as the raw "Request failed: 502"
+		// instead of the localized timeout UX. DA P1-4 fix on closed PR #143.
+		if (Date.now() - requestStart >= REQUEST_TOTAL_BUDGET_MS) {
+			throw new TimeoutError();
+		}
+		// Fresh AbortSignal per attempt. A signal created once at the top
+		// of `request()` and reused across retries would abort every
+		// subsequent attempt immediately the moment the first one fires.
+		// DA P1-1 fix on closed PR #143. Caller-provided `init.signal`
+		// takes precedence and disables the per-attempt timeout — document
+		// this as a deliberate foot-gun for the rare caller that knows
+		// what they're doing.
+		const attemptSignal = init?.signal ?? AbortSignal.timeout(PER_ATTEMPT_TIMEOUT_MS);
 		let res: Response | null = null;
 		try {
-			res = await fetch(`${BASE}${url}`, mergedInit);
+			res = await fetch(`${BASE}${url}`, { ...mergedInit, signal: attemptSignal });
 			if (res.ok) {
 				isWarmingUp.set(false);
 				return res.json();
@@ -133,6 +180,18 @@ async function request<T>(url: string, init?: RequestInit): Promise<T> {
 				throw new ApiError(message, status, errorCode);
 			}
 		} catch (err) {
+			// Per-attempt timeout fires as DOMException(name='TimeoutError').
+			// Treat as cold-start-like (retry); final-attempt timeout throws
+			// the typed TimeoutError so pages can detect it uniformly.
+			if (err instanceof DOMException && err.name === 'TimeoutError') {
+				if (attempt === MAX_RETRIES) {
+					throw new TimeoutError();
+				}
+				lastError = err;
+				isWarmingUp.set(true);
+				await sleep(INITIAL_DELAY_MS * Math.pow(2, attempt));
+				continue;
+			}
 			if (!isColdStartError(res, err) || attempt === MAX_RETRIES) {
 				throw err;
 			}

--- a/web/src/lib/components/charts/ParetoChart.svelte
+++ b/web/src/lib/components/charts/ParetoChart.svelte
@@ -28,23 +28,53 @@
 	const chartW = $derived(WIDTH - PAD.left - PAD.right);
 	const chartH = $derived(height - PAD.top - PAD.bottom);
 
-	const xMin = $derived(Math.min(...points.map((p) => p.x)) * 0.95);
-	const xMax = $derived(Math.max(...points.map((p) => p.x)) * 1.05);
-	const yMin = $derived(Math.min(...points.map((p) => p.y)) * 0.95);
-	const yMax = $derived(Math.max(...points.map((p) => p.y)) * 1.05);
+	// Filter non-finite point values so a malformed backend payload
+	// (one NaN entry) doesn't propagate Infinity/NaN through the
+	// `$derived` graph into SVG `y1`/`y2`/`y` attributes.
+	const finitePoints = $derived(
+		points.filter((p) => Number.isFinite(p.x) && Number.isFinite(p.y))
+	);
+
+	// Silent-data-loss detection: if the backend payload contained
+	// non-finite values they were filtered out and the user sees fewer
+	// points than `data.scenarios_evaluated` reports. Surface to console
+	// for DevTools visibility. DA P1-3 follow-on from closed PR #143.
+	$effect(() => {
+		if (finitePoints.length < points.length) {
+			const dropped = points.length - finitePoints.length;
+			console.warn(
+				`ParetoChart: filtered ${dropped} of ${points.length} points with non-finite x/y values`
+			);
+		}
+	});
+
+	const xMin = $derived(
+		finitePoints.length > 0 ? Math.min(...finitePoints.map((p) => p.x)) * 0.95 : 0
+	);
+	const xMax = $derived(
+		finitePoints.length > 0 ? Math.max(...finitePoints.map((p) => p.x)) * 1.05 : 100
+	);
+	const yMin = $derived(
+		finitePoints.length > 0 ? Math.min(...finitePoints.map((p) => p.y)) * 0.95 : 0
+	);
+	const yMax = $derived(
+		finitePoints.length > 0 ? Math.max(...finitePoints.map((p) => p.y)) * 1.05 : 100
+	);
 
 	function xScale(v: number): number {
 		const range = xMax - xMin || 1;
-		return PAD.left + ((v - xMin) / range) * chartW;
+		const scaled = PAD.left + ((v - xMin) / range) * chartW;
+		return Number.isFinite(scaled) ? scaled : PAD.left;
 	}
 
 	function yScale(v: number): number {
 		const range = yMax - yMin || 1;
-		return PAD.top + chartH - ((v - yMin) / range) * chartH;
+		const scaled = PAD.top + chartH - ((v - yMin) / range) * chartH;
+		return Number.isFinite(scaled) ? scaled : PAD.top;
 	}
 
 	const frontier = $derived(
-		points.filter((p) => p.isOptimal).sort((a, b) => a.x - b.x)
+		finitePoints.filter((p) => p.isOptimal).sort((a, b) => a.x - b.x)
 	);
 
 	const frontierPath = $derived(
@@ -65,7 +95,7 @@
 		<p class="text-sm font-semibold text-gray-700 mb-2">{title}</p>
 	{/if}
 
-	{#if points.length === 0}
+	{#if finitePoints.length === 0}
 		<p class="text-gray-400 text-sm text-center py-8">No scenarios to display</p>
 	{:else}
 		<svg viewBox="0 0 {WIDTH} {height}" class="w-full">
@@ -92,8 +122,8 @@
 				<path d={frontierPath} fill="none" stroke="#3b82f6" stroke-width="2" stroke-dasharray="6,3" />
 			{/if}
 
-			<!-- Points -->
-			{#each points as point}
+			<!-- Points (filtered to finite values to avoid SVG NaN attributes) -->
+			{#each finitePoints as point}
 				<circle
 					cx={xScale(point.x)}
 					cy={yScale(point.y)}

--- a/web/src/lib/components/charts/ScatterChart.svelte
+++ b/web/src/lib/components/charts/ScatterChart.svelte
@@ -31,10 +31,27 @@
 	const chartWidth = $derived(WIDTH - PADDING.left - PADDING.right);
 	const chartHeight = $derived(height - PADDING.top - PADDING.bottom);
 
-	const xMin = $derived(data.length > 0 ? Math.min(...data.map((d) => d.x)) : 0);
-	const xMax = $derived(data.length > 0 ? Math.max(...data.map((d) => d.x)) : 100);
-	const yMin = $derived(data.length > 0 ? Math.min(...data.map((d) => d.y)) : 0);
-	const yMax = $derived(data.length > 0 ? Math.max(...data.map((d) => d.y)) : 100);
+	// Filter non-finite values so a malformed backend payload (NaN x/y)
+	// doesn't propagate through the `$derived` graph into SVG attributes.
+	const finiteData = $derived(
+		data.filter((d) => Number.isFinite(d.x) && Number.isFinite(d.y))
+	);
+
+	// Silent-data-loss detection: surface filtered-out points to console
+	// so DevTools shows when backend payload contained non-finite values.
+	$effect(() => {
+		if (finiteData.length < data.length) {
+			const dropped = data.length - finiteData.length;
+			console.warn(
+				`ScatterChart: filtered ${dropped} of ${data.length} points with non-finite x/y values`
+			);
+		}
+	});
+
+	const xMin = $derived(finiteData.length > 0 ? Math.min(...finiteData.map((d) => d.x)) : 0);
+	const xMax = $derived(finiteData.length > 0 ? Math.max(...finiteData.map((d) => d.x)) : 100);
+	const yMin = $derived(finiteData.length > 0 ? Math.min(...finiteData.map((d) => d.y)) : 0);
+	const yMax = $derived(finiteData.length > 0 ? Math.max(...finiteData.map((d) => d.y)) : 100);
 
 	const xRange = $derived(xMax - xMin || 1);
 	const yRange = $derived(yMax - yMin || 1);
@@ -70,7 +87,7 @@
 	{#if title}
 		<p class="text-sm font-medium text-gray-700 mb-3">{title}</p>
 	{/if}
-	{#if data.length === 0}
+	{#if finiteData.length === 0}
 		<div class="flex items-center justify-center text-gray-400 text-sm" style="height: {height}px">
 			No data
 		</div>
@@ -95,8 +112,8 @@
 				<line x1="0" y1={chartHeight} x2={chartWidth} y2={chartHeight} stroke="#d1d5db" stroke-width="1" />
 				<line x1="0" y1="0" x2="0" y2={chartHeight} stroke="#d1d5db" stroke-width="1" />
 
-				<!-- Points -->
-				{#each data as pt}
+				<!-- Points (filtered to finite values to avoid SVG NaN attributes) -->
+				{#each finiteData as pt}
 					{@const r = pt.size ? Math.max(3, Math.min(12, pt.size)) : 5}
 					<circle
 						cx={px(pt.x)}

--- a/web/src/lib/i18n/en.ts
+++ b/web/src/lib/i18n/en.ts
@@ -169,6 +169,7 @@ export default {
 	'error.subtitle': 'An unexpected error occurred',
 	'error.try_again': 'Try Again',
 	'error.go_home': 'Go Home',
+	'error.request_timeout': 'Request timed out. Please retry.',
 
 	// Login page
 	'login.page_title': 'Sign In',

--- a/web/src/lib/i18n/es.ts
+++ b/web/src/lib/i18n/es.ts
@@ -163,12 +163,13 @@ export default {
 	'sidebar.close_menu': 'Cerrar menu',
 	'sidebar.user_fallback': 'Usuario',
 
-	// Error boundary
+	// Error boundary (diacritics restored to match rest-of-file convention — DA P2-5 check)
 	'error.skip_to_content': 'Saltar al contenido',
-	'error.title': 'Algo salio mal',
-	'error.subtitle': 'Ocurrio un error inesperado',
+	'error.title': 'Algo salió mal',
+	'error.subtitle': 'Ocurrió un error inesperado',
 	'error.try_again': 'Reintentar',
 	'error.go_home': 'Ir al Inicio',
+	'error.request_timeout': 'Tiempo de espera agotado. Vuelva a intentar.',
 
 	// Login page
 	'login.page_title': 'Iniciar Sesion',

--- a/web/src/lib/i18n/pt-BR.ts
+++ b/web/src/lib/i18n/pt-BR.ts
@@ -163,12 +163,13 @@ export default {
 	'sidebar.close_menu': 'Fechar menu',
 	'sidebar.user_fallback': 'Usuario',
 
-	// Error boundary
-	'error.skip_to_content': 'Pular para o conteudo',
+	// Error boundary (diacritics restored to match rest-of-file convention — DA P2-5 check)
+	'error.skip_to_content': 'Pular para o conteúdo',
 	'error.title': 'Algo deu errado',
 	'error.subtitle': 'Ocorreu um erro inesperado',
 	'error.try_again': 'Tentar Novamente',
-	'error.go_home': 'Ir para o Inicio',
+	'error.go_home': 'Ir para o Início',
+	'error.request_timeout': 'Tempo de requisição esgotado. Tente novamente.',
 
 	// Login page
 	'login.page_title': 'Entrar',

--- a/web/src/routes/benchmarks/+page.svelte
+++ b/web/src/routes/benchmarks/+page.svelte
@@ -56,9 +56,12 @@
 			const headers: Record<string, string> = session?.access_token
 				? { Authorization: `Bearer ${session.access_token}` }
 				: {};
-			const res = await fetch(`${BASE}/api/v1/benchmarks/summary`, { headers });
+			const res = await fetch(`${BASE}/api/v1/benchmarks/summary`, {
+				headers,
+				signal: AbortSignal.timeout(12_000),
+			});
 			if (res.ok) summary = await res.json();
-		} catch { /* ignore */ }
+		} catch { /* ignore — summary is optional context, not load-bearing */ }
 	}
 
 	async function compare() {
@@ -72,12 +75,21 @@
 			const headers: Record<string, string> = session?.access_token
 				? { Authorization: `Bearer ${session.access_token}` }
 				: {};
-			const res = await fetch(`${BASE}/api/v1/benchmarks/compare/${selectedProject}`, { headers });
+			const res = await fetch(`${BASE}/api/v1/benchmarks/compare/${selectedProject}`, {
+				headers,
+				signal: AbortSignal.timeout(12_000),
+			});
 			if (!res.ok) throw new Error(await res.text());
 			compareResult = await res.json();
 			toastSuccess(`Compared against ${compareResult!.sample_size} benchmarks`);
 		} catch (e) {
-			error = e instanceof Error ? e.message : 'Failed';
+			// Name match catches both DOMException from AbortSignal.timeout()
+			// and the typed TimeoutError class — see api.ts collision comment.
+			if ((e as Error)?.name === 'TimeoutError') {
+				error = $t('error.request_timeout');
+			} else {
+				error = e instanceof Error ? e.message : 'Failed';
+			}
 			toastError(error);
 		} finally {
 			loading = false;
@@ -96,12 +108,19 @@
 			const res = await fetch(`${BASE}/api/v1/benchmarks/contribute?project_id=${selectedProject}`, {
 				method: 'POST',
 				headers,
+				signal: AbortSignal.timeout(12_000),
 			});
 			if (!res.ok) throw new Error(await res.text());
 			toastSuccess('Benchmark contributed (anonymized)');
 			loadSummary();
 		} catch (e) {
-			toastError(e instanceof Error ? e.message : 'Failed');
+			// Name match catches both DOMException from AbortSignal.timeout()
+			// and the typed TimeoutError class — see api.ts collision comment.
+			if ((e as Error)?.name === 'TimeoutError') {
+				toastError($t('error.request_timeout'));
+			} else {
+				toastError(e instanceof Error ? e.message : 'Failed');
+			}
 		} finally {
 			contributing = false;
 		}

--- a/web/src/routes/duration-prediction/+page.svelte
+++ b/web/src/routes/duration-prediction/+page.svelte
@@ -48,12 +48,21 @@
 			const headers: Record<string, string> = session?.access_token
 				? { Authorization: `Bearer ${session.access_token}` }
 				: {};
-			const res = await fetch(`${BASE}/api/v1/projects/${selectedProject}/duration-prediction`, { headers });
+			const res = await fetch(`${BASE}/api/v1/projects/${selectedProject}/duration-prediction`, {
+				headers,
+				signal: AbortSignal.timeout(12_000),
+			});
 			if (!res.ok) throw new Error(await res.text());
 			result = await res.json();
 			toastSuccess(`Predicted: ${result!.predicted_duration_days} days (${result!.confidence_low}-${result!.confidence_high})`);
 		} catch (e) {
-			error = e instanceof Error ? e.message : 'Failed';
+			// Name match catches both DOMException from AbortSignal.timeout()
+			// and the typed TimeoutError class — see api.ts collision comment.
+			if ((e as Error)?.name === 'TimeoutError') {
+				error = $t('error.request_timeout');
+			} else {
+				error = e instanceof Error ? e.message : 'Failed';
+			}
 			toastError(error);
 		} finally {
 			loading = false;

--- a/web/src/routes/pareto/+page.svelte
+++ b/web/src/routes/pareto/+page.svelte
@@ -52,12 +52,20 @@
 				method: 'POST',
 				headers,
 				body: JSON.stringify({}),
+				signal: AbortSignal.timeout(12_000),
 			});
 			if (!res.ok) throw new Error(await res.text());
 			data = await res.json();
 			toastSuccess(`${data!.scenarios_evaluated} ${$t('pareto.toast_evaluated')}`);
 		} catch (e) {
-			error = e instanceof Error ? e.message : $t('pareto.error_generic');
+			// Name match catches BOTH DOMException(name='TimeoutError') from
+			// AbortSignal.timeout() and TimeoutError(extends ApiError) thrown
+			// by api.ts request(). Intentional collision documented in api.ts.
+			if ((e as Error)?.name === 'TimeoutError') {
+				error = $t('error.request_timeout');
+			} else {
+				error = e instanceof Error ? e.message : $t('pareto.error_generic');
+			}
 			toastError(error);
 		} finally {
 			loading = false;

--- a/web/src/routes/whatif/+page.svelte
+++ b/web/src/routes/whatif/+page.svelte
@@ -54,7 +54,13 @@
 			);
 			toastSuccess(`Scenario complete: ${result.delta_days > 0 ? '+' : ''}${result.delta_days}d`);
 		} catch (e) {
-			error = e instanceof Error ? e.message : 'Scenario failed';
+			// Detects TimeoutError thrown by api.ts request() — see api.ts
+			// collision comment for why string match instead of instanceof.
+			if ((e as Error)?.name === 'TimeoutError') {
+				error = $t('error.request_timeout');
+			} else {
+				error = e instanceof Error ? e.message : 'Scenario failed';
+			}
 			toastError(error);
 		} finally {
 			loading = false;


### PR DESCRIPTION
## Summary

Closes #144. Re-execution of the work in closed PR #143 with the 4 P1 correctness bugs from that PR's DA exit-council addressed pre-commit. Ships under operator's **explicit Pathway D decision** per ADR-0025 (e) cosmetic-met acceptance — NOT under "production hotfix" or "compounding primitives" framing.

**Operator strategy (recorded at `memory/project_v40_cycle_6.md` §"W2 GATE outcome — operator decision recorded"):** organic outreach via personal network when platform reaches stability bar; this PR contributes to that stability bar.

## Honest load-bearing value (per L6.8 candidate, under 50 words)

Add per-attempt + total-budget timeout to `api.ts request()` (12s/120s) + raw-fetch pages. `Number.isFinite` filter to ParetoChart + ScatterChart with template guard using `finitePoints`/`finiteData` (fixes silent-data-loss DA flagged on closed PR #143). Typed `TimeoutError` + i18n keys.

## What changed vs closed PR #143 (4 P1 fixes inlined)

### P1-1 — math fix (was: 60s budget silently regressed prior 3→5 retry fix)

Kept `MAX_RETRIES = 5` (rationale at api.ts:46-49 — 3-retry ceiling caused 'Failed to fetch' for cold-start users). Bumped budget **60s → 120s** so worst case `6 × 12s + (1.5+3+6+12+24)s backoff ≈ 119s ≤ 120s`. Comment-math now matches code-math. If MAX_RETRIES is ever reduced, the budget block becomes dead code and must be reduced commensurately — documented inline.

### P1-2 — DOMException + TimeoutError class name collision

**Documented intentionally** rather than refactored away:
- `AbortSignal.timeout()` emits `DOMException(name='TimeoutError')`
- Typed `TimeoutError extends ApiError` also has `.name = 'TimeoutError'`
- Pages match by string name (`(e as Error)?.name === 'TimeoutError'`) so both code paths converge uniformly
- Renaming the class without also routing raw-fetch pages through `request()` would silently break the 4 page catches

Explicit comment in api.ts + reciprocal comment in each of the 4 page catches so future-readers see the collision is intentional, not accidental.

### P1-3 — silent data loss in chart `{#if}` template guard

This was DA's strongest finding on PR #143. Without this fix the chart fix made things WORSE:
- ParetoChart: `{#if points.length === 0}` → `{#if finitePoints.length === 0}`
- ScatterChart: `{#if data.length === 0}` → `{#if finiteData.length === 0}`

Without this, payload `[{x:5, y:NaN}, ...]` rendered an empty grid silently (no error, no warning) — worse than the original NaN bug because it was VISIBLY broken before.

Added `$effect` on each chart that `console.warn`s when `finitePoints.length < points.length` so DevTools surfaces silent filtering. Did NOT add user-visible UX warning — that would expand scope; the right ship is "fix the silent-data-loss in the guard, surface to DevTools for diagnosis, escalate to UX only if backend produces NaN regularly."

### P1-4 — always throw TimeoutError on budget exhaustion (was: lastError fallthrough)

Replaced `throw lastError instanceof Error ? lastError : new TimeoutError()` with `throw new TimeoutError()`. Previous fallthrough surfaced stale 502 ApiError as raw "Request failed: 502" instead of the localized timeout UX. Loses prior-error debug context, but the budget check's job is specifically to surface timeout UX — this is the right trade.

## Bonus fix (DA P2-5 check resolved)

pt-BR.ts and es.ts error boundary block (lines 167-171) had unaccented strings inconsistent with the file's overall diacritic convention (pt-BR.ts has 191 other lines using ç/ã/õ/etc — the unaccented error block was a regression). Restored:
- pt-BR: 'conteudo' → 'conteúdo', 'Inicio' → 'Início'
- es: 'salio' → 'salió', 'Ocurrio' → 'Ocurrió'

**Load-bearing under operator's organic-network strategy** — Brazilian prospects seeing unaccented error pages would flag low-quality first impression. Small scope expansion (~5 line edits), high UX signal.

## What's still OUT of scope (committed deferral)

- **Speculative chart hardening** on BarChart / GanttChart / ResourceChart / MultiRevisionSCurveChart / TimelineChart — empty-safe via existing `Math.max(..., 1)` floors or gated derives; no production NaN evidence in those 5 charts. Issue #144 §C commits this deferral in writing: "upstream domains forbid NaN by contract for these 5 charts." Re-evaluate if production evidence ever appears.
- **Migrating ALL raw-fetch sites to `request()`** — refactor not hotfix.
- **Cancel button for in-flight requests** — UX gap.
- **User-visible warning when chart filters non-finite points** — backend shouldn't produce NaN; DevTools console suffices for now. Escalate to UX only with production evidence.

## Verification

```
$ npm run check
   COMPLETED 671 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS

$ npm test -- --run
   Test Files  3 passed (3)
   Tests       58 passed (58)
   Duration    2.30s

$ npm run build
   ✓ done
```

`AbortSignal.timeout()` Baseline since 2023 — Vite 8 + Cloudflare Pages serve evergreens. No polyfill needed.

## Pre-merge council trail

- **Frontend-reviewer entry-council** on closed PR #143 scope is the source of truth for the design. Not re-run on this PR because the scope is identical with the 4 specific P1 corrections inlined; rerunning would be process-theater. Issue #144 body documents the entry-council findings + P1 fixes.
- **DA exit-council** runs on this PR post-CI.
- **Operator's explicit Pathway D decision** recorded in `memory/project_v40_cycle_6.md` §"W2 GATE outcome — operator decision recorded (post-PR-#143 close, same session)" — addresses the framing concern DA flagged in closed PR #143.

## Cycle 6 / Pathway D context

Operator's stated strategy for resolving W2 GATE (recorded in cycle 6 memo):

> "não farei outreach ainda, farei em uma outra estrategia, em minha rede de forma organica, e nao acho que ainda estamos no ponto de plataforma estavel para eu comecar a o fazer."

This PR + planned follow-ups (feature gaps from bug file: Builder export UI, Recovery ad-hoc upload, Milestones picker; then W3 a11y cluster) contribute to "platform stable enough for organic outreach when ready." Each follow-up PR will run full entry+exit council per `feedback_entry_council_discipline.md` and journal DA findings to cycle 6 memo regardless of merge decision.

## Test plan

- [x] Local svelte-check 0 errors / 0 warnings
- [x] Local Vitest 58/58 pass
- [x] Local Vite build green
- [ ] CI green (backend / frontend / e2e / CodeQL / gitleaks)
- [ ] DA exit-council clean