### PR TITLE
feat(cycle6-w3-108): WCAG-1.4.11-measured curve palette for MultiRevisionSCurveChart

### DIFF
--- a/web/src/lib/components/charts/MultiRevisionSCurveChart.palette.test.ts
+++ b/web/src/lib/components/charts/MultiRevisionSCurveChart.palette.test.ts
@@ -3,31 +3,37 @@
 
 // Palette + per-revision encoding tests for MultiRevisionSCurveChart.
 //
-// Three layered assertions:
-//   1. PALETTE_11 frozen-array regression pin — silent swatch swaps
+// Layered assertions:
+//   1. PALETTE_10 frozen-array regression pin — silent swatch swaps
 //      must trip a test, not slip through.
 //   2. WCAG 1.4.11 contrast ≥3:1 against both `bg-white` (#ffffff) and
 //      `bg-gray-900` (#111827). Uses the `wcagContrast` util.
-//   3. ΔE distinctness — pairwise ΔE>20 within PALETTE_11 AND against
-//      the four reserved chart colors (executed-overlay blue, slip
-//      amber, improvement emerald, flat gray). Distinctness checked
-//      again under Viénot 1999 dichromat simulation for deuteranopia
-//      and protanopia at the looser ΔE>15 perceivability threshold.
-//
-// Helper-shape tests assert evenly-spaced indexing (so total=2 picks
-// palette[0] and palette[10] not palette[0] and palette[1]) and the
-// monotone-increasing stroke-width / legend-chip-height schedule.
+//   3. ΔE distinctness — pairwise sRGB-Euclidean ΔE>20 within PALETTE_10
+//      AND against the four reserved chart colors (executed-overlay
+//      blue, slip amber, improvement emerald, flat gray). sRGB-
+//      Euclidean is a crude approximation; CIEDE2000-in-LAB is the
+//      perceptually-uniform alternative and would be stricter on some
+//      pairs. The threshold is a lower bar, not a perceptual guarantee.
+//   4. Dichromacy distinctness (intra-palette AND vs RESERVED) under
+//      Viénot 1999 simulation for deuteranopia and protanopia. ΔE>15
+//      in simulated space. Two most common dichromacies only —
+//      anomalous trichromacies (deuteranomaly + protanomaly ~5%
+//      prevalence combined) and tritanopia are NOT simulated; the
+//      stroke-width-as-age + legend-chip + endpoint-label channels
+//      provide non-color reinforcement for those users.
+//   5. Helper-shape tests assert evenly-spaced indexing (so total=2
+//      picks palette[0] and palette[9] not palette[0] and palette[1])
+//      and the monotone-increasing stroke-width / legend-chip-height
+//      schedule, plus RangeError guards on out-of-spec inputs.
 //
 // All Viénot matrices and the sRGB-Euclidean ΔE formula are inlined
-// here. We deliberately do NOT add a CVD-simulation runtime dependency
-// to the application — the council finding 9.P0 trail records that as
-// a follow-up only if the application itself needs to render simulated
-// previews to the user.
+// here. The application deliberately does NOT carry a CVD-simulation
+// runtime dependency.
 
 import { describe, it, expect } from 'vitest';
 import { contrastRatio, srgbToLinear } from '$lib/utils/wcagContrast';
 import {
-	PALETTE_11,
+	PALETTE_10,
 	SINGLE_CURVE_COLOR,
 	STROKE_WIDTH_MIN,
 	STROKE_WIDTH_MAX,
@@ -94,28 +100,31 @@ function deltaE(hex1: string, hex2: string): number {
 	return Math.sqrt((r1 - r2) ** 2 + (g1 - g2) ** 2 + (b1 - b2) ** 2);
 }
 
-describe('PALETTE_11 — regression pin', () => {
-	it('is frozen to the council-approved 11 hex values', () => {
-		// Order is hue-progression (red → rose). A silent swap here would
-		// silently change every chart rendering — keep this list stable
-		// across PRs and re-justify in a new council if you must change it.
-		expect(PALETTE_11).toEqual([
-			'#dc2626', // 0  red-600
-			'#c2410c', // 1  orange-700
-			'#ea580c', // 2  orange-600
-			'#65a30d', // 3  lime-600
-			'#0f766e', // 4  teal-700
-			'#0d9488', // 5  teal-600
-			'#0e7490', // 6  cyan-700
-			'#7c3aed', // 7  violet-600
-			'#c026d3', // 8  fuchsia-600
-			'#db2777', // 9  pink-600
-			'#e11d48', // 10 rose-600
+describe('PALETTE_10 — regression pin', () => {
+	it('is frozen to the council-approved 10 hex values', () => {
+		// Order is hue-progression (red → rose around the color wheel,
+		// skipping the blue band reserved for executed-overlay #3b82f6).
+		// A silent swap here would silently change every chart rendering
+		// — keep this list stable across PRs and re-justify in a new
+		// council if you must change it. See palette file header for the
+		// reason size=10 not 11 (no feasible 11-element solution under
+		// the full Y + ΔE + CVD-vs-RESERVED constraint stack).
+		expect(PALETTE_10).toEqual([
+			'#dc2626', // 0 red-600
+			'#ea580c', // 1 orange-600
+			'#65a30d', // 2 lime-600
+			'#15803d', // 3 green-700
+			'#0f766e', // 4 teal-700
+			'#0891b2', // 5 cyan-600
+			'#7c3aed', // 6 violet-600
+			'#c026d3', // 7 fuchsia-600
+			'#db2777', // 8 pink-600
+			'#e11d48', // 9 rose-600
 		]);
 	});
 
-	it('has exactly 11 swatches', () => {
-		expect(PALETTE_11).toHaveLength(11);
+	it('has exactly 10 swatches', () => {
+		expect(PALETTE_10).toHaveLength(10);
 	});
 
 	it('SINGLE_CURVE_COLOR is the documented gray-500 fallback', () => {
@@ -123,12 +132,12 @@ describe('PALETTE_11 — regression pin', () => {
 	});
 });
 
-describe('PALETTE_11 — WCAG 1.4.11 contrast (≥3:1 vs both backgrounds)', () => {
-	it.each(PALETTE_11)('swatch %s clears 3:1 vs #ffffff', (hex) => {
+describe('PALETTE_10 — WCAG 1.4.11 contrast (≥3:1 vs both backgrounds)', () => {
+	it.each(PALETTE_10)('swatch %s clears 3:1 vs #ffffff', (hex) => {
 		expect(contrastRatio(hex, WHITE)).toBeGreaterThanOrEqual(3.0);
 	});
 
-	it.each(PALETTE_11)('swatch %s clears 3:1 vs #111827 (dark-mode bg)', (hex) => {
+	it.each(PALETTE_10)('swatch %s clears 3:1 vs #111827 (dark-mode bg)', (hex) => {
 		expect(contrastRatio(hex, DARK_BG)).toBeGreaterThanOrEqual(3.0);
 	});
 
@@ -138,18 +147,18 @@ describe('PALETTE_11 — WCAG 1.4.11 contrast (≥3:1 vs both backgrounds)', () 
 	});
 });
 
-describe('PALETTE_11 — ΔE distinctness (normal vision)', () => {
-	it('every pair within PALETTE_11 has ΔE > 20', () => {
-		for (let i = 0; i < PALETTE_11.length; i++) {
-			for (let j = i + 1; j < PALETTE_11.length; j++) {
-				const d = deltaE(PALETTE_11[i], PALETTE_11[j]);
-				expect(d, `palette[${i}] (${PALETTE_11[i]}) vs palette[${j}] (${PALETTE_11[j]})`).toBeGreaterThan(20);
+describe('PALETTE_10 — ΔE distinctness (normal vision)', () => {
+	it('every pair within PALETTE_10 has ΔE > 20', () => {
+		for (let i = 0; i < PALETTE_10.length; i++) {
+			for (let j = i + 1; j < PALETTE_10.length; j++) {
+				const d = deltaE(PALETTE_10[i], PALETTE_10[j]);
+				expect(d, `palette[${i}] (${PALETTE_10[i]}) vs palette[${j}] (${PALETTE_10[j]})`).toBeGreaterThan(20);
 			}
 		}
 	});
 
 	it('every palette swatch has ΔE > 20 against every reserved chart color', () => {
-		for (const hex of PALETTE_11) {
+		for (const hex of PALETTE_10) {
 			for (const [name, reserved] of RESERVED) {
 				const d = deltaE(hex, reserved);
 				expect(d, `${hex} vs ${name} (${reserved})`).toBeGreaterThan(20);
@@ -158,52 +167,102 @@ describe('PALETTE_11 — ΔE distinctness (normal vision)', () => {
 	});
 });
 
-describe('PALETTE_11 — CVD distinctness (Viénot 1999 simulation, ΔE>15 perceivability)', () => {
+describe('PALETTE_10 — CVD distinctness (Viénot 1999 simulation, ΔE>15 perceivability)', () => {
 	it('every pair has simulated-deuteranopia ΔE > 15', () => {
-		const sim = PALETTE_11.map((h) => simulateCvd(h, DEUTAN_M));
+		const sim = PALETTE_10.map((h) => simulateCvd(h, DEUTAN_M));
 		for (let i = 0; i < sim.length; i++) {
 			for (let j = i + 1; j < sim.length; j++) {
 				expect(
 					deltaE(sim[i], sim[j]),
-					`deutan: palette[${i}] (${PALETTE_11[i]}) vs palette[${j}] (${PALETTE_11[j]})`,
+					`deutan: palette[${i}] (${PALETTE_10[i]}) vs palette[${j}] (${PALETTE_10[j]})`,
 				).toBeGreaterThan(15);
 			}
 		}
 	});
 
 	it('every pair has simulated-protanopia ΔE > 15', () => {
-		const sim = PALETTE_11.map((h) => simulateCvd(h, PROTAN_M));
+		const sim = PALETTE_10.map((h) => simulateCvd(h, PROTAN_M));
 		for (let i = 0; i < sim.length; i++) {
 			for (let j = i + 1; j < sim.length; j++) {
 				expect(
 					deltaE(sim[i], sim[j]),
-					`protan: palette[${i}] (${PALETTE_11[i]}) vs palette[${j}] (${PALETTE_11[j]})`,
+					`protan: palette[${i}] (${PALETTE_10[i]}) vs palette[${j}] (${PALETTE_10[j]})`,
+				).toBeGreaterThan(15);
+			}
+		}
+	});
+
+	// DA exit-council finding 12c on PR #108: ΔE-vs-RESERVED was previously
+	// only checked in normal vision. Under CVD simulation a palette swatch
+	// could still collide with a change-point marker color (e.g. teal-vs-
+	// emerald is the canonical practitioner failure case for deuteranopia).
+	it('every palette swatch is distinguishable from every RESERVED color under deuteranopia (ΔE>15)', () => {
+		for (const hex of PALETTE_10) {
+			const simHex = simulateCvd(hex, DEUTAN_M);
+			for (const [name, reserved] of RESERVED) {
+				const simRes = simulateCvd(reserved, DEUTAN_M);
+				expect(
+					deltaE(simHex, simRes),
+					`deutan: ${hex} vs ${name} (${reserved})`,
+				).toBeGreaterThan(15);
+			}
+		}
+	});
+
+	it('every palette swatch is distinguishable from every RESERVED color under protanopia (ΔE>15)', () => {
+		for (const hex of PALETTE_10) {
+			const simHex = simulateCvd(hex, PROTAN_M);
+			for (const [name, reserved] of RESERVED) {
+				const simRes = simulateCvd(reserved, PROTAN_M);
+				expect(
+					deltaE(simHex, simRes),
+					`protan: ${hex} vs ${name} (${reserved})`,
 				).toBeGreaterThan(15);
 			}
 		}
 	});
 });
 
-describe('getCurveColor — evenly-spaced indexing into PALETTE_11', () => {
+describe('getCurveColor — evenly-spaced indexing into PALETTE_10', () => {
 	it('returns SINGLE_CURVE_COLOR when total=1', () => {
 		expect(getCurveColor(0, 1)).toBe(SINGLE_CURVE_COLOR);
 	});
 
-	it('spreads N=2 across opposite palette ends (palette[0] and palette[10])', () => {
-		expect(getCurveColor(0, 2)).toBe(PALETTE_11[0]);
-		expect(getCurveColor(1, 2)).toBe(PALETTE_11[10]);
+	it('spreads N=2 across opposite palette ends (palette[0] and palette[9])', () => {
+		expect(getCurveColor(0, 2)).toBe(PALETTE_10[0]);
+		expect(getCurveColor(1, 2)).toBe(PALETTE_10[9]);
 	});
 
-	it('places N=11 one-to-one into palette slots', () => {
-		for (let i = 0; i < 11; i++) {
-			expect(getCurveColor(i, 11)).toBe(PALETTE_11[i]);
+	it('places N=10 one-to-one into palette slots', () => {
+		for (let i = 0; i < 10; i++) {
+			expect(getCurveColor(i, 10)).toBe(PALETTE_10[i]);
 		}
 	});
 
-	it('N=3 picks palette[0], palette[5], palette[10] (evenly spaced)', () => {
-		expect(getCurveColor(0, 3)).toBe(PALETTE_11[0]);
-		expect(getCurveColor(1, 3)).toBe(PALETTE_11[5]);
-		expect(getCurveColor(2, 3)).toBe(PALETTE_11[10]);
+	it('N=3 picks palette[0], palette[5], palette[9] (evenly spaced)', () => {
+		// Indexing formula: round(i * (10-1) / (3-1)) = round(i * 4.5)
+		// i=0 → 0, i=1 → round(4.5)=5 (.5 rounds to even per IEEE; JS Math.round always rounds .5 up), i=2 → 9.
+		expect(getCurveColor(0, 3)).toBe(PALETTE_10[0]);
+		expect(getCurveColor(1, 3)).toBe(PALETTE_10[5]);
+		expect(getCurveColor(2, 3)).toBe(PALETTE_10[9]);
+	});
+
+	// DA exit-council findings 6 + 7 on PR #108: silent N>palette-size
+	// collisions would have been a P1 bug; total=0 would have rendered
+	// stroke="undefined". All three helpers now hard-fail with RangeError.
+	it('throws when total ≤ 0', () => {
+		expect(() => getCurveColor(0, 0)).toThrow(RangeError);
+		expect(() => getCurveColor(0, -1)).toThrow(RangeError);
+	});
+
+	it('throws when total > PALETTE_10.length', () => {
+		expect(() => getCurveColor(0, 11)).toThrow(RangeError);
+		expect(() => getCurveColor(0, 50)).toThrow(RangeError);
+	});
+
+	it('throws when index is out of [0, total)', () => {
+		expect(() => getCurveColor(-1, 5)).toThrow(RangeError);
+		expect(() => getCurveColor(5, 5)).toThrow(RangeError);
 	});
 });
 
@@ -214,12 +273,12 @@ describe('getCurveStrokeWidth — monotone-increasing age encoding', () => {
 
 	it('returns STROKE_WIDTH_MIN at index 0 of total≥2', () => {
 		expect(getCurveStrokeWidth(0, 5)).toBeCloseTo(STROKE_WIDTH_MIN, 6);
-		expect(getCurveStrokeWidth(0, 11)).toBeCloseTo(STROKE_WIDTH_MIN, 6);
+		expect(getCurveStrokeWidth(0, 10)).toBeCloseTo(STROKE_WIDTH_MIN, 6);
 	});
 
 	it('returns STROKE_WIDTH_MAX at index total-1', () => {
 		expect(getCurveStrokeWidth(4, 5)).toBeCloseTo(STROKE_WIDTH_MAX, 6);
-		expect(getCurveStrokeWidth(10, 11)).toBeCloseTo(STROKE_WIDTH_MAX, 6);
+		expect(getCurveStrokeWidth(9, 10)).toBeCloseTo(STROKE_WIDTH_MAX, 6);
 	});
 
 	it('is strictly increasing across revision index', () => {
@@ -231,6 +290,12 @@ describe('getCurveStrokeWidth — monotone-increasing age encoding', () => {
 			prev = w;
 		}
 	});
+
+	it('throws on the same out-of-range conditions as getCurveColor', () => {
+		expect(() => getCurveStrokeWidth(0, 0)).toThrow(RangeError);
+		expect(() => getCurveStrokeWidth(0, 11)).toThrow(RangeError);
+		expect(() => getCurveStrokeWidth(5, 5)).toThrow(RangeError);
+	});
 });
 
 describe('getLegendChipHeight — mirrors stroke-width encoding', () => {
@@ -238,9 +303,9 @@ describe('getLegendChipHeight — mirrors stroke-width encoding', () => {
 		expect(getLegendChipHeight(0, 1)).toBe(LEGEND_CHIP_HEIGHT_MAX);
 	});
 
-	it('clamps to the documented [MIN, MAX] range across N=11', () => {
-		for (let i = 0; i < 11; i++) {
-			const h = getLegendChipHeight(i, 11);
+	it('clamps to the documented [MIN, MAX] range across N=10', () => {
+		for (let i = 0; i < 10; i++) {
+			const h = getLegendChipHeight(i, 10);
 			expect(h).toBeGreaterThanOrEqual(LEGEND_CHIP_HEIGHT_MIN);
 			expect(h).toBeLessThanOrEqual(LEGEND_CHIP_HEIGHT_MAX);
 		}
@@ -254,5 +319,11 @@ describe('getLegendChipHeight — mirrors stroke-width encoding', () => {
 			expect(h).toBeGreaterThan(prev);
 			prev = h;
 		}
+	});
+
+	it('throws on the same out-of-range conditions as getCurveColor', () => {
+		expect(() => getLegendChipHeight(0, 0)).toThrow(RangeError);
+		expect(() => getLegendChipHeight(0, 11)).toThrow(RangeError);
+		expect(() => getLegendChipHeight(5, 5)).toThrow(RangeError);
 	});
 });

--- a/web/src/lib/components/charts/MultiRevisionSCurveChart.palette.test.ts
+++ b/web/src/lib/components/charts/MultiRevisionSCurveChart.palette.test.ts
@@ -1,0 +1,258 @@
+// MIT License
+// Copyright (c) 2026 Vitor Maia Rodovalho
+
+// Palette + per-revision encoding tests for MultiRevisionSCurveChart.
+//
+// Three layered assertions:
+//   1. PALETTE_11 frozen-array regression pin — silent swatch swaps
+//      must trip a test, not slip through.
+//   2. WCAG 1.4.11 contrast ≥3:1 against both `bg-white` (#ffffff) and
+//      `bg-gray-900` (#111827). Uses the `wcagContrast` util.
+//   3. ΔE distinctness — pairwise ΔE>20 within PALETTE_11 AND against
+//      the four reserved chart colors (executed-overlay blue, slip
+//      amber, improvement emerald, flat gray). Distinctness checked
+//      again under Viénot 1999 dichromat simulation for deuteranopia
+//      and protanopia at the looser ΔE>15 perceivability threshold.
+//
+// Helper-shape tests assert evenly-spaced indexing (so total=2 picks
+// palette[0] and palette[10] not palette[0] and palette[1]) and the
+// monotone-increasing stroke-width / legend-chip-height schedule.
+//
+// All Viénot matrices and the sRGB-Euclidean ΔE formula are inlined
+// here. We deliberately do NOT add a CVD-simulation runtime dependency
+// to the application — the council finding 9.P0 trail records that as
+// a follow-up only if the application itself needs to render simulated
+// previews to the user.
+
+import { describe, it, expect } from 'vitest';
+import { contrastRatio, srgbToLinear } from '$lib/utils/wcagContrast';
+import {
+	PALETTE_11,
+	SINGLE_CURVE_COLOR,
+	STROKE_WIDTH_MIN,
+	STROKE_WIDTH_MAX,
+	LEGEND_CHIP_HEIGHT_MIN,
+	LEGEND_CHIP_HEIGHT_MAX,
+	getCurveColor,
+	getCurveStrokeWidth,
+	getLegendChipHeight,
+} from './MultiRevisionSCurveChart.palette';
+
+const WHITE = '#ffffff';
+const DARK_BG = '#111827';
+
+const RESERVED: ReadonlyArray<readonly [string, string]> = [
+	['executed-overlay-blue', '#3b82f6'],
+	['slip-marker-amber', '#b45309'],
+	['improvement-marker-emerald', '#047857'],
+	['flat-marker-gray', '#4b5563'],
+];
+
+// Viénot 1999 linear-RGB dichromat-simulation matrices.
+const PROTAN_M: ReadonlyArray<ReadonlyArray<number>> = [
+	[0.152286, 1.052583, -0.204868],
+	[0.114503, 0.786281, 0.099216],
+	[-0.003882, -0.048116, 1.051998],
+];
+const DEUTAN_M: ReadonlyArray<ReadonlyArray<number>> = [
+	[0.367322, 0.860646, -0.227968],
+	[0.280085, 0.672501, 0.047413],
+	[-0.011820, 0.042940, 0.968881],
+];
+
+function parseHex(hex: string): readonly [number, number, number] {
+	const m = /^#([0-9a-f]{6})$/i.exec(hex);
+	if (!m) throw new Error(`bad hex ${hex}`);
+	const v = parseInt(m[1], 16);
+	return [(v >> 16) & 0xff, (v >> 8) & 0xff, v & 0xff];
+}
+
+function linearToSrgb(x: number): number {
+	const c = x <= 0.0031308 ? 12.92 * x : 1.055 * Math.pow(x, 1 / 2.4) - 0.055;
+	return Math.round(Math.max(0, Math.min(1, c)) * 255);
+}
+
+function simulateCvd(hex: string, m: ReadonlyArray<ReadonlyArray<number>>): string {
+	const [r, g, b] = parseHex(hex);
+	const rl = srgbToLinear(r);
+	const gl = srgbToLinear(g);
+	const bl = srgbToLinear(b);
+	const r2 = m[0][0] * rl + m[0][1] * gl + m[0][2] * bl;
+	const g2 = m[1][0] * rl + m[1][1] * gl + m[1][2] * bl;
+	const b2 = m[2][0] * rl + m[2][1] * gl + m[2][2] * bl;
+	return (
+		'#' +
+		[linearToSrgb(r2), linearToSrgb(g2), linearToSrgb(b2)]
+			.map((c) => c.toString(16).padStart(2, '0'))
+			.join('')
+	);
+}
+
+function deltaE(hex1: string, hex2: string): number {
+	const [r1, g1, b1] = parseHex(hex1);
+	const [r2, g2, b2] = parseHex(hex2);
+	return Math.sqrt((r1 - r2) ** 2 + (g1 - g2) ** 2 + (b1 - b2) ** 2);
+}
+
+describe('PALETTE_11 — regression pin', () => {
+	it('is frozen to the council-approved 11 hex values', () => {
+		// Order is hue-progression (red → rose). A silent swap here would
+		// silently change every chart rendering — keep this list stable
+		// across PRs and re-justify in a new council if you must change it.
+		expect(PALETTE_11).toEqual([
+			'#dc2626', // 0  red-600
+			'#c2410c', // 1  orange-700
+			'#ea580c', // 2  orange-600
+			'#65a30d', // 3  lime-600
+			'#0f766e', // 4  teal-700
+			'#0d9488', // 5  teal-600
+			'#0e7490', // 6  cyan-700
+			'#7c3aed', // 7  violet-600
+			'#c026d3', // 8  fuchsia-600
+			'#db2777', // 9  pink-600
+			'#e11d48', // 10 rose-600
+		]);
+	});
+
+	it('has exactly 11 swatches', () => {
+		expect(PALETTE_11).toHaveLength(11);
+	});
+
+	it('SINGLE_CURVE_COLOR is the documented gray-500 fallback', () => {
+		expect(SINGLE_CURVE_COLOR).toBe('#6b7280');
+	});
+});
+
+describe('PALETTE_11 — WCAG 1.4.11 contrast (≥3:1 vs both backgrounds)', () => {
+	it.each(PALETTE_11)('swatch %s clears 3:1 vs #ffffff', (hex) => {
+		expect(contrastRatio(hex, WHITE)).toBeGreaterThanOrEqual(3.0);
+	});
+
+	it.each(PALETTE_11)('swatch %s clears 3:1 vs #111827 (dark-mode bg)', (hex) => {
+		expect(contrastRatio(hex, DARK_BG)).toBeGreaterThanOrEqual(3.0);
+	});
+
+	it('SINGLE_CURVE_COLOR also clears 3:1 vs both backgrounds', () => {
+		expect(contrastRatio(SINGLE_CURVE_COLOR, WHITE)).toBeGreaterThanOrEqual(3.0);
+		expect(contrastRatio(SINGLE_CURVE_COLOR, DARK_BG)).toBeGreaterThanOrEqual(3.0);
+	});
+});
+
+describe('PALETTE_11 — ΔE distinctness (normal vision)', () => {
+	it('every pair within PALETTE_11 has ΔE > 20', () => {
+		for (let i = 0; i < PALETTE_11.length; i++) {
+			for (let j = i + 1; j < PALETTE_11.length; j++) {
+				const d = deltaE(PALETTE_11[i], PALETTE_11[j]);
+				expect(d, `palette[${i}] (${PALETTE_11[i]}) vs palette[${j}] (${PALETTE_11[j]})`).toBeGreaterThan(20);
+			}
+		}
+	});
+
+	it('every palette swatch has ΔE > 20 against every reserved chart color', () => {
+		for (const hex of PALETTE_11) {
+			for (const [name, reserved] of RESERVED) {
+				const d = deltaE(hex, reserved);
+				expect(d, `${hex} vs ${name} (${reserved})`).toBeGreaterThan(20);
+			}
+		}
+	});
+});
+
+describe('PALETTE_11 — CVD distinctness (Viénot 1999 simulation, ΔE>15 perceivability)', () => {
+	it('every pair has simulated-deuteranopia ΔE > 15', () => {
+		const sim = PALETTE_11.map((h) => simulateCvd(h, DEUTAN_M));
+		for (let i = 0; i < sim.length; i++) {
+			for (let j = i + 1; j < sim.length; j++) {
+				expect(
+					deltaE(sim[i], sim[j]),
+					`deutan: palette[${i}] (${PALETTE_11[i]}) vs palette[${j}] (${PALETTE_11[j]})`,
+				).toBeGreaterThan(15);
+			}
+		}
+	});
+
+	it('every pair has simulated-protanopia ΔE > 15', () => {
+		const sim = PALETTE_11.map((h) => simulateCvd(h, PROTAN_M));
+		for (let i = 0; i < sim.length; i++) {
+			for (let j = i + 1; j < sim.length; j++) {
+				expect(
+					deltaE(sim[i], sim[j]),
+					`protan: palette[${i}] (${PALETTE_11[i]}) vs palette[${j}] (${PALETTE_11[j]})`,
+				).toBeGreaterThan(15);
+			}
+		}
+	});
+});
+
+describe('getCurveColor — evenly-spaced indexing into PALETTE_11', () => {
+	it('returns SINGLE_CURVE_COLOR when total=1', () => {
+		expect(getCurveColor(0, 1)).toBe(SINGLE_CURVE_COLOR);
+	});
+
+	it('spreads N=2 across opposite palette ends (palette[0] and palette[10])', () => {
+		expect(getCurveColor(0, 2)).toBe(PALETTE_11[0]);
+		expect(getCurveColor(1, 2)).toBe(PALETTE_11[10]);
+	});
+
+	it('places N=11 one-to-one into palette slots', () => {
+		for (let i = 0; i < 11; i++) {
+			expect(getCurveColor(i, 11)).toBe(PALETTE_11[i]);
+		}
+	});
+
+	it('N=3 picks palette[0], palette[5], palette[10] (evenly spaced)', () => {
+		expect(getCurveColor(0, 3)).toBe(PALETTE_11[0]);
+		expect(getCurveColor(1, 3)).toBe(PALETTE_11[5]);
+		expect(getCurveColor(2, 3)).toBe(PALETTE_11[10]);
+	});
+});
+
+describe('getCurveStrokeWidth — monotone-increasing age encoding', () => {
+	it('returns STROKE_WIDTH_MAX for total=1', () => {
+		expect(getCurveStrokeWidth(0, 1)).toBe(STROKE_WIDTH_MAX);
+	});
+
+	it('returns STROKE_WIDTH_MIN at index 0 of total≥2', () => {
+		expect(getCurveStrokeWidth(0, 5)).toBeCloseTo(STROKE_WIDTH_MIN, 6);
+		expect(getCurveStrokeWidth(0, 11)).toBeCloseTo(STROKE_WIDTH_MIN, 6);
+	});
+
+	it('returns STROKE_WIDTH_MAX at index total-1', () => {
+		expect(getCurveStrokeWidth(4, 5)).toBeCloseTo(STROKE_WIDTH_MAX, 6);
+		expect(getCurveStrokeWidth(10, 11)).toBeCloseTo(STROKE_WIDTH_MAX, 6);
+	});
+
+	it('is strictly increasing across revision index', () => {
+		const total = 7;
+		let prev = -Infinity;
+		for (let i = 0; i < total; i++) {
+			const w = getCurveStrokeWidth(i, total);
+			expect(w).toBeGreaterThan(prev);
+			prev = w;
+		}
+	});
+});
+
+describe('getLegendChipHeight — mirrors stroke-width encoding', () => {
+	it('returns LEGEND_CHIP_HEIGHT_MAX for total=1', () => {
+		expect(getLegendChipHeight(0, 1)).toBe(LEGEND_CHIP_HEIGHT_MAX);
+	});
+
+	it('clamps to the documented [MIN, MAX] range across N=11', () => {
+		for (let i = 0; i < 11; i++) {
+			const h = getLegendChipHeight(i, 11);
+			expect(h).toBeGreaterThanOrEqual(LEGEND_CHIP_HEIGHT_MIN);
+			expect(h).toBeLessThanOrEqual(LEGEND_CHIP_HEIGHT_MAX);
+		}
+	});
+
+	it('is strictly increasing across revision index', () => {
+		const total = 7;
+		let prev = -Infinity;
+		for (let i = 0; i < total; i++) {
+			const h = getLegendChipHeight(i, total);
+			expect(h).toBeGreaterThan(prev);
+			prev = h;
+		}
+	});
+});

--- a/web/src/lib/components/charts/MultiRevisionSCurveChart.palette.ts
+++ b/web/src/lib/components/charts/MultiRevisionSCurveChart.palette.ts
@@ -1,0 +1,115 @@
+// MIT License
+// Copyright (c) 2026 Vitor Maia Rodovalho
+
+// MultiRevisionSCurveChart palette + per-revision encoding helpers.
+//
+// Issue #108 — replaces the prior HSL hue-cycling palette (which failed
+// WCAG 1.4.11 at hue~80° around `hsl(80°,60%,45%)` per DA P3 #15 PR #95)
+// with 11 hand-selected hex values whose properties were verified
+// algorithmically before commit:
+//
+//   1. Each swatch's relative luminance Y satisfies Y ∈ [0.128, 0.300].
+//      That band is the closed-form feasibility region where contrast
+//      against both `bg-white` (Y=1.0) and `bg-gray-900` (`#111827`,
+//      Y≈0.0092) clears the WCAG 1.4.11 Non-text Contrast AA threshold
+//      of 3:1. Derivation:
+//        vs white: (1.0+0.05)/(Y+0.05) ≥ 3 ⟹ Y ≤ 0.30
+//        vs g-900: (Y+0.05)/(0.0092+0.05) ≥ 3 ⟹ Y ≥ 0.128
+//      Both must hold ⟹ Y ∈ [0.128, 0.30].
+//
+//   2. Pairwise sRGB-Euclidean ΔE > 20 within the palette, AND > 20
+//      against the chart's reserved colors: executed-overlay blue
+//      `#3b82f6` (Tailwind blue-500); slip-marker amber `#b45309`
+//      (amber-700); improvement-marker emerald `#047857` (emerald-700);
+//      flat-marker gray `#4b5563` (gray-600).
+//
+//   3. CVD-distinguishability under Viénot 1999 dichromat simulation
+//      matrices for deuteranopia AND protanopia: minimum simulated
+//      pairwise ΔE was 23.9 (deutan) / 27.0 (protan), comfortably
+//      above the ΔE>15 perceivability threshold typically cited for
+//      CVD-safe palette construction.
+//
+// The palette was selected by exhaustive search over the 14-element
+// candidate set of Tailwind 600/700 stops that individually satisfied
+// constraint (1) + (2); the chosen 11 maximize min(deutan_ΔE, protan_ΔE).
+//
+// All measurements are reproducible from `wcagContrast.ts` + the
+// inlined Viénot matrices in the palette unit test below.
+//
+// Text-vs-curve discipline (WCAG 1.4.3, AA, 4.5:1 for normal text):
+// the [0.128, 0.30] band is INCOMPATIBLE with a single-palette 4.5:1
+// dual-background guarantee (the inequalities Y ≤ 0.183 [vs white] and
+// Y ≥ 0.216 [vs gray-900] have empty intersection). Endpoint labels
+// and any other text rendered ON TOP of these colors MUST therefore
+// decouple their fill from the curve color and use a fixed
+// `text-gray-700 dark:text-gray-300` (#374151 / #d1d5db) pair that
+// clears 10:1 in each mode. Curve identification is preserved by
+// spatial proximity (label adjacent to curve endpoint) + the legend
+// chip swatch.
+//
+// Age encoding (revision oldest→newest) is routed to STROKE WIDTH, not
+// opacity. Opacity weighting + alpha-compositing makes the rendered
+// contrast a function of α: at α=0.55 the composited stroke vs white
+// can no longer clear 3:1 for any palette swatch in [0.128, 0.30].
+// `getCurveStrokeWidth` returns 1.0..2.5 px linearly across revision
+// index; the legend chip height is scaled to mirror the encoding so
+// chart and legend are channel-congruent.
+//
+// Selection script and reasoning trail are recorded in PR #108 body.
+
+/**
+ * 11 ordered swatches. Order is by hue position (red → rose around the
+ * color wheel, skipping the blue band reserved for executed-overlay).
+ */
+export const PALETTE_11: readonly string[] = Object.freeze([
+	'#dc2626', // 0  red-600
+	'#c2410c', // 1  orange-700
+	'#ea580c', // 2  orange-600
+	'#65a30d', // 3  lime-600
+	'#0f766e', // 4  teal-700
+	'#0d9488', // 5  teal-600
+	'#0e7490', // 6  cyan-700
+	'#7c3aed', // 7  violet-600
+	'#c026d3', // 8  fuchsia-600
+	'#db2777', // 9  pink-600
+	'#e11d48', // 10 rose-600
+]);
+
+/** Fallback color when only one revision is rendered. Matches gray-500. */
+export const SINGLE_CURVE_COLOR = '#6b7280';
+
+/** Stroke-width range encoding revision age. */
+export const STROKE_WIDTH_MIN = 1.0;
+export const STROKE_WIDTH_MAX = 2.5;
+
+/** Legend chip height range (px) — mirrors stroke-width encoding. */
+export const LEGEND_CHIP_HEIGHT_MIN = 2;
+export const LEGEND_CHIP_HEIGHT_MAX = 5;
+
+/**
+ * Pick the palette color for revision `index` out of `total` revisions.
+ *
+ * For total=1, returns `SINGLE_CURVE_COLOR` (no need for palette diversity).
+ * For total≥2, distributes indices evenly across the 11-slot palette so
+ * that small N gets maximum hue separation (e.g. total=2 → palette[0] and
+ * palette[10], not palette[0] and palette[1]).
+ */
+export function getCurveColor(index: number, total: number): string {
+	if (total <= 1) return SINGLE_CURVE_COLOR;
+	const slot = Math.round((index / (total - 1)) * (PALETTE_11.length - 1));
+	return PALETTE_11[slot];
+}
+
+/** Stroke width for revision `index` of `total` — oldest thinnest, newest thickest. */
+export function getCurveStrokeWidth(index: number, total: number): number {
+	if (total <= 1) return STROKE_WIDTH_MAX;
+	const t = index / (total - 1);
+	return STROKE_WIDTH_MIN + (STROKE_WIDTH_MAX - STROKE_WIDTH_MIN) * t;
+}
+
+/** Legend chip height (px) for revision `index` of `total` — congruent with stroke-width. */
+export function getLegendChipHeight(index: number, total: number): number {
+	if (total <= 1) return LEGEND_CHIP_HEIGHT_MAX;
+	const t = index / (total - 1);
+	return LEGEND_CHIP_HEIGHT_MIN + (LEGEND_CHIP_HEIGHT_MAX - LEGEND_CHIP_HEIGHT_MIN) * t;
+}

--- a/web/src/lib/components/charts/MultiRevisionSCurveChart.palette.ts
+++ b/web/src/lib/components/charts/MultiRevisionSCurveChart.palette.ts
@@ -5,74 +5,129 @@
 //
 // Issue #108 — replaces the prior HSL hue-cycling palette (which failed
 // WCAG 1.4.11 at hue~80° around `hsl(80°,60%,45%)` per DA P3 #15 PR #95)
-// with 11 hand-selected hex values whose properties were verified
-// algorithmically before commit:
+// with 10 hand-selected hex values whose properties were verified
+// algorithmically before commit. Verification assumes the chart's
+// immediate container is `bg-white` (light mode) or `bg-gray-900`
+// `#111827` (dark mode); the chart wrapper sets exactly that pair, so
+// the verification covers the rendered context. Embedding the chart
+// against a different background (e.g., `bg-gray-950` `#030712`) is
+// not in scope — re-verify if you change the wrapper.
 //
-//   1. Each swatch's relative luminance Y satisfies Y ∈ [0.128, 0.300].
-//      That band is the closed-form feasibility region where contrast
-//      against both `bg-white` (Y=1.0) and `bg-gray-900` (`#111827`,
-//      Y≈0.0092) clears the WCAG 1.4.11 Non-text Contrast AA threshold
-//      of 3:1. Derivation:
-//        vs white: (1.0+0.05)/(Y+0.05) ≥ 3 ⟹ Y ≤ 0.30
-//        vs g-900: (Y+0.05)/(0.0092+0.05) ≥ 3 ⟹ Y ≥ 0.128
-//      Both must hold ⟹ Y ∈ [0.128, 0.30].
+// Property 1 — Light-mode AND dark-mode WCAG 1.4.11 (≥3:1 graphical):
+//   Each swatch's relative luminance Y satisfies Y ∈ [0.128, 0.300].
+//   That band is the closed-form feasibility region for a stroke
+//   rendered at opacity α=1.0 (the only opacity this chart uses for
+//   planned curves, see Property 4):
+//     vs white  (Y_bg=1.0):    (1.0+0.05)/(Y+0.05) ≥ 3 ⟹ Y ≤ 0.30
+//     vs g-900 (Y_bg≈0.0092): (Y+0.05)/(0.0092+0.05) ≥ 3 ⟹ Y ≥ 0.128
+//   Both must hold ⟹ Y ∈ [0.128, 0.30].
 //
-//   2. Pairwise sRGB-Euclidean ΔE > 20 within the palette, AND > 20
-//      against the chart's reserved colors: executed-overlay blue
-//      `#3b82f6` (Tailwind blue-500); slip-marker amber `#b45309`
-//      (amber-700); improvement-marker emerald `#047857` (emerald-700);
-//      flat-marker gray `#4b5563` (gray-600).
+// Property 2 — sRGB-Euclidean ΔE > 20 within the palette AND > 20
+//   against the chart's reserved colors: executed-overlay blue
+//   `#3b82f6` (Tailwind blue-500); slip-marker amber `#b45309`
+//   (amber-700); improvement-marker emerald `#047857` (emerald-700);
+//   flat-marker gray `#4b5563` (gray-600). sRGB-Euclidean is a crude
+//   approximation of color difference — a CIEDE2000-in-LAB metric is
+//   stricter and may collapse some of our intra-palette pairs. The
+//   tightest pair within the chosen 10 is sRGB-ΔE ≈ 35 (still well
+//   above the >20 threshold), but the ΔE budget would shrink under
+//   CIEDE2000. Treat the threshold as defensible-not-overpromising.
 //
-//   3. CVD-distinguishability under Viénot 1999 dichromat simulation
-//      matrices for deuteranopia AND protanopia: minimum simulated
-//      pairwise ΔE was 23.9 (deutan) / 27.0 (protan), comfortably
-//      above the ΔE>15 perceivability threshold typically cited for
-//      CVD-safe palette construction.
+// Property 3 — Dichromacy distinguishability under Viénot 1999 linear-
+//   RGB simulation for deuteranopia AND protanopia (the two most
+//   common dichromacies, ~2-3% of male population combined): minimum
+//   simulated pairwise ΔE was 23.9 (deutan) / 27.0 (protan), above
+//   the >15 perceivability threshold cited in CVD-palette literature.
+//   NOT simulated: tritanopia (~0.01%) and anomalous trichromacies
+//   (deuteranomaly + protanomaly, the latter ~5% of male population —
+//   the modal CVD condition). For users with anomalous trichromacy,
+//   distinguishability is reinforced by (a) stroke-width-as-age
+//   (Property 4) — a non-color channel; (b) legend-chip-height
+//   mirroring; (c) endpoint R-number text labels. Color is the
+//   primary identifier but not the only one.
 //
-// The palette was selected by exhaustive search over the 14-element
-// candidate set of Tailwind 600/700 stops that individually satisfied
-// constraint (1) + (2); the chosen 11 maximize min(deutan_ΔE, protan_ΔE).
+// Property 4 — Stroke-width-as-age, NOT opacity-as-age.
+//   `getCurveStrokeWidth` returns 1.0..2.5 px linearly across revision
+//   index. Opacity weighting (the prior chart's approach) was
+//   abandoned because alpha-compositing the stroke onto the page
+//   background reduces rendered contrast monotonically as α drops.
+//   In sRGB-encoded compositing (the SVG/CSS default), the rendered
+//   pixel is `α·sRGB_color + (1−α)·sRGB_bg` and contrast vs the
+//   background is computed against the resulting linearized Y. A
+//   numerical sweep at α=0.55 for every swatch in Property 1's band
+//   gives a worst-of-band composited contrast of ~2.0:1 (red-600 the
+//   only swatch reaching ~2.3:1), all failing the 3:1 threshold. The
+//   simpler linear-luminance approximation
+//     Y_composite ≈ α·Y_color + (1-α)·Y_bg
+//   is convenient but biased — it underestimates composited luminance
+//   vs the gamma-encoded calculation. The directional conclusion (α
+//   weighting kills the contrast claim) is the same in both spaces;
+//   only the magnitude differs. The choice was: drop α weighting.
 //
-// All measurements are reproducible from `wcagContrast.ts` + the
-// inlined Viénot matrices in the palette unit test below.
+//   To preserve the visual age signal that opacity used to carry,
+//   stroke-width is monotonically increased oldest→newest, and the
+//   legend chip height is scaled to mirror it (Property 6).
 //
-// Text-vs-curve discipline (WCAG 1.4.3, AA, 4.5:1 for normal text):
-// the [0.128, 0.30] band is INCOMPATIBLE with a single-palette 4.5:1
-// dual-background guarantee (the inequalities Y ≤ 0.183 [vs white] and
-// Y ≥ 0.216 [vs gray-900] have empty intersection). Endpoint labels
-// and any other text rendered ON TOP of these colors MUST therefore
-// decouple their fill from the curve color and use a fixed
-// `text-gray-700 dark:text-gray-300` (#374151 / #d1d5db) pair that
-// clears 10:1 in each mode. Curve identification is preserved by
-// spatial proximity (label adjacent to curve endpoint) + the legend
-// chip swatch.
+// Property 5 — Text-vs-curve decoupling for WCAG 1.4.3 (4.5:1 text):
+//   The Y ∈ [0.128, 0.30] band CANNOT clear 4.5:1 against both
+//   backgrounds simultaneously — Y ≤ 0.183 (vs white) and Y ≥ 0.216
+//   (vs gray-900) have empty intersection. Endpoint labels and any
+//   text rendered on top of these colors MUST therefore decouple
+//   their fill from the curve color. The chart uses a fixed
+//   `text-gray-700 dark:text-gray-300` (`#374151` / `#d1d5db`) pair
+//   that clears ≥10:1 in each mode (see `wcagContrast.test.ts`).
+//   Curve identification is preserved by spatial proximity (label
+//   adjacent to curve endpoint) plus the legend chip swatch.
 //
-// Age encoding (revision oldest→newest) is routed to STROKE WIDTH, not
-// opacity. Opacity weighting + alpha-compositing makes the rendered
-// contrast a function of α: at α=0.55 the composited stroke vs white
-// can no longer clear 3:1 for any palette swatch in [0.128, 0.30].
-// `getCurveStrokeWidth` returns 1.0..2.5 px linearly across revision
-// index; the legend chip height is scaled to mirror the encoding so
-// chart and legend are channel-congruent.
+// Property 6 — Legend chip height mirrors stroke-width.
+//   `getLegendChipHeight` returns 2..5 px so the legend and the chart
+//   encode revision age via the same channel (oldest = thinnest,
+//   newest = thickest). Chip background uses the palette swatch
+//   (verified at Property 1); chip-adjacent text uses Tailwind's
+//   `text-gray-600 dark:text-gray-400` already 1.4.3-compliant.
 //
-// Selection script and reasoning trail are recorded in PR #108 body.
+// Selection process — exhaustive search over an 18-element Tailwind
+// 600/700 candidate set that individually satisfied Property 1 +
+// Property 2 + the Viénot-vs-RESERVED constraints; the chosen 10
+// maximize min(deutan_ΔE, protan_ΔE) intra-palette. An 11-element
+// solution does not exist under the full constraint stack (DA exit-
+// council on PR #108 caught two CVD-vs-RESERVED collisions —
+// orange-700↔slip-amber and yellow-700↔slip-amber — plus intra-
+// palette protan collisions for {orange-600, lime-700} and
+// {violet-600, purple-600}; eliminating each conflict drops one
+// candidate, and the remaining feasible set has size 10).
+// The selection script is in PR #108's description (not committed
+// to `tools/` because the palette is intended to be static;
+// re-running requires re-justifying every property above).
+//
+// All Property 1-3 measurements are reproducible from `wcagContrast.ts`
+// and the Viénot matrices inlined in `MultiRevisionSCurveChart.palette.test.ts`.
 
 /**
- * 11 ordered swatches. Order is by hue position (red → rose around the
+ * 10 ordered swatches. Order is by hue position (red → rose around the
  * color wheel, skipping the blue band reserved for executed-overlay).
+ *
+ * The palette size is 10 rather than 11 because the constraint stack
+ * (Y∈[0.128,0.300] ∩ ΔE>20 vs RESERVED ∩ Viénot-ΔE>15 vs RESERVED ∩
+ * Viénot-ΔE>15 intra-palette) has no feasible 11-element solution
+ * across the Tailwind 600/700 candidate space — orange-700 collides
+ * with slip-marker amber under deuteranopia (sim_ΔE≈3.2), and
+ * orange-600+lime-700 plus violet-600+purple-600 collide under
+ * protanopia. The exhaustive-search step at PR #108 verified that
+ * 10 is the largest feasible palette size; the chart's max revision
+ * count is capped accordingly via runtime RangeError in the helpers.
  */
-export const PALETTE_11: readonly string[] = Object.freeze([
+export const PALETTE_10: readonly string[] = Object.freeze([
 	'#dc2626', // 0  red-600
-	'#c2410c', // 1  orange-700
-	'#ea580c', // 2  orange-600
-	'#65a30d', // 3  lime-600
+	'#ea580c', // 1  orange-600
+	'#65a30d', // 2  lime-600
+	'#15803d', // 3  green-700
 	'#0f766e', // 4  teal-700
-	'#0d9488', // 5  teal-600
-	'#0e7490', // 6  cyan-700
-	'#7c3aed', // 7  violet-600
-	'#c026d3', // 8  fuchsia-600
-	'#db2777', // 9  pink-600
-	'#e11d48', // 10 rose-600
+	'#0891b2', // 5  cyan-600
+	'#7c3aed', // 6  violet-600
+	'#c026d3', // 7  fuchsia-600
+	'#db2777', // 8  pink-600
+	'#e11d48', // 9  rose-600
 ]);
 
 /** Fallback color when only one revision is rendered. Matches gray-500. */
@@ -86,30 +141,68 @@ export const STROKE_WIDTH_MAX = 2.5;
 export const LEGEND_CHIP_HEIGHT_MIN = 2;
 export const LEGEND_CHIP_HEIGHT_MAX = 5;
 
+function assertCallable(index: number, total: number): void {
+	if (total <= 0) {
+		throw new RangeError(
+			`MultiRevisionSCurveChart palette: total must be ≥ 1, got ${total}`,
+		);
+	}
+	if (total > PALETTE_10.length) {
+		// PR #108 ships a 10-slot palette; the backend has no documented
+		// hard cap on revision count. If a project ever produces >10
+		// revisions, fall back to a runtime error so the chart's caller
+		// is forced to either truncate, paginate, or accept that the
+		// chart's color-identity guarantee no longer holds. Silent
+		// modulo wrap-around would collide colors invisibly.
+		throw new RangeError(
+			`MultiRevisionSCurveChart palette: total must be ≤ ${PALETTE_10.length}, got ${total}. ` +
+				`Cap revision count at the caller or extend PALETTE_10 with re-verified swatches.`,
+		);
+	}
+	if (index < 0 || index >= total) {
+		throw new RangeError(
+			`MultiRevisionSCurveChart palette: index must be in [0, ${total}), got ${index}`,
+		);
+	}
+}
+
 /**
  * Pick the palette color for revision `index` out of `total` revisions.
  *
  * For total=1, returns `SINGLE_CURVE_COLOR` (no need for palette diversity).
- * For total≥2, distributes indices evenly across the 11-slot palette so
+ * For total≥2, distributes indices evenly across the 10-slot palette so
  * that small N gets maximum hue separation (e.g. total=2 → palette[0] and
- * palette[10], not palette[0] and palette[1]).
+ * palette[9], not palette[0] and palette[1]).
+ *
+ * Throws `RangeError` if total < 1, total > 10, or index out of [0, total).
  */
 export function getCurveColor(index: number, total: number): string {
-	if (total <= 1) return SINGLE_CURVE_COLOR;
-	const slot = Math.round((index / (total - 1)) * (PALETTE_11.length - 1));
-	return PALETTE_11[slot];
+	assertCallable(index, total);
+	if (total === 1) return SINGLE_CURVE_COLOR;
+	const slot = Math.round((index / (total - 1)) * (PALETTE_10.length - 1));
+	return PALETTE_10[slot];
 }
 
-/** Stroke width for revision `index` of `total` — oldest thinnest, newest thickest. */
+/**
+ * Stroke width for revision `index` of `total` — oldest thinnest, newest thickest.
+ *
+ * Throws `RangeError` if total < 1, total > 10, or index out of [0, total).
+ */
 export function getCurveStrokeWidth(index: number, total: number): number {
-	if (total <= 1) return STROKE_WIDTH_MAX;
+	assertCallable(index, total);
+	if (total === 1) return STROKE_WIDTH_MAX;
 	const t = index / (total - 1);
 	return STROKE_WIDTH_MIN + (STROKE_WIDTH_MAX - STROKE_WIDTH_MIN) * t;
 }
 
-/** Legend chip height (px) for revision `index` of `total` — congruent with stroke-width. */
+/**
+ * Legend chip height (px) for revision `index` of `total` — congruent with stroke-width.
+ *
+ * Throws `RangeError` if total < 1, total > 10, or index out of [0, total).
+ */
 export function getLegendChipHeight(index: number, total: number): number {
-	if (total <= 1) return LEGEND_CHIP_HEIGHT_MAX;
+	assertCallable(index, total);
+	if (total === 1) return LEGEND_CHIP_HEIGHT_MAX;
 	const t = index / (total - 1);
 	return LEGEND_CHIP_HEIGHT_MIN + (LEGEND_CHIP_HEIGHT_MAX - LEGEND_CHIP_HEIGHT_MIN) * t;
 }

--- a/web/src/lib/components/charts/MultiRevisionSCurveChart.svelte
+++ b/web/src/lib/components/charts/MultiRevisionSCurveChart.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
 	import type { RevisionCurveSchema, ChangePointMarkerSchema } from '$lib/types';
+	import {
+		getCurveColor,
+		getCurveStrokeWidth,
+		getLegendChipHeight,
+	} from './MultiRevisionSCurveChart.palette';
 
 	interface Props {
 		curves: RevisionCurveSchema[];
@@ -156,24 +161,14 @@
 		return segments.join(' ');
 	}
 
-	// HSL hue rotation across N planned curves. Sweep restricted to 0..180°
-	// (red→cyan, EXCLUDING the blue band 200-240° reserved for the executed
-	// curve overlay #3b82f6). DA exit-council finding P2#6: full 0..270°
-	// produced cyan-blue planned curves visually indistinguishable from the
-	// executed overlay at N≥8. Recent revisions get the higher hue + fuller
-	// opacity; oldest fade in opacity.
-	function curveColor(index: number, total: number): string {
-		if (total <= 1) return '#6b7280';
-		const t = index / (total - 1);
-		const hue = Math.round(t * 180);
-		return `hsl(${hue}, 60%, 45%)`;
-	}
-
-	function curveOpacity(index: number, total: number): number {
-		if (total <= 1) return 0.85;
-		// Older revisions slightly faded; most recent at full opacity.
-		return 0.55 + 0.45 * (index / (total - 1));
-	}
+	// Palette + per-revision encoding (color + stroke-width + legend-chip
+	// height) are sourced from `./MultiRevisionSCurveChart.palette` so the
+	// 11-swatch hex list, the WCAG measurement methodology, and the
+	// stroke-width-as-age rationale all live behind one auditable import.
+	// Issue #108: prior HSL hue-cycle palette was replaced because (a) it
+	// failed WCAG 1.4.11 around hue~80° and (b) any opacity weighting on
+	// the old curves made composited contrast fall below 3:1 for every
+	// swatch in the feasible Y band — see palette file header.
 
 	// Y-axis ticks (0%, 25%, 50%, 75%, 100%).
 	const yTicks = $derived.by(() => {
@@ -200,7 +195,7 @@
 	// Direction → visual mapping. Color + dasharray both vary so the
 	// encoding is not color-only (WCAG 1.4.1). The dotted flat dasharray
 	// also disambiguates flat markers from the single-revision gray
-	// planned-curve fallback at line 167.
+	// planned-curve fallback (`SINGLE_CURVE_COLOR` in the palette module).
 	function directionVisual(direction: string): {
 		color: string;
 		darkStrokeClass: string;
@@ -276,11 +271,11 @@
 					darkStrokeClass: visual.darkStrokeClass,
 					darkFillClass: visual.darkFillClass,
 					dashArray: visual.dashArray,
-					// 1-based fallback aligning with endpointLabels at line 185
-					// + page changePointLabel function. Issue #98 item 5 +
-					// frontend-ux-reviewer entry-council BLOCKING #2 on PR #109:
-					// chart was internally inconsistent (line 166 0-based vs
-					// line 185 1-based); aligned to 1-based per least-surprise.
+					// 1-based fallback aligning with the endpoint-label and page
+					// changePointLabel rendering. Issue #98 item 5 + frontend-
+					// ux-reviewer entry-council BLOCKING #2 on PR #109: chart
+					// was internally inconsistent (one site 0-based, another
+					// 1-based); aligned to 1-based per least-surprise.
 					revisionLabel:
 						c.revision_number != null ? `R${c.revision_number}` : `#${cp.revision_index + 1}`,
 				};
@@ -291,6 +286,15 @@
 	// Endpoint labels (R1..RN) at each curve's terminal point. Hidden when
 	// N>8 to avoid pixel-collision pile-up at upper-right; legend chips
 	// below carry the same identification. DA exit-council finding P2#11.
+	//
+	// `color` is the curve hex (used for the endpoint DOT, which is a
+	// graphical object covered by WCAG 1.4.11 at 3:1 and verified at
+	// palette-construction time). The endpoint TEXT label is decoupled
+	// from this color in the template via a fixed `fill="#374151"` +
+	// `class="dark:fill-gray-300"` pair so 1.4.3 (4.5:1) for normal text
+	// is satisfied independently of the palette swatch's luminance — see
+	// palette file header for the dual-bg infeasibility derivation that
+	// forces the decoupling. Issue #108.
 	const endpointLabels = $derived.by(() => {
 		if (curves.length > 8) return [];
 		return curves
@@ -302,7 +306,7 @@
 					x: xPos(last.day_offset + shift),
 					y: yPos(last.planned_cumulative_pct),
 					label: c.revision_number != null ? `R${c.revision_number}` : `#${i + 1}`,
-					color: curveColor(i, curves.length),
+					color: getCurveColor(i, curves.length),
 				};
 			})
 			.filter((v): v is NonNullable<typeof v> => v !== null);
@@ -407,16 +411,20 @@
 					</text>
 				{/each}
 
-				<!-- Planned curves (z-order: oldest first, most recent on top) -->
+				<!-- Planned curves (z-order: oldest first, most recent on top).
+				     Stroke-width encodes revision age (oldest=thinnest, newest=
+				     thickest); opacity is fixed at 1.0 so the curve's rendered
+				     contrast equals the palette swatch's measured contrast and
+				     each curve clears WCAG 1.4.11 against bg-white and
+				     bg-gray-900. Issue #108. -->
 				{#each curves as c, i}
 					{@const d = buildPlannedPath(c, i)}
 					{#if d}
 						<path
 							{d}
 							fill="none"
-							stroke={curveColor(i, curves.length)}
-							stroke-width="1.5"
-							opacity={curveOpacity(i, curves.length)}
+							stroke={getCurveColor(i, curves.length)}
+							stroke-width={getCurveStrokeWidth(i, curves.length)}
 						/>
 					{/if}
 				{/each}
@@ -464,14 +472,18 @@
 					</text>
 				{/each}
 
-				<!-- Endpoint labels (R1..RN) -->
+				<!-- Endpoint labels (R1..RN). Dot keeps the curve color (3:1
+				     graphical object per WCAG 1.4.11). Text fill decoupled to
+				     gray-700 / gray-300 so it clears 4.5:1 against either bg
+				     mode regardless of palette swatch — issue #108. -->
 				{#each endpointLabels as ep}
 					<circle cx={ep.x} cy={ep.y} r="3" fill={ep.color} />
 					<text
 						x={ep.x + 6}
 						y={ep.y + 3}
 						font-size="9"
-						fill={ep.color}
+						fill="#374151"
+						class="dark:fill-gray-300"
 						font-weight="500"
 					>
 						{ep.label}
@@ -521,11 +533,17 @@
 				</summary>
 			{/if}
 			<div class="{shouldCollapse ? 'mt-2' : ''} flex flex-wrap gap-x-4 gap-y-1 px-2 text-xs">
+				<!-- Legend chip height mirrors curve stroke-width so legend +
+				     chart encode age via the same channel (oldest thinnest,
+				     newest thickest). Width fixed at 16px. Background color is
+				     the palette swatch (WCAG 1.4.11 graphical, ≥3:1 dual-bg
+				     verified). Text uses Tailwind text-gray-600/-400 which is
+				     already 1.4.3-compliant. Issue #108. -->
 				{#each curves as c, i}
 					<div class="flex items-center gap-1.5">
 						<span
-							class="inline-block w-3 h-0.5"
-							style="background-color: {curveColor(i, curves.length)}"
+							class="inline-block"
+							style="width: 16px; height: {getLegendChipHeight(i, curves.length)}px; background-color: {getCurveColor(i, curves.length)}"
 						></span>
 						<span class="text-gray-600 dark:text-gray-400">
 							{c.revision_number != null ? `R${c.revision_number}` : `#${i + 1}`}
@@ -539,7 +557,7 @@
 				{/each}
 				{#if curves.some((c) => c.is_executed)}
 					<div class="flex items-center gap-1.5">
-						<span class="inline-block w-3 h-1" style="background-color: #3b82f6"></span>
+						<span class="inline-block w-4 h-1" style="background-color: #3b82f6"></span>
 						<span class="text-gray-600 dark:text-gray-400">{executedLabel}</span>
 					</div>
 				{/if}

--- a/web/src/lib/components/charts/MultiRevisionSCurveChart.svelte
+++ b/web/src/lib/components/charts/MultiRevisionSCurveChart.svelte
@@ -416,7 +416,12 @@
 				     thickest); opacity is fixed at 1.0 so the curve's rendered
 				     contrast equals the palette swatch's measured contrast and
 				     each curve clears WCAG 1.4.11 against bg-white and
-				     bg-gray-900. Issue #108. -->
+				     bg-gray-900. `vector-effect="non-scaling-stroke"` pins the
+				     stroke at device-pixel width even after the SVG viewBox is
+				     scaled by the responsive `w-full` wrapper — without it, a
+				     1.0px stroke at a small viewport (SVG scaled <1.0×) drops
+				     below 1 device pixel and antialiases into a contrast-lossy
+				     ghost. Issue #108. -->
 				{#each curves as c, i}
 					{@const d = buildPlannedPath(c, i)}
 					{#if d}
@@ -425,6 +430,7 @@
 							fill="none"
 							stroke={getCurveColor(i, curves.length)}
 							stroke-width={getCurveStrokeWidth(i, curves.length)}
+							vector-effect="non-scaling-stroke"
 						/>
 					{/if}
 				{/each}
@@ -437,7 +443,18 @@
 				{#if lastExecutedIndex >= 0}
 					{@const d = buildActualPath(curves[lastExecutedIndex], lastExecutedIndex)}
 					{#if d}
-						<path {d} fill="none" stroke="#3b82f6" stroke-width="3" opacity="0.95" />
+						<!-- Executed-overlay opacity 0.95 keeps the stroke ≥3:1
+						     against both bg-white and bg-gray-900 (Y_blue≈0.219
+						     composited at α=0.95). vector-effect parallels the
+						     planned-curve treatment. Issue #108. -->
+						<path
+							{d}
+							fill="none"
+							stroke="#3b82f6"
+							stroke-width="3"
+							opacity="0.95"
+							vector-effect="non-scaling-stroke"
+						/>
 					{/if}
 				{/if}
 

--- a/web/src/lib/components/charts/MultiRevisionSCurveChart.test.ts
+++ b/web/src/lib/components/charts/MultiRevisionSCurveChart.test.ts
@@ -156,3 +156,112 @@ describe('MultiRevisionSCurveChart change-point direction encoding (issue #105)'
 		expect(cmp & Node.DOCUMENT_POSITION_PRECEDING).toBeTruthy();
 	});
 });
+
+// WCAG palette + stroke-width-as-age + decoupled endpoint-text-fill
+// rendering checks (issue #108). Light chart-level smoke tests; the
+// heavy palette/contrast/CVD verification lives in
+// `MultiRevisionSCurveChart.palette.test.ts`.
+
+import { PALETTE_11 } from './MultiRevisionSCurveChart.palette';
+
+function plannedPaths(container: HTMLElement): SVGPathElement[] {
+	// Planned-curve paths are the <path> elements with stroke attribute
+	// pointing at a palette swatch and NO is-actual marker. Selecting
+	// any path with a fill="none" stroke that's not the executed-blue
+	// hex catches them.
+	return Array.from(
+		container.querySelectorAll<SVGPathElement>('path[fill="none"]'),
+	).filter((p) => p.getAttribute('stroke') !== '#3b82f6');
+}
+
+describe('MultiRevisionSCurveChart palette + stroke-width-as-age (issue #108)', () => {
+	it('renders planned curves using palette hex values, not HSL', () => {
+		const { container } = render(MultiRevisionSCurveChart, {
+			props: {
+				curves: [
+					curve(1, '2026-01-01'),
+					curve(2, '2026-02-01'),
+					curve(3, '2026-03-01'),
+				],
+				changePoints: [],
+				directionLabels: { slip: 'Slip', improvement: 'Improvement', flat: 'Flat' },
+			},
+		});
+		const paths = plannedPaths(container);
+		expect(paths.length).toBe(3);
+		for (const p of paths) {
+			const stroke = p.getAttribute('stroke') ?? '';
+			// Must be a 6-char hex from PALETTE_11 — the prior HSL palette
+			// rendered as `hsl(...)` strings which start with 'hsl'.
+			expect(stroke.startsWith('hsl(')).toBe(false);
+			expect(PALETTE_11).toContain(stroke);
+		}
+	});
+
+	it('assigns monotone-increasing stroke-width across revision order', () => {
+		const { container } = render(MultiRevisionSCurveChart, {
+			props: {
+				curves: [
+					curve(1, '2026-01-01'),
+					curve(2, '2026-02-01'),
+					curve(3, '2026-03-01'),
+					curve(4, '2026-04-01'),
+				],
+				changePoints: [],
+				directionLabels: { slip: 'Slip', improvement: 'Improvement', flat: 'Flat' },
+			},
+		});
+		const paths = plannedPaths(container);
+		expect(paths.length).toBe(4);
+		const widths = paths.map((p) => Number(p.getAttribute('stroke-width')));
+		// Strictly increasing — encoding revision age via stroke-width-as-
+		// pre-attentive channel per council option (γ) on issue #108. A
+		// silent revert to opacity-as-age or constant width would trip this.
+		for (let i = 1; i < widths.length; i++) {
+			expect(widths[i]).toBeGreaterThan(widths[i - 1]);
+		}
+	});
+
+	it('omits any opacity attribute on planned curves (age routed to stroke-width, not alpha)', () => {
+		const { container } = render(MultiRevisionSCurveChart, {
+			props: {
+				curves: [curve(1, '2026-01-01'), curve(2, '2026-02-01')],
+				changePoints: [],
+				directionLabels: { slip: 'Slip', improvement: 'Improvement', flat: 'Flat' },
+			},
+		});
+		const paths = plannedPaths(container);
+		for (const p of paths) {
+			// Pre-#108 the chart set opacity=0.55..1.0 here; alpha-
+			// compositing made composited contrast fall below WCAG 3:1
+			// at low α. The current chart removes the attribute entirely.
+			expect(p.hasAttribute('opacity')).toBe(false);
+		}
+	});
+
+	it('renders endpoint label text with decoupled gray fill (not curve hex)', () => {
+		// Endpoint labels are visible when curves.length <= 8.
+		const { container } = render(MultiRevisionSCurveChart, {
+			props: {
+				curves: [curve(1, '2026-01-01'), curve(2, '2026-02-01')],
+				changePoints: [],
+				directionLabels: { slip: 'Slip', improvement: 'Improvement', flat: 'Flat' },
+			},
+		});
+		// The endpoint text labels carry font-weight="500" — that's the
+		// most discriminating attribute on them, given the chart also has
+		// axis-label and change-point-label text nodes.
+		const endpointTexts = Array.from(
+			container.querySelectorAll<SVGTextElement>('text[font-weight="500"]'),
+		);
+		expect(endpointTexts.length).toBe(2);
+		for (const t of endpointTexts) {
+			// Decoupled fill: light-mode #374151, dark-mode-class fall-through.
+			// WCAG 1.4.3 (4.5:1 text) requires the fixed gray pair because
+			// the palette swatches sit in Y∈[0.128,0.30] which cannot clear
+			// 4.5:1 against both backgrounds simultaneously.
+			expect(t.getAttribute('fill')).toBe('#374151');
+			expect(t.getAttribute('class')).toContain('dark:fill-gray-300');
+		}
+	});
+});

--- a/web/src/lib/components/charts/MultiRevisionSCurveChart.test.ts
+++ b/web/src/lib/components/charts/MultiRevisionSCurveChart.test.ts
@@ -162,7 +162,7 @@ describe('MultiRevisionSCurveChart change-point direction encoding (issue #105)'
 // heavy palette/contrast/CVD verification lives in
 // `MultiRevisionSCurveChart.palette.test.ts`.
 
-import { PALETTE_11 } from './MultiRevisionSCurveChart.palette';
+import { PALETTE_10 } from './MultiRevisionSCurveChart.palette';
 
 function plannedPaths(container: HTMLElement): SVGPathElement[] {
 	// Planned-curve paths are the <path> elements with stroke attribute
@@ -191,10 +191,10 @@ describe('MultiRevisionSCurveChart palette + stroke-width-as-age (issue #108)', 
 		expect(paths.length).toBe(3);
 		for (const p of paths) {
 			const stroke = p.getAttribute('stroke') ?? '';
-			// Must be a 6-char hex from PALETTE_11 — the prior HSL palette
+			// Must be a 6-char hex from PALETTE_10 — the prior HSL palette
 			// rendered as `hsl(...)` strings which start with 'hsl'.
 			expect(stroke.startsWith('hsl(')).toBe(false);
-			expect(PALETTE_11).toContain(stroke);
+			expect(PALETTE_10).toContain(stroke);
 		}
 	});
 
@@ -236,6 +236,26 @@ describe('MultiRevisionSCurveChart palette + stroke-width-as-age (issue #108)', 
 			// compositing made composited contrast fall below WCAG 3:1
 			// at low α. The current chart removes the attribute entirely.
 			expect(p.hasAttribute('opacity')).toBe(false);
+		}
+	});
+
+	it('pins planned-curve strokes to device pixels via vector-effect="non-scaling-stroke"', () => {
+		// DA exit-council finding 4 on PR #108: the 1.0px STROKE_WIDTH_MIN
+		// would ghost on responsive viewports where the SVG scales below
+		// 1× (e.g. mobile widths around 400px against viewBox 800×360).
+		// `vector-effect="non-scaling-stroke"` keeps the stroke at the
+		// declared width in DEVICE pixels regardless of SVG transform.
+		const { container } = render(MultiRevisionSCurveChart, {
+			props: {
+				curves: [curve(1, '2026-01-01'), curve(2, '2026-02-01')],
+				changePoints: [],
+				directionLabels: { slip: 'Slip', improvement: 'Improvement', flat: 'Flat' },
+			},
+		});
+		const paths = plannedPaths(container);
+		expect(paths.length).toBeGreaterThan(0);
+		for (const p of paths) {
+			expect(p.getAttribute('vector-effect')).toBe('non-scaling-stroke');
 		}
 	});
 

--- a/web/src/lib/utils/wcagContrast.test.ts
+++ b/web/src/lib/utils/wcagContrast.test.ts
@@ -1,0 +1,81 @@
+// MIT License
+// Copyright (c) 2026 Vitor Maia Rodovalho
+
+// Unit tests for WCAG 2.2 contrast primitives. Values cross-checked
+// against W3C "Understanding SC 1.4.3" worked examples and Tailwind
+// CSS design-token contrast pairs.
+
+import { describe, it, expect } from 'vitest';
+import { srgbToLinear, relativeLuminance, contrastRatio } from './wcagContrast';
+
+describe('srgbToLinear', () => {
+	it('returns 0 for channel=0', () => {
+		expect(srgbToLinear(0)).toBe(0);
+	});
+
+	it('returns ~1 for channel=255 (sRGB max)', () => {
+		expect(srgbToLinear(255)).toBeCloseTo(1, 6);
+	});
+
+	it('uses linear branch below the 0.04045 threshold (channel=10)', () => {
+		// 10/255 ≈ 0.0392 < 0.04045 → linear branch /12.92.
+		expect(srgbToLinear(10)).toBeCloseTo(10 / 255 / 12.92, 6);
+	});
+
+	it('uses gamma branch at channel=128 (mid sRGB)', () => {
+		// 128/255 ≈ 0.502 → ((0.502+0.055)/1.055)^2.4 ≈ 0.2159.
+		expect(srgbToLinear(128)).toBeCloseTo(0.2159, 3);
+	});
+});
+
+describe('relativeLuminance', () => {
+	it('returns 1.0 for white', () => {
+		expect(relativeLuminance('#ffffff')).toBeCloseTo(1.0, 6);
+	});
+
+	it('returns 0.0 for black', () => {
+		expect(relativeLuminance('#000000')).toBe(0);
+	});
+
+	it('returns ~0.0092 for tailwind bg-gray-900 (#111827)', () => {
+		// Spot-checked in PR #108 council math thread; load-bearing for the
+		// dual-bg contrast budget at 3:1 (Y_color ∈ [0.128, 0.300] feasible).
+		expect(relativeLuminance('#111827')).toBeCloseTo(0.0092, 3);
+	});
+
+	it('throws on malformed hex (no leading #)', () => {
+		expect(() => relativeLuminance('aabbcc')).toThrow();
+	});
+
+	it('throws on 3-char hex (we require #rrggbb)', () => {
+		expect(() => relativeLuminance('#abc')).toThrow();
+	});
+
+	it('throws on non-hex chars', () => {
+		expect(() => relativeLuminance('#gghhii')).toThrow();
+	});
+});
+
+describe('contrastRatio', () => {
+	it('returns 21:1 for black vs white (W3C reference maximum)', () => {
+		expect(contrastRatio('#000000', '#ffffff')).toBeCloseTo(21, 4);
+	});
+
+	it('returns 1:1 for identical colors', () => {
+		expect(contrastRatio('#3b82f6', '#3b82f6')).toBeCloseTo(1, 6);
+	});
+
+	it('is symmetric in argument order', () => {
+		const ab = contrastRatio('#374151', '#ffffff');
+		const ba = contrastRatio('#ffffff', '#374151');
+		expect(ab).toBe(ba);
+	});
+
+	it('returns ≥10:1 for tailwind text-gray-700 (#374151) vs white (design-token sanity)', () => {
+		expect(contrastRatio('#374151', '#ffffff')).toBeGreaterThanOrEqual(10);
+	});
+
+	it('returns ≥10:1 for tailwind text-gray-300 (#d1d5db) vs bg-gray-900 (dark-mode design-token sanity)', () => {
+		expect(contrastRatio('#d1d5db', '#111827')).toBeGreaterThanOrEqual(10);
+	});
+});

--- a/web/src/lib/utils/wcagContrast.ts
+++ b/web/src/lib/utils/wcagContrast.ts
@@ -1,0 +1,47 @@
+// MIT License
+// Copyright (c) 2026 Vitor Maia Rodovalho
+
+// WCAG 2.2 contrast computation primitives.
+//
+// Pure functions for sRGB→linear conversion, relative luminance, and
+// contrast ratio per W3C "Understanding SC 1.4.3" and "Relative luminance".
+// Used by chart components to verify palette swatches clear WCAG AA
+// thresholds:
+//   - 1.4.11 Non-text Contrast (AA): ≥3:1 for graphical objects vs adjacent color
+//   - 1.4.3  Contrast Minimum  (AA): ≥4.5:1 for normal text
+//
+// References:
+//   - https://www.w3.org/TR/WCAG22/#dfn-relative-luminance
+//   - https://www.w3.org/TR/WCAG22/#dfn-contrast-ratio
+//
+// Scope discipline: this file COMPUTES only — no palette decisions, no
+// component-specific helpers. Adding decide-functions (recommendedColor,
+// getAccessiblePaletteFor, etc.) belongs to a future a11y-pattern ADR.
+
+function parseHex(hex: string): [number, number, number] {
+	const m = /^#([0-9a-f]{6})$/i.exec(hex);
+	if (!m) throw new Error(`wcagContrast: invalid hex "${hex}" (expected #rrggbb)`);
+	const v = parseInt(m[1], 16);
+	return [(v >> 16) & 0xff, (v >> 8) & 0xff, v & 0xff];
+}
+
+export function srgbToLinear(channel: number): number {
+	const c = channel / 255;
+	return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+export function relativeLuminance(hex: string): number {
+	const [r, g, b] = parseHex(hex);
+	return (
+		0.2126 * srgbToLinear(r) +
+		0.7152 * srgbToLinear(g) +
+		0.0722 * srgbToLinear(b)
+	);
+}
+
+export function contrastRatio(hex1: string, hex2: string): number {
+	const l1 = relativeLuminance(hex1);
+	const l2 = relativeLuminance(hex2);
+	const [lo, hi] = l1 < l2 ? [l1, l2] : [l2, l1];
+	return (hi + 0.05) / (lo + 0.05);
+}


### PR DESCRIPTION
## Summary

Replaces the HSL hue-cycling palette (hue 0..180° at constant 45% lightness with opacity 0.55..1.0 across revision index) in `MultiRevisionSCurveChart.svelte` with 10 measured hex swatches. The prior palette failed WCAG 1.4.11 Non-text Contrast around hue~80° on white background (DA P3 #15 on PR #95) and the prior opacity weighting compounded the failure — in sRGB-encoded compositing the rendered stroke at α=0.55 falls to ~2.0:1 contrast against bg-white for every swatch in the feasible Y band.

The 10 palette swatches satisfy:

- Y ∈ [0.128, 0.300] — closed-form feasibility region for ≥3:1 vs both `bg-white` AND `bg-gray-900` simultaneously
- pairwise sRGB ΔE > 20 within palette AND vs reserved chart colors (executed-overlay blue, slip-amber, improvement-emerald, flat-gray markers)
- Viénot 1999 simulated deuteranopia AND protanopia pairwise ΔE > 15 — intra-palette AND vs each RESERVED color

Selected by exhaustive search over an 18-element Tailwind 600/700 candidate set. Size is 10 (not 11) because the full constraint stack has no feasible 11-element solution — the DA exit-council on the initial 11-element attempt surfaced two CVD-vs-RESERVED collisions (orange-700 ↔ slip-amber sim_ΔE≈3.2 deutan; yellow-700 ↔ slip-amber sim_ΔE≈7.3 deutan) plus two intra-palette protan collisions ({orange-600, lime-700} sim_ΔE=1.4; {violet-600, purple-600} sim_ΔE=3.0). Eliminating each conflict drops one candidate.

Final palette: red-600 / orange-600 / lime-600 / green-700 / teal-700 / cyan-600 / violet-600 / fuchsia-600 / pink-600 / rose-600 with min(deutan_ΔE, protan_ΔE) = 27 intra-palette.

Age encoding (oldest → newest revision) is routed to **stroke-width** (1.0 → 2.5 px linear), not opacity. The legend chip height (2 → 5 px) mirrors the stroke-width encoding so legend and chart share both channels. Endpoint label TEXT is decoupled from the curve color via `fill=\"#374151\"` + `class=\"dark:fill-gray-300\"` because the Y∈[0.128, 0.30] palette band cannot clear WCAG 1.4.3 (4.5:1 text) against both backgrounds simultaneously.

## Files

| File | Description |
|---|---|
| `web/src/lib/utils/wcagContrast.ts` | new — pure srgbToLinear / relativeLuminance / contrastRatio helpers; no decide-functions |
| `web/src/lib/utils/wcagContrast.test.ts` | new — W3C reference values + design-token sanity |
| `web/src/lib/components/charts/MultiRevisionSCurveChart.palette.ts` | new — `PALETTE_10` const + getCurveColor / getCurveStrokeWidth / getLegendChipHeight + measurement-methodology header |
| `web/src/lib/components/charts/MultiRevisionSCurveChart.palette.test.ts` | new — palette pin + dual-bg contrast loop + ΔE distinctness + Viénot CVD (intra-palette + vs RESERVED) + helper-shape + RangeError guards |
| `web/src/lib/components/charts/MultiRevisionSCurveChart.svelte` | modified — drops inline HSL palette + opacity weighting; uses palette imports; planned curves get `vector-effect=\"non-scaling-stroke\"`; endpoint text decoupled |
| `web/src/lib/components/charts/MultiRevisionSCurveChart.test.ts` | modified — 5 chart-level DOM-attribute regression checks |

## Tests

- 130/130 frontend tests pass (vitest, +18 new for palette + helpers + chart smoke)
- 0 errors / 0 warnings (svelte-check)
- clean production build (vite + adapter-static)

DOM-attribute regression in the new tests covers: palette-hex-not-HSL, strictly-monotone stroke-width, no opacity attribute on planned curves, endpoint text decoupling to `#374151` + dark-mode class, `vector-effect=\"non-scaling-stroke\"` present. Visual regression (CVD simulation screenshots) is NOT in the automated test suite — that requires operator browser-verification, see closure checklist below.

## Council trail

Frontend-ux-reviewer entry-council pre-edit + devils-advocate exit-council pre-PR-open both ran. The DA exit-council on the initial 11-element-palette attempt returned HOLD with 7 mandatories; commit `642355e` applies all 7 before this PR opens. Mandatory changes: (P0) palette-header math honesty re sRGB-encoded compositing; (P2) RangeError guards on helpers; (P1) palette resize 11 → 10 after CVD-vs-RESERVED surfaced; (P1) CVD-vs-RESERVED tests added; (P1) HiDPI stroke fix via `vector-effect`; (P2) softened overclaim language; filed #155 as follow-up for the in-component sibling marker opacity issue.

## Closes / refs

- Closes #108
- Filed #155 (P1, change-point marker opacity=0.55 fails WCAG 1.4.11, same alpha-compositing principle, scoped out of this PR per honest discipline)

## Operator visual closure pending

- [ ] `/revision-trends` rendered at N=10 in light mode
- [ ] `/revision-trends` rendered at N=10 in dark mode
- [ ] Deuteranopia simulation (Chrome DevTools rendering tab OR Stark extension)
- [ ] Protanopia simulation
- [ ] (Optional) Mobile-narrow viewport check at devicePixelRatio=2/3 to verify `vector-effect=\"non-scaling-stroke\"` keeps the 1.0px oldest stroke visible