### PR TITLE
feat(cycle6-w3): recovery ad-hoc scenario upload (5 entry-council fixes pre-edit)

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -245,8 +245,21 @@ export async function uploadXER(file: File, isSandbox: boolean = false): Promise
 	return request<ProjectSummary>('/api/v1/upload', { method: 'POST', body: form });
 }
 
-export async function getProjects(): Promise<ProjectListResponse> {
-	return request<ProjectListResponse>('/api/v1/projects');
+/**
+ * List the current user's projects. Sandbox-flagged projects are
+ * excluded by default (backend `include_sandbox=false`); pages that
+ * specifically need to surface sandbox projects (e.g. `/recovery` for
+ * hypothetical scenario uploads) pass ``includeSandbox=true``.
+ *
+ * DA P1-1 on PR #148: scenarios uploaded with ``isSandbox=true`` on
+ * the recovery page were invisible on next page reload because
+ * `getProjects` defaulted to filtering sandbox. Adding the parameter
+ * lets recovery (or other scenario-oriented pages) opt in without
+ * polluting the dropdowns on every other page.
+ */
+export async function getProjects(includeSandbox: boolean = false): Promise<ProjectListResponse> {
+	const qs = includeSandbox ? '?include_sandbox=true' : '';
+	return request<ProjectListResponse>(`/api/v1/projects${qs}`);
 }
 
 // Re-export commonly used schema types so consumer pages don't have to

--- a/web/src/lib/i18n/en.ts
+++ b/web/src/lib/i18n/en.ts
@@ -364,6 +364,11 @@ export default {
 	'recovery.col_activity': 'Activity',
 	'recovery.col_description': 'Description',
 	'recovery.all_pass': 'No issues found. Recovery schedule passed all validation checks.',
+	'recovery.or_upload_scenario': 'Or upload a hypothetical scenario file (.xer or .xml)',
+	'recovery.upload_processing': 'Uploading and processing scenario...',
+	'recovery.upload_invalid_format': 'Please select a .xer or .xml file',
+	'recovery.upload_failed': 'Scenario upload failed',
+	'recovery.processing_failed': 'Scenario processing failed',
 
 	// IPS Reconciliation page
 	'ips.subtitle': 'Verify consistency between a master schedule and sub-schedules. Per AACE Recommended Practice 71R-12.',

--- a/web/src/lib/i18n/es.ts
+++ b/web/src/lib/i18n/es.ts
@@ -364,6 +364,11 @@ export default {
 	'recovery.col_activity': 'Actividad',
 	'recovery.col_description': 'Descripcion',
 	'recovery.all_pass': 'No se encontraron problemas. El cronograma de recuperacion paso todas las verificaciones.',
+	'recovery.or_upload_scenario': 'O subir un archivo de escenario hipotético (.xer o .xml)',
+	'recovery.upload_processing': 'Subiendo y procesando escenario...',
+	'recovery.upload_invalid_format': 'Por favor seleccione un archivo .xer o .xml',
+	'recovery.upload_failed': 'Error al subir escenario',
+	'recovery.processing_failed': 'Error al procesar escenario',
 
 	// IPS Reconciliation page
 	'ips.subtitle': 'Verifica la consistencia entre un cronograma maestro y sub-cronogramas. Segun AACE Recommended Practice 71R-12.',

--- a/web/src/lib/i18n/pt-BR.ts
+++ b/web/src/lib/i18n/pt-BR.ts
@@ -364,6 +364,11 @@ export default {
 	'recovery.col_activity': 'Atividade',
 	'recovery.col_description': 'Descricao',
 	'recovery.all_pass': 'Nenhum problema encontrado. Cronograma de recuperacao passou em todas as verificacoes.',
+	'recovery.or_upload_scenario': 'Ou subir um arquivo de cenário hipotético (.xer ou .xml)',
+	'recovery.upload_processing': 'Subindo e processando cenário...',
+	'recovery.upload_invalid_format': 'Por favor selecione um arquivo .xer ou .xml',
+	'recovery.upload_failed': 'Falha ao subir cenário',
+	'recovery.processing_failed': 'Falha ao processar cenário',
 
 	// IPS Reconciliation page
 	'ips.subtitle': 'Verifica consistencia entre um cronograma mestre e sub-cronogramas. Conforme AACE Recommended Practice 71R-12.',

--- a/web/src/routes/recovery/+page.svelte
+++ b/web/src/routes/recovery/+page.svelte
@@ -2,11 +2,13 @@
 	import { onMount } from 'svelte';
 	import {
 		getProjects,
+		uploadXER,
 		validateRecovery,
 		type RecoveryValidationResult
 	} from '$lib/api';
+	import { useProjectStatusPolling } from '$lib/composables/useProjectStatusPolling';
 	import { t } from '$lib/i18n';
-	import type { ProjectListItem } from '$lib/types';
+	import type { ProjectListItem, ProjectSummary } from '$lib/types';
 	import AnalysisSkeleton from '$lib/components/AnalysisSkeleton.svelte';
 	import GaugeChart from '$lib/components/charts/GaugeChart.svelte';
 	import PieChart from '$lib/components/charts/PieChart.svelte';
@@ -18,6 +20,16 @@
 	let recoveryId = $state('');
 	let validating = $state(false);
 	let result: RecoveryValidationResult | null = $state(null);
+	// Ad-hoc scenario upload (operator's 2026-05-17 triage): users want
+	// to upload a hypothetical recovery XER/XML directly on this page
+	// rather than going through the upload page first. uploadXER returns
+	// 202 + pending status when async materialization is in flight; the
+	// global computingProjects store (driven by `useProjectStatusPolling`)
+	// polls until the project flips to ready or failed.
+	let uploading = $state(false);
+	let uploadError = $state('');
+	let activeUploadId = 0;
+	let pendingScenarioProject: ProjectSummary | null = $state(null);
 
 	onMount(async () => {
 		try {
@@ -29,6 +41,83 @@
 			loading = false;
 		}
 	});
+
+	// Reactive watcher: when an upload finishes its sync round-trip but
+	// the project is still 'pending', we set `pendingScenarioProject` and
+	// this effect subscribes via the composable. The composable handles
+	// its own `onDestroy` cleanup, so multiple back-to-back uploads leave
+	// stale watchers harmlessly attached until the component unmounts —
+	// the `activeUploadId` snapshot blocks stale callbacks from writing
+	// state, so the leak is bounded and side-effect-free.
+	$effect(() => {
+		const proj = pendingScenarioProject;
+		if (!proj) return;
+		const snapshotUploadId = activeUploadId;
+		useProjectStatusPolling(proj.project_id, {
+			onTerminal: (status) => {
+				if (snapshotUploadId !== activeUploadId) return;
+				if (proj !== pendingScenarioProject) return;
+				if (status === 'ready') {
+					appendAndSelectScenario(proj);
+				} else {
+					uploadError = $t('recovery.processing_failed');
+					uploading = false;
+				}
+				pendingScenarioProject = null;
+			},
+		});
+	});
+
+	function appendAndSelectScenario(proj: ProjectSummary) {
+		projects = [
+			...projects,
+			{
+				project_id: proj.project_id,
+				name: proj.name,
+				activity_count: proj.activity_count,
+				relationship_count: proj.relationship_count,
+				data_date: proj.data_date,
+				status: 'ready',
+			},
+		];
+		recoveryId = proj.project_id;
+		uploading = false;
+	}
+
+	async function handleScenarioUpload(event: Event) {
+		const input = event.target as HTMLInputElement;
+		const file = input.files?.[0];
+		if (!file) return;
+		// Pre-validate extension to avoid the backend 400 round-trip + an
+		// opaque error toast. Backend `upload.py` accepts only .xer / .xml.
+		const name = file.name.toLowerCase();
+		if (!name.endsWith('.xer') && !name.endsWith('.xml')) {
+			uploadError = $t('recovery.upload_invalid_format');
+			input.value = '';
+			return;
+		}
+		uploading = true;
+		uploadError = '';
+		const uploadId = ++activeUploadId;
+		try {
+			// Hypothetical scenarios → sandbox so they don't pollute the
+			// user's primary project list per entry-council S1.
+			const uploaded = await uploadXER(file, true);
+			if (uploadId !== activeUploadId) return;
+			if (uploaded.status === 'ready') {
+				appendAndSelectScenario(uploaded);
+			} else {
+				pendingScenarioProject = uploaded;
+			}
+		} catch (e: unknown) {
+			if (uploadId === activeUploadId) {
+				uploadError = e instanceof Error ? e.message : $t('recovery.upload_failed');
+				uploading = false;
+			}
+		} finally {
+			input.value = '';
+		}
+	}
 
 	async function runValidation() {
 		if (!impactedId || !recoveryId) return;
@@ -98,18 +187,39 @@
 				</label>
 				<label class="block">
 					<span class="text-sm font-medium text-gray-700 dark:text-gray-300">{$t('recovery.label_recovery')}</span>
-					<select bind:value={recoveryId} class="mt-1 block w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm">
+					<select bind:value={recoveryId} disabled={uploading} class="mt-1 block w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm">
 						<option value="">{$t('recovery.select_recovery')}</option>
 						{#each projects.filter(p => p.project_id !== impactedId) as p}
 							<option value={p.project_id}>{p.name || p.project_id} ({p.activity_count} {$t('recovery.act_suffix')})</option>
 						{/each}
 					</select>
+					<div class="mt-2">
+						<label class="block text-xs text-gray-600 dark:text-gray-400">
+							{$t('recovery.or_upload_scenario')}
+							<input
+								type="file"
+								accept=".xer,.xml"
+								onchange={handleScenarioUpload}
+								disabled={uploading || validating}
+								class="mt-1 block w-full text-xs file:mr-2 file:py-1 file:px-3 file:rounded file:border-0 file:text-xs file:font-medium file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100 disabled:opacity-50"
+								aria-busy={uploading}
+								aria-describedby="scenario-upload-status"
+							/>
+						</label>
+						<div id="scenario-upload-status" aria-live="polite">
+							{#if uploading}
+								<p class="text-xs text-blue-600 mt-1 animate-pulse">{$t('recovery.upload_processing')}</p>
+							{:else if uploadError}
+								<p class="text-xs text-red-600 mt-1">{uploadError}</p>
+							{/if}
+						</div>
+					</div>
 				</label>
 			</div>
 			<div class="mt-4">
 				<button
 					onclick={runValidation}
-					disabled={!impactedId || !recoveryId || validating}
+					disabled={!impactedId || !recoveryId || validating || uploading}
 					class="px-6 py-2.5 bg-blue-600 text-white text-sm font-semibold rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
 				>
 					{validating ? $t('recovery.btn_validating') : $t('recovery.btn_validate')}

--- a/web/src/routes/recovery/+page.svelte
+++ b/web/src/routes/recovery/+page.svelte
@@ -33,7 +33,13 @@
 
 	onMount(async () => {
 		try {
-			const res = await getProjects();
+			// Include sandbox-flagged projects so hypothetical recovery
+			// scenarios (uploaded with isSandbox=true via the inline file
+			// input below) remain visible in the dropdown across sessions.
+			// DA P1-1 on PR #148: scenarios were invisible on page reload
+			// without this opt-in. Other pages keep the default filtered
+			// view to avoid clutter.
+			const res = await getProjects(true);
 			projects = res.projects;
 		} catch {
 			error = $t('recovery.load_failed');


### PR DESCRIPTION
## Summary

Cycle 6 W3 wave 3 — second feature gap from operator's 2026-05-17 production triage. Adds inline file upload to `/recovery` page so users can simulate hypothetical recovery scenarios without leaving the page to upload through `/upload` first.

## Honest load-bearing value (per L6.8, <50 words)

Add file input alongside existing recovery dropdown. Upload via `uploadXER(file, isSandbox=true)`. Async materialization observed via existing `useProjectStatusPolling` composable; on terminal-ready auto-select as recoveryId, on terminal-failed surface i18n error. Reduces hypothetical-scenario friction.

## Diff stat (final, with fix-up)

```
 web/src/lib/api.ts                   |  14 +++-
 web/src/lib/i18n/en.ts               |   5 ++
 web/src/lib/i18n/es.ts               |   5 ++
 web/src/lib/i18n/pt-BR.ts            |   5 ++
 web/src/routes/recovery/+page.svelte | 128 +++++++++++++++++++++++++++++++++--
 5 files changed, 150 insertions(+), 7 deletions(-)
```

## What this PR DOES

1. Adds file input next to the existing recovery dropdown on `/recovery`. Accepts `.xer` and `.xml` (matches backend `upload.py:104-110`).
2. Pre-validates extension client-side to avoid backend 400 round-trip + opaque error toast.
3. Uploads file with `isSandbox=true` so scenarios don't pollute primary project list on other pages.
4. On upload terminal-ready (sync fast-path OR async via `useProjectStatusPolling`), appends new project to local `projects` array + auto-selects as `recoveryId`.
5. Extends `getProjects()` to accept `includeSandbox: boolean = false` parameter (DA P1-1 fix-up commit). Recovery page passes `true` so sandbox scenarios remain visible across sessions when user reloads the page; other pages keep default filtered behavior.
6. 5 i18n keys × 3 locales = 15 entries with proper pt-BR/es diacritics.
7. a11y: `aria-busy`, `aria-describedby`, `aria-live="polite"` on the upload status region.

## What this PR EXPLICITLY DOES NOT do

- **No manual polling** — uses council-blessed `useProjectStatusPolling` composable + `computingProjects` global aggregate store.
- **No backend changes** — extends a frontend api.ts function signature only; backend already supports `include_sandbox` query param.
- **No fix for the unaccented `recovery.*` pt-BR/es strings** ('recuperacao', 'Descricao', 'Atividade') — same diacritic regression as the error block fixed in PR #145. Out of scope.
- **No sandbox-filter UI on dropdown** — `include_sandbox=true` shows ALL sandbox projects on the recovery page (not just THIS user's scenarios). Acceptable for now; can be tightened later if dropdown clutter from old scenarios becomes a problem.
- **No cancel button for in-flight upload polling** — rare use case; not worth UX complexity.

## State machine notes

```ts
// $effect reactive scope: composable is meant to be called here, not in
// event handlers (per composable docstring). The effect re-runs when
// pendingScenarioProject changes.
$effect(() => {
    const proj = pendingScenarioProject;
    if (!proj) return;
    const snapshotUploadId = activeUploadId;
    useProjectStatusPolling(proj.project_id, {
        onTerminal: (status) => {
            if (snapshotUploadId !== activeUploadId) return;  // stale (newer upload)
            if (proj !== pendingScenarioProject) return;  // stale (paranoid)
            if (status === 'ready') {
                appendAndSelectScenario(proj);
            } else {
                uploadError = $t('recovery.processing_failed');
                uploading = false;
            }
            pendingScenarioProject = null;
        },
    });
});
```

`activeUploadId` counter pattern lifted directly from PR #147's spinner-state fix.

## Local verification

```
$ npm run check
   COMPLETED 671 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS

$ npm test -- --run
   Test Files  3 passed (3)
   Tests       58 passed (58)

$ npm run build
   ✓ done
```

## Pre-merge council trail

### Frontend-reviewer entry-council (pre-edit)
Caught 5 findings, all addressed pre-commit. **Detail moved to footnote below (DA P2 on PR #148: prominent display of process discipline read as inoculation framing).**

### DA exit-council (post-PR-open)
45/55 HOLD verdict + L6.12 SOFT FIRE on a NEW sub-variant ("process-discipline as visible artifact" — the prominent corrections-table in the PR body was preempting adversarial scrutiny). DA caught P1-1 (sandbox-invisibility on page reload) that entry-council missed because the prominent corrections display had lowered DA's P0-hunting vigilance.

DA's specific recommendation: *"Do not close PR; require the sandbox-invisibility fix (P1-1) PRE-merge and demote the corrections table to a footnote. Per ADR-0025 (d): amend the sycophancy-recurrence ADR to log 'meta-sycophancy via prominent entry-council-corrections table' as a banked sub-variant."*

Operator chose Fix-P1+demote+merge per DA recommendation. Fix-up commit `101c445` extends `getProjects()` with `includeSandbox` param; recovery page passes `true`. Corrections table demoted to this footer.

## Cycle 6 / session-arc context

5th PR of ~10h session. Trajectory: 30/70 → 40/60 (closed) → 50/50 → 45/55 → 45/55 (this PR HOLD). L6.12 soft fire on a NEW sub-variant pattern (process-display) journaled at `memory/project_v40_cycle_6.md` for Cycle 7 council. ADR-0025 (d) hard trigger NOT FIRED but threshold proximity persists.

Refs operator's organic-network strategy + Pathway D acceptance.

---

## Footnote: entry-council 5 findings detail (demoted per DA P2 on PR #148)

`.mspdi` accept dropped → backend rejects, would have shipped opaque 400. `useProjectStatusPolling` used instead of manual polling → council-blessed Cycle 1 W3 pattern. `isSandbox=true` added → primary list clean (paired with `include_sandbox=true` on getProjects via DA P1-1 fix-up). After-ready append-not-refetch → skip extra round-trip. `disabled={uploading}` on validate button + recovery dropdown → no stale-validation race.

## Test plan

- [x] Local svelte-check 0 errors / 0 warnings
- [x] Local Vitest 58/58 pass
- [x] Local Vite build green
- [x] CI green (initial PR + fix-up commit)
- [x] DA exit-council ran (45/55 HOLD, L6.12 soft fire); findings addressed (P1-1 fixed, table demoted)
- [ ] Manual smoke: /recovery → pick impacted → click file input → select .xer/.xml → wait → verify auto-select → validate → refresh page → verify scenario still in dropdown