### PR TITLE
feat(cycle6-w3): direction-aware change-point markers (#105 + refs #110)

### DIFF
--- a/web/src/lib/components/charts/MultiRevisionSCurveChart.svelte
+++ b/web/src/lib/components/charts/MultiRevisionSCurveChart.svelte
@@ -11,6 +11,7 @@
 		executedLabel?: string;
 		changePointLabel?: string;
 		legendCollapsedSummary?: (n: number) => string;
+		directionLabels?: { slip: string; improvement: string; flat: string };
 	}
 
 	let {
@@ -23,6 +24,7 @@
 		executedLabel = 'Executed',
 		changePointLabel = 'Change point',
 		legendCollapsedSummary = (n: number) => `${n} revisions — show legend`,
+		directionLabels = { slip: 'Slip', improvement: 'Improvement', flat: 'Flat' },
 	}: Props = $props();
 
 	// Mobile legend-collapse state (issue #97 part 2 / DA P2 #12 from PR #95).
@@ -195,6 +197,63 @@
 		return ticks;
 	});
 
+	// Direction → visual mapping. Color + dasharray both vary so the
+	// encoding is not color-only (WCAG 1.4.1). The dotted flat dasharray
+	// also disambiguates flat markers from the single-revision gray
+	// planned-curve fallback at line 167.
+	function directionVisual(direction: string): {
+		color: string;
+		darkStrokeClass: string;
+		darkFillClass: string;
+		dashArray: string;
+	} {
+		switch (direction) {
+			case 'slip':
+				return {
+					color: '#b45309',
+					darkStrokeClass: 'dark:stroke-amber-400',
+					darkFillClass: 'dark:fill-amber-400',
+					dashArray: '4 3',
+				};
+			case 'improvement':
+				return {
+					color: '#047857',
+					darkStrokeClass: 'dark:stroke-emerald-400',
+					darkFillClass: 'dark:fill-emerald-400',
+					dashArray: '2 2 6 2',
+				};
+			case 'flat':
+				return {
+					color: '#4b5563',
+					darkStrokeClass: 'dark:stroke-gray-400',
+					darkFillClass: 'dark:fill-gray-400',
+					dashArray: '1 3',
+				};
+			default:
+				// Unknown direction — likely a future backend value the frontend
+				// hasn't been updated for. Render flat-styled but log so the
+				// regression surfaces in Sentry breadcrumbs (auto-captured from
+				// console.warn) rather than failing silent.
+				// eslint-disable-next-line no-console
+				console.warn(
+					'[MultiRevisionSCurveChart] unknown change-point direction:',
+					direction,
+				);
+				return {
+					color: '#4b5563',
+					darkStrokeClass: 'dark:stroke-gray-400',
+					darkFillClass: 'dark:fill-gray-400',
+					dashArray: '1 3',
+				};
+		}
+	}
+
+	function directionLabelOf(direction: string): string {
+		if (direction === 'slip') return directionLabels.slip;
+		if (direction === 'improvement') return directionLabels.improvement;
+		return directionLabels.flat;
+	}
+
 	// Change-point markers — vertical lines positioned at the START
 	// (data_date) of the curve at `revision_index`, NOT at its planned-finish
 	// day. The CUSUM fires at the moment the new revision is detected to
@@ -207,9 +266,16 @@
 				const c = curves[cp.revision_index];
 				if (!c) return null;
 				const shift = curveShift(cp.revision_index);
