### PR TITLE
feat(cycle6-w3): milestones picker via HTML5 datalist (refs #146)

### DIFF
--- a/web/src/routes/milestones/+page.svelte
+++ b/web/src/routes/milestones/+page.svelte
@@ -5,12 +5,13 @@
 		getValueMilestones,
 		createValueMilestone,
 		updateValueMilestone,
+		getMilestones,
 		type ValueMilestone,
 		type ValueMilestoneCreate
 	} from '$lib/api';
 	import { success, error as toastError } from '$lib/toast';
 	import { t, locale } from '$lib/i18n';
-	import type { ProjectListItem } from '$lib/types';
+	import type { ProjectListItem, MilestoneSchema } from '$lib/types';
 
 	const TYPE_KEYS: Record<string, string> = {
 		payment: 'milestones.type_payment',
@@ -30,6 +31,12 @@
 	let projects: ProjectListItem[] = $state([]);
 	let selectedProjectId = $state('');
 	let milestones: ValueMilestone[] = $state([]);
+	// Schedule milestones for the picker (populated alongside value-milestones).
+	// Drives the <datalist> bound to the task_code input — replaces typing
+	// from memory with a native HTML5 combobox. See issue filed for the
+	// WBS-tree picker follow-up (requires `MilestoneSchema.wbs_id` schema
+	// extension that's deferred from this PR).
+	let availableMilestones: MilestoneSchema[] = $state([]);
 	let loading = $state(true);
 	let milestonesLoading = $state(false);
 	let error = $state('');
@@ -75,19 +82,33 @@
 
 	async function loadMilestones() {
 		if (!selectedProjectId) return;
+		// Capture the project id at request time so a race (user changes
+		// project mid-fetch) doesn't write stale data into either array
+		// after `selectedProjectId` has already moved. Frontend-reviewer
+		// entry-council P0-1 on this PR.
+		const requestedId = selectedProjectId;
 		milestonesLoading = true;
 		try {
-			const res = await getValueMilestones(selectedProjectId);
-			milestones = res.milestones;
+			const [valueRes, scheduleRes] = await Promise.all([
+				getValueMilestones(requestedId),
+				getMilestones(requestedId),
+			]);
+			if (requestedId !== selectedProjectId) return;
+			milestones = valueRes.milestones;
+			availableMilestones = scheduleRes.milestones;
 		} catch (e: unknown) {
+			if (requestedId !== selectedProjectId) return;
 			toastError(e instanceof Error ? e.message : $t('milestones.load_milestones_failed'));
 		} finally {
-			milestonesLoading = false;
+			if (requestedId === selectedProjectId) {
+				milestonesLoading = false;
+			}
 		}
 	}
 
 	async function handleProjectChange() {
 		milestones = [];
+		availableMilestones = [];
 		editingId = null;
 		showForm = false;
 		await loadMilestones();
@@ -284,7 +305,18 @@
 				<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
 					<div>
 						<label for="task-code" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{$t('milestones.field_task_code')}</label>
-						<input id="task-code" type="text" bind:value={formData.task_code} class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" placeholder={$t('milestones.placeholder_task_code')} />
+						<input id="task-code" type="text" list="schedule-milestones-picker" bind:value={formData.task_code} class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" placeholder={$t('milestones.placeholder_task_code')} />
+						<!-- Native HTML5 combobox: type-ahead search + arrow affordance,
+						     falls back to free-text input on browsers without datalist UI.
+						     Auto-fill of task_name intentionally NOT implemented per
+						     frontend-reviewer entry-council P0-2 (the guard is wrong in
+						     both directions; datalist option content surfaces task_name
+						     as secondary text so users can read + copy). -->
+						<datalist id="schedule-milestones-picker">
+							{#each availableMilestones as m (m.task_id)}
+								<option value={m.task_code}>{m.task_name}</option>
+							{/each}
+						</datalist>
 					</div>
 					<div>
 						<label for="task-name" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{$t('milestones.field_task_name')}</label>

--- a/web/src/routes/milestones/+page.svelte
+++ b/web/src/routes/milestones/+page.svelte
@@ -40,6 +40,15 @@
 	let loading = $state(true);
 	let milestonesLoading = $state(false);
 	let error = $state('');
+	// Monotonic load-token. Each `loadMilestones()` call claims a fresh id;
+	// only the most-recent id is "active" — older calls (from rapid project
+	// switches OR project clears) detect they're stale via `loadId !==
+	// activeLoadId` and skip both data writes AND the spinner reset. Plain
+	// `let` (not `$state`) because no UI binding needs to observe it.
+	// DA P1 fix on PR #147 — prior `requestedId === selectedProjectId`
+	// check left `milestonesLoading=true` forever when user cleared the
+	// project mid-load (captured 'A' !== current '').
+	let activeLoadId = 0;
 
 	// Create form state
 	let showForm = $state(false);
@@ -82,25 +91,31 @@
 
 	async function loadMilestones() {
 		if (!selectedProjectId) return;
-		// Capture the project id at request time so a race (user changes
-		// project mid-fetch) doesn't write stale data into either array
-		// after `selectedProjectId` has already moved. Frontend-reviewer
-		// entry-council P0-1 on this PR.
+		// Capture both the project id (for the actual fetch) and a
+		// monotonic load-token (for stale-call detection). The token
+		// pattern handles BOTH project-switch (A → B) AND clear-project
+		// (A → '') cases — the prior `requestedId === selectedProjectId`
+		// check was correct for the data race but broken for the spinner
+		// state (DA P1 on PR #147 — spinner stuck true forever when user
+		// cleared the project mid-load because the early-return in the
+		// fresh call didn't touch the spinner and the old call's finally
+		// check failed).
 		const requestedId = selectedProjectId;
+		const loadId = ++activeLoadId;
 		milestonesLoading = true;
 		try {
 			const [valueRes, scheduleRes] = await Promise.all([
 				getValueMilestones(requestedId),
 				getMilestones(requestedId),
 			]);
-			if (requestedId !== selectedProjectId) return;
+			if (loadId !== activeLoadId) return;
 			milestones = valueRes.milestones;
 			availableMilestones = scheduleRes.milestones;
 		} catch (e: unknown) {
-			if (requestedId !== selectedProjectId) return;
+			if (loadId !== activeLoadId) return;
 			toastError(e instanceof Error ? e.message : $t('milestones.load_milestones_failed'));
 		} finally {
-			if (requestedId === selectedProjectId) {
+			if (loadId === activeLoadId) {
 				milestonesLoading = false;
 			}
 		}


### PR DESCRIPTION
## Summary

Cycle 6 W3 wave 2 — first feature gap from operator's 2026-05-17 production triage. Adds a native HTML5 `<datalist>` picker to the `/milestones` page's task_code input, fed by the existing `getMilestones()` API for the selected project. Replaces typing-from-memory with type-ahead combobox.

## Honest load-bearing value (per L6.8, <50 words)

Replace typing-task_code-from-memory with HTML5 datalist picker on the milestones page, fed by existing `getMilestones()` API. Native a11y + graceful-degradation fallback to free-text. P0 race-condition fix on project-change-during-load. WBS-tree alternative deferred to #146 with backend cost surfaced.

## Diff stat

```
 web/src/routes/milestones/+page.svelte | 42 ++++++++++++++++++++++++++++++----
 1 file changed, 37 insertions(+), 5 deletions(-)
```

Single file change. Zero new components. No API contract changes (uses existing `getMilestones(projectId)` endpoint and `MilestoneSchema` type).

## What this PR DOES

1. **Imports `getMilestones` + `MilestoneSchema`** from `$lib/api` and `$lib/types`.
2. **Adds `availableMilestones: MilestoneSchema[]` $state** to track the picker's data source.
3. **Refactors `loadMilestones()`** to load both endpoints in parallel via `Promise.all([getValueMilestones(), getMilestones()])`. Captures `requestedId = selectedProjectId` before await, checks after, so a race (user changes project mid-fetch) doesn't write stale data.
4. **Resets `availableMilestones = []`** in `handleProjectChange()` alongside `milestones = []` so the picker doesn't flash stale entries.
5. **Wires `list="schedule-milestones-picker"`** on the task_code input.
6. **Renders `<datalist id="schedule-milestones-picker">`** with one `<option value={m.task_code}>{m.task_name}</option>` per milestone, keyed by `m.task_id`.

## What this PR EXPLICITLY DOES NOT do

- **No auto-fill of task_name on task_code match.** Initial design proposed `$effect` for this; frontend-reviewer entry-council found the guard was broken in both directions (wipes manual edits OR fails to re-sync on code change). Decision: drop the auto-fill. Datalist option content already surfaces task_name as secondary text — users read + type or copy. Simpler + honest.
- **No WBS-tree picker.** Operator's quote named WBS-level as an alternative; filed as #146 with backend schema cost surfaced (`MilestoneSchema` has no `wbs_id` field — requires backend query join `task.wbs_id → projwbs` before any frontend tree component can be built).
- **No new i18n keys.** Helper text "Pick from existing milestones or type a code" would be marginal UX gain for 3 i18n keys; datalist's dropdown affordance is self-revealing. Frontend-reviewer endorsed skipping.
- **No new components.** HTML5 native primitive — works across all evergreens with graceful degradation.

## Pre-merge council trail

### Frontend-reviewer entry-council (pre-edit) — 3 P0s ALL ADDRESSED

1. **P0-1 (race condition):** Project-change-during-load could write stale data into `availableMilestones`. Fix: captured-id guard before assignment. **Applied** at `loadMilestones()` body.
2. **P0-2 (auto-fill task_name was broken in both directions):** Trace via reviewer found that `!task_name.trim()` guard wipes on first match AND fails to re-sync on legitimate code change. **Dropped** the auto-fill entirely per reviewer recommendation.
3. **P0-3 (WBS-tree deferral must be explicit):** Reviewer noted shipping project-level without acknowledging WBS-level reads as cherry-picking. **Filed** as #146 with backend schema cost surfaced (MilestoneSchema lacks wbs_id).

### DA exit-council
Pending on this PR post-CI. **Note for DA:** this is the 4th PR of an ~8h session — DA's biggest concern on PR #145 was the session-arc. This PR ships per operator's explicit Pathway D + "continuar" instruction plus stated sequence (#144 done → feature gaps → W3 a11y). Operator picked Milestones picker as the smallest-scope feature gap to fit session-arc concerns. DA should evaluate whether the smaller scope + explicit operator sequencing + 3 P0s addressed pre-edit are sufficient meta-defenses, or whether the session-arc concern persists.

## Local verification

```
$ npm run check
   COMPLETED 671 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS

$ npm test -- --run
   Test Files  3 passed (3)
   Tests       58 passed (58)
   Duration    4.94s

$ npm run build
   ✓ done
```

## Browser support

- Datalist Baseline since 2017. Universal support on evergreens.
- Safari iOS 17+: dropdown renders as tap-to-reveal sheet ✓
- Firefox desktop: keyboard nav (ArrowDown opens, Enter selects) ✓
- Firefox Android: historical gaps but degrades gracefully to free-text input ✓
- **Worst case is graceful degradation** — user types, no autocomplete, still works. Acceptable for admin form (not a hot path).

## Session-arc context

This is the 4th PR of an ~8h session (#142 30/70 merged → #143 40/60 closed → #145 50/50 merged → #147 this PR). Operator's explicit sequence (post-Pathway-D acceptance per ADR-0025 (e)): #144 done → feature gaps → W3 a11y. This PR is the first feature gap.

Operator chose **Milestones picker** specifically as the smallest-scope feature gap (~2-3h vs Builder export ~4-6h or Recovery upload ~3-4h) to fit session-arc concerns. PR diff stat confirms: 37 insertions / 5 deletions / 1 file — actually came in smaller than budgeted.

## Test plan

- [x] Local svelte-check 0 errors / 0 warnings
- [x] Local Vitest 58/58 pass
- [x] Local Vite build green
- [ ] CI green (backend / frontend / e2e / CodeQL / gitleaks)
- [ ] DA exit-council clean
- [ ] Manual smoke: navigate to /milestones, select a project that has milestones in its schedule, verify datalist dropdown appears on task_code focus

## Cycle 6 context

- Pre-registered success criteria progress: 3/9 closed (W2 GATE cosmetic-met via Pathway D ADR-0025 (e))
- Next in sequence (per operator + handoff memo): after this merges, feature gaps continue → Recovery ad-hoc upload OR Builder export UI OR W3 a11y cluster — operator decides

Refs #146.