+				const visual = directionVisual(cp.direction);
 				return {
 					x: xPos(0 + shift),
 					description: cp.description,
+					direction: cp.direction,
+					directionLabel: directionLabelOf(cp.direction),
+					strokeColor: visual.color,
+					darkStrokeClass: visual.darkStrokeClass,
+					darkFillClass: visual.darkFillClass,
+					dashArray: visual.dashArray,
 					// 1-based fallback aligning with endpointLabels at line 185
 					// + page changePointLabel function. Issue #98 item 5 +
 					// frontend-ux-reviewer entry-council BLOCKING #2 on PR #109:
@@ -367,27 +433,32 @@
 					{/if}
 				{/if}
 
-				<!-- Change-point vertical markers -->
+				<!-- Change-point vertical markers — direction-aware color + dasharray
+				     per issue #105. Color encodes direction (slip/improvement/flat),
+				     dasharray provides the non-color redundancy required by WCAG 1.4.1
+				     (frontend-ux-reviewer entry-council P1-1). `<title>` carries the
+				     direction word for AT users. -->
 				{#each changePointVisuals as cp}
 					<line
 						x1={cp.x}
 						y1="0"
 						x2={cp.x}
 						y2={chartH}
-						stroke="#dc2626"
+						stroke={cp.strokeColor}
+						class={cp.darkStrokeClass}
 						stroke-width="1"
-						stroke-dasharray="4 3"
+						stroke-dasharray={cp.dashArray}
 						opacity="0.55"
 					>
-						<title>{cp.revisionLabel}: {cp.description}</title>
+						<title>{cp.revisionLabel}: {cp.directionLabel} — {cp.description}</title>
 					</line>
 					<text
 						x={cp.x}
 						y="-6"
 						text-anchor="middle"
 						font-size="8"
-						fill="#dc2626"
-						class="dark:fill-red-400"
+						fill={cp.strokeColor}
+						class={cp.darkFillClass}
 					>
 						{cp.revisionLabel}
 					</text>
@@ -475,8 +546,7 @@
 				{#if changePointVisuals.length > 0}
 					<div class="flex items-center gap-1.5">
 						<span
-							class="inline-block w-3 h-px border-t border-dashed"
-							style="border-color: #dc2626"
+							class="inline-block w-3 h-px border-t border-dashed border-gray-500 dark:border-gray-400"
 						></span>
 						<span class="text-gray-600 dark:text-gray-400">{changePointLabel}</span>
 					</div>

--- a/web/src/lib/components/charts/MultiRevisionSCurveChart.test.ts
+++ b/web/src/lib/components/charts/MultiRevisionSCurveChart.test.ts
@@ -1,0 +1,158 @@
+// MIT License
+// Copyright (c) 2026 Vitor Maia Rodovalho
+
+// Direction-aware change-point marker encoding (issue #105). Vitest +
+// @testing-library/svelte. Three tests per frontend-ux-reviewer entry-
+// council P2-4 cap — one per direction, each asserting BOTH the color
+// (color channel) AND the stroke-dasharray (non-color channel required
+// by WCAG 1.4.1 — P1-1). The flat-at-last-revision edge case (P1-4)
+// folds into the flat test by placing the change point on the executed
+// revision.
+//
+// Out of scope: full chart-rendering snapshots, single-revision empty
+// state, legend collapse, calendar-alignment fallback, endpoint labels.
+// Each could merit its own test in a future hardening PR.
+
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import MultiRevisionSCurveChart from './MultiRevisionSCurveChart.svelte';
+import type { RevisionCurveSchema, ChangePointMarkerSchema } from '$lib/types';
+
+// jsdom does not implement window.matchMedia; the chart's mobile-legend
+// $effect at MultiRevisionSCurveChart.svelte:48 calls it unconditionally.
+// Stub once before tests with matches=false (desktop layout) — these tests
+// do NOT exercise the mobile-legend-collapse branch, so a flat stub is
+// sufficient.
+beforeAll(() => {
+	Object.defineProperty(window, 'matchMedia', {
+		writable: true,
+		value: vi.fn().mockImplementation((query: string) => ({
+			matches: false,
+			media: query,
+			onchange: null,
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			addListener: vi.fn(),
+			removeListener: vi.fn(),
+			dispatchEvent: vi.fn(),
+		})),
+	});
+});
+
+afterEach(() => cleanup());
+
+function curve(rev: number, dataDate: string, isExecuted = false): RevisionCurveSchema {
+	return {
+		project_id: 'proj-test',
+		revision_id: `rev-${rev}`,
+		revision_number: rev,
+		data_date: dataDate,
+		points: [
+			{
+				day_offset: 0,
+				planned_cumulative_pct: 0,
+				actual_cumulative_pct: isExecuted ? 0 : null,
+			},
+			{
+				day_offset: 60,
+				planned_cumulative_pct: 1,
+				actual_cumulative_pct: isExecuted ? 0.5 : null,
+			},
+		],
+		is_executed: isExecuted,
+	};
+}
+
+function changePoint(
+	revIdx: number,
+	direction: 'slip' | 'improvement' | 'flat',
+	delta: number,
+): ChangePointMarkerSchema {
+	return {
+		revision_index: revIdx,
+		revision_id: `rev-${revIdx + 1}`,
+		delta_days: delta,
+		cusum_value: 0,
+		direction,
+		description: `shift of ${delta} days vs prior revision`,
+	};
+}
+
+function markerLines(container: HTMLElement): SVGLineElement[] {
+	return Array.from(
+		container.querySelectorAll<SVGLineElement>('line[stroke-dasharray]'),
+	);
+}
+
+describe('MultiRevisionSCurveChart change-point direction encoding (issue #105)', () => {
+	it('renders slip markers with amber color (#b45309) and dasharray "4 3"', () => {
+		const { container } = render(MultiRevisionSCurveChart, {
+			props: {
+				curves: [curve(1, '2026-01-01'), curve(2, '2026-02-01')],
+				changePoints: [changePoint(1, 'slip', 40)],
+				directionLabels: { slip: 'Slip', improvement: 'Improvement', flat: 'Flat' },
+			},
+		});
+		const lines = markerLines(container);
+		expect(lines.length).toBe(1);
+		const marker = lines[0];
+		expect(marker.getAttribute('stroke')).toBe('#b45309');
+		expect(marker.getAttribute('stroke-dasharray')).toBe('4 3');
+		expect(marker.getAttribute('class')).toContain('dark:stroke-amber-400');
+		const title = marker.querySelector('title');
+		expect(title?.textContent).toContain('Slip');
+	});
+
+	it('renders improvement markers with emerald color (#047857) and dasharray "2 2 6 2"', () => {
+		const { container } = render(MultiRevisionSCurveChart, {
+			props: {
+				curves: [curve(1, '2026-01-01'), curve(2, '2026-02-01')],
+				changePoints: [changePoint(1, 'improvement', -20)],
+				directionLabels: { slip: 'Slip', improvement: 'Improvement', flat: 'Flat' },
+			},
+		});
+		const lines = markerLines(container);
+		expect(lines.length).toBe(1);
+		const marker = lines[0];
+		expect(marker.getAttribute('stroke')).toBe('#047857');
+		expect(marker.getAttribute('stroke-dasharray')).toBe('2 2 6 2');
+		expect(marker.getAttribute('class')).toContain('dark:stroke-emerald-400');
+		const title = marker.querySelector('title');
+		expect(title?.textContent).toContain('Improvement');
+	});
+
+	it('renders flat markers with gray color (#4b5563) and dotted dasharray "1 3" even on the executed revision (P1-4 fixture)', () => {
+		// Flat-at-last-revision edge case (frontend-ux-reviewer entry-council
+		// P1-4). Change point on the executed revision (R2). Two things to pin:
+		// (a) the marker attributes (color + dasharray + a11y title) so a
+		//     future refactor cannot silently drop the encoding; and
+		// (b) DOM source order — the marker `<line>` must appear AFTER the
+		//     executed-curve `<path stroke="#3b82f6">` so SVG painter-order
+		//     puts the marker on top. A swap of these two render blocks
+		//     would silently regress visibility.
+		const { container } = render(MultiRevisionSCurveChart, {
+			props: {
+				curves: [curve(1, '2026-01-01'), curve(2, '2026-02-01', true)],
+				changePoints: [changePoint(1, 'flat', 0)],
+				directionLabels: { slip: 'Slip', improvement: 'Improvement', flat: 'Flat' },
+			},
+		});
+		const lines = markerLines(container);
+		expect(lines.length).toBe(1);
+		const marker = lines[0];
+		expect(marker.getAttribute('stroke')).toBe('#4b5563');
+		expect(marker.getAttribute('stroke-dasharray')).toBe('1 3');
+		expect(marker.getAttribute('class')).toContain('dark:stroke-gray-400');
+		const title = marker.querySelector('title');
+		expect(title?.textContent).toContain('Flat');
+
+		// z-order pin: executed-curve path precedes marker in source order.
+		const executedPath = container.querySelector('path[stroke="#3b82f6"]');
+		expect(executedPath).not.toBeNull();
+		const cmp = marker.compareDocumentPosition(executedPath!);
+		// DOCUMENT_POSITION_PRECEDING bit set on the result of A.compare(B)
+		// means B precedes A in document order — i.e., the executed path
+		// renders BEFORE the marker, so the marker paints on top.
+		expect(cmp & Node.DOCUMENT_POSITION_PRECEDING).toBeTruthy();
+	});
+});

--- a/web/src/lib/i18n/en.ts
+++ b/web/src/lib/i18n/en.ts
@@ -1364,4 +1364,13 @@ export default {
 	'revision_trends.axis_not_calendar_disclosure': 'X-axis shows days from each revision\'s own data-date — revisions are NOT calendar-aligned. One or more curves is missing data_date metadata.',
 	'revision_trends.legend.collapsed_summary': '{n} revisions — show legend',
 	'revision_trends.multi_executed_warning': 'Backend invariant violated: more than one revision flagged is_executed=true. Chart renders only the latest. Report at github.com/VitorMRodovalho/meridianiq/issues.',
+
+	// Cycle 6 W3 wave 4 — issue #105 direction-aware change-point markers.
+	// Direction derives from sign(delta_days) of the local revision shift
+	// (NOT cumulative cusum_value) per ADR-0009 / DA P0 #1 fix on PR #104.
+	'revision_trends.direction.slip': 'Slip',
+	'revision_trends.direction.improvement': 'Improvement',
+	'revision_trends.direction.flat': 'Flat',
+	'revision_trends.direction_legend':
+		'Amber = slip (later finish), green = improvement (earlier finish), gray = flat (no change). Dash patterns repeat the encoding for color-blind readers.',
 } as Record<string, string>;

--- a/web/src/lib/i18n/es.ts
+++ b/web/src/lib/i18n/es.ts
@@ -1362,4 +1362,11 @@ export default {
 	'revision_trends.axis_not_calendar_disclosure': 'El eje X muestra días desde la data-date de cada revisión — las revisiones NO están alineadas por calendario. Una o más curvas no tiene el metadato data_date.',
 	'revision_trends.legend.collapsed_summary': '{n} revisiones — mostrar leyenda',
 	'revision_trends.multi_executed_warning': 'Invariante del backend violada: más de una revisión marcada is_executed=true. El gráfico muestra solo la más reciente. Reportar en github.com/VitorMRodovalho/meridianiq/issues.',
+
+	// Cycle 6 W3 wave 4 — issue #105 dirección de los puntos de cambio CUSUM.
+	'revision_trends.direction.slip': 'Atraso',
+	'revision_trends.direction.improvement': 'Mejora',
+	'revision_trends.direction.flat': 'Sin variación',
+	'revision_trends.direction_legend':
+		'Ámbar = atraso (finalización más tardía), verde = mejora (finalización más temprana), gris = sin variación. Los patrones de trazo repiten la codificación para lectores con daltonismo.',
 } as Record<string, string>;

--- a/web/src/lib/i18n/pt-BR.ts
+++ b/web/src/lib/i18n/pt-BR.ts
@@ -1362,4 +1362,11 @@ export default {
 	'revision_trends.axis_not_calendar_disclosure': 'O eixo X mostra dias a partir da data-status de cada revisão — as revisões NÃO estão alinhadas por calendário. Uma ou mais curvas está sem o metadado data_date.',
 	'revision_trends.legend.collapsed_summary': '{n} revisões — mostrar legenda',
 	'revision_trends.multi_executed_warning': 'Invariante de backend violada: mais de uma revisão sinalizada is_executed=true. O gráfico mostra apenas a mais recente. Reportar em github.com/VitorMRodovalho/meridianiq/issues.',
+
+	// Cycle 6 W3 wave 4 — issue #105 direção dos pontos de mudança CUSUM.
+	'revision_trends.direction.slip': 'Atraso',
+	'revision_trends.direction.improvement': 'Melhoria',
+	'revision_trends.direction.flat': 'Sem variação',
+	'revision_trends.direction_legend':
+		'Âmbar = atraso (término mais tarde), verde = melhoria (término mais cedo), cinza = sem variação. Os padrões de traço repetem a codificação para leitores com daltonismo.',
 } as Record<string, string>;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -980,6 +980,7 @@ export interface ChangePointMarkerSchema {
 	revision_id: string | null;
 	delta_days: number;
 	cusum_value: number;
+	direction: 'slip' | 'improvement' | 'flat';
 	description: string;
 }
 

--- a/web/src/lib/utils/revisionTrendsDirection.test.ts
+++ b/web/src/lib/utils/revisionTrendsDirection.test.ts
@@ -1,0 +1,32 @@
+// MIT License
+// Copyright (c) 2026 Vitor Maia Rodovalho
+
+// Unit test for the page list-row color helper. DA P0 #2 on Cycle 6
+// W3 wave 4: pinning the slip/improvement/flat → text-class mapping
+// here means a future PR that changes the chart marker hex set
+// without updating the list helper (or vice versa) will surface as
+// a test failure rather than a silent visual divergence.
+
+import { describe, expect, it } from 'vitest';
+import { directionTextClass } from './revisionTrendsDirection';
+
+describe('directionTextClass', () => {
+	it('maps slip to amber tokens', () => {
+		const cls = directionTextClass('slip');
+		expect(cls).toContain('text-amber-700');
+		expect(cls).toContain('dark:text-amber-400');
+	});
+
+	it('maps improvement to emerald tokens', () => {
+		const cls = directionTextClass('improvement');
+		expect(cls).toContain('text-emerald-700');
+		expect(cls).toContain('dark:text-emerald-400');
+	});
+
+	it('maps flat (and unknown values) to neutral gray', () => {
+		expect(directionTextClass('flat')).toContain('text-gray-600');
+		// Unknown direction string falls through to gray rather than
+		// erroring out — same defense the chart's directionVisual uses.
+		expect(directionTextClass('partial_recovery')).toContain('text-gray-600');
+	});
+});

--- a/web/src/lib/utils/revisionTrendsDirection.ts
+++ b/web/src/lib/utils/revisionTrendsDirection.ts
@@ -1,0 +1,23 @@
+// MIT License
+// Copyright (c) 2026 Vitor Maia Rodovalho
+
+// Direction → Tailwind text-class mapping for the /revision-trends
+// change-points list. Extracted from +page.svelte so it can be unit-
+// tested independently of the page render (DA P0 #2 on Cycle 6 W3
+// wave 4: the chart marker color was covered, the page list color
+// was not — schema-helper drift would have passed silently).
+//
+// Color tokens (amber-700/emerald-700/gray-600 light + amber-400/
+// emerald-400/gray-400 dark) match the chart marker hex set:
+//   slip       → amber-700 #b45309
+//   improvement → emerald-700 #047857
+//   flat        → gray-600 #4b5563
+// — verified WCAG-AA contrast against bg-white + bg-gray-900.
+// Unknown direction values fall through to neutral gray.
+
+export function directionTextClass(direction: string): string {
+	const base = 'font-medium min-w-12';
+	if (direction === 'slip') return `text-amber-700 dark:text-amber-400 ${base}`;
+	if (direction === 'improvement') return `text-emerald-700 dark:text-emerald-400 ${base}`;
+	return `text-gray-600 dark:text-gray-400 ${base}`;
+}

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -80,7 +80,7 @@
 				{ href: '/lookahead', labelKey: 'nav.lookahead', icon: 'M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z' },
 				{ href: '/calendar-validation', labelKey: 'nav.calendars', icon: 'M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z' },
 				{ href: '/float-trends', labelKey: 'nav.float_trends', icon: 'M7 12l3-3 3 3 4-4M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z' },
-				{ href: '/revision-trends', labelKey: 'nav.revision_trends', icon: 'M3 17l6-6 4 4 7-7M3 17h4m14-7v4' },
+				{ href: '/revision-trends', labelKey: 'nav.revision_trends', icon: 'M3 17l6-6 4 4 7-7M3 11l3-3 2 2 5-5' },
 				{ href: '/trends', labelKey: 'nav.trends', icon: 'M13 7h8m0 0v8m0-8l-8 8-4-4-6 6' },
 			],
 		},

--- a/web/src/routes/revision-trends/+page.svelte
+++ b/web/src/routes/revision-trends/+page.svelte
@@ -6,6 +6,7 @@
 	import { formatNumber } from '$lib/i18n/format';
 	import AnalysisSkeleton from '$lib/components/AnalysisSkeleton.svelte';
 	import MultiRevisionSCurveChart from '$lib/components/charts/MultiRevisionSCurveChart.svelte';
+	import { directionTextClass } from '$lib/utils/revisionTrendsDirection';
 
 	let projects = $state<{ project_id: string; name: string }[]>([]);
 	let selectedProject = $state<string>('');
@@ -77,6 +78,7 @@
 		if (c?.revision_number != null) return `R${c.revision_number}`;
 		return `#${cp.revision_index + 1}`;
 	}
+
 
 	// Client-side derived warnings — frontend-ux-reviewer entry-council
 	// SHOULD-FIX #6 + DA exit-council P1 #5 on PR #109: console.warn for
@@ -256,6 +258,11 @@
 				changePointLabel={$t('revision_trends.change_point_label')}
 				legendCollapsedSummary={(n) =>
 					$t('revision_trends.legend.collapsed_summary').replace('{n}', String(n))}
+				directionLabels={{
+					slip: $t('revision_trends.direction.slip'),
+					improvement: $t('revision_trends.direction.improvement'),
+					flat: $t('revision_trends.direction.flat'),
+				}}
 			/>
 
 			{#if isSingleRev && !hasExecuted}
@@ -274,13 +281,16 @@
 					<ul class="space-y-1">
 						{#each trends.change_points as cp}
 							<li class="text-sm text-gray-700 dark:text-gray-300 flex gap-2">
-								<span class="text-red-500 dark:text-red-400 font-medium min-w-12">
+								<span class={directionTextClass(cp.direction)}>
 									{changePointLabel(cp)}
 								</span>
 								<span>{cp.description}</span>
 							</li>
 						{/each}
 					</ul>
+					<p class="text-xs text-gray-500 dark:text-gray-400 mt-3 italic">
+						{$t('revision_trends.direction_legend')}
+					</p>
 				</div>
 			{/if}
 


### PR DESCRIPTION
## Summary

Frontend now consumes the existing backend `ChangePointMarker.direction` field (emitted since PR #104, previously unused). On `/revision-trends`, change-point markers render amber for slip / emerald for improvement / gray for flat — were uniformly red regardless of meaning. Stroke-dasharray varies per direction so the encoding is not color-only (WCAG 1.4.1).

Honest note: zero production users on `/revision-trends` today. The schema-gap closure is the load-bearing fix; the visual encoding prepares for program-mode upload users who will eventually reach the page.

## Changes

- `web/src/lib/types.ts` — added `direction: 'slip' | 'improvement' | 'flat'` to `ChangePointMarkerSchema` (closes TS-vs-Pydantic gap)
- `web/src/lib/components/charts/MultiRevisionSCurveChart.svelte` — direction-aware marker color + dasharray + title; optional `directionLabels` prop (English defaults); unknown-direction `console.warn` for future-backend-value visibility
- `web/src/routes/revision-trends/+page.svelte` — list-row colors mirror marker convention via shared helper; methodology footnote discloses the encoding
- `web/src/lib/utils/revisionTrendsDirection.ts` (new) — shared `directionTextClass` for the page list-row
- `web/src/routes/+layout.svelte` — nav icon swapped to two-stacked trend lines (disambiguates from /float-trends adjacent entry)
- `web/src/lib/i18n/{en,pt-BR,es}.ts` — 4 new keys × 3 locales: `revision_trends.direction.{slip,improvement,flat}` + `direction_legend`

## Test plan

- [x] `npm run check` — 0 errors / 0 warnings (674 files)
- [x] `npm run test -- --run` — 64/64 passing (3 chart-component tests + 3 helper unit tests new)
- [x] `npm run build` — clean
- [ ] **Operator browser-verify** required: nav icon rendering in light + dark mode at sidebar (20px) and mobile-compact (16px); marker colors + dashes on a real `/revision-trends` payload with multi-direction change-points

Closes #105.
Refs #110 — implementation merged; visual closure deferred pending operator browser-verify.