### PR TITLE
fix(frontend): capture masked client errors via boundary onerror

### DIFF
--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -3,7 +3,7 @@
 	import { onMount } from 'svelte';
 	import { user, isLoading, initAuth, signOut } from '$lib/auth';
 	import { isWarmingUp, warmUp } from '$lib/api';
-	import { initAnalytics } from '$lib/analytics';
+	import { initAnalytics, trackEvent } from '$lib/analytics';
 	import { isDark, toggleTheme, initTheme } from '$lib/stores/theme';
 	import Breadcrumb from '$lib/components/Breadcrumb.svelte';
 	import ComputingBanner from '$lib/components/ComputingBanner.svelte';
@@ -57,6 +57,23 @@
 
 	function closeSidebar() {
 		sidebarOpen = false;
+	}
+
+	// Error-boundary reporter. A throw inside a reactive effect bubbles through
+	// Svelte's <svelte:boundary> (a different path than SvelteKit's
+	// hooks.client.ts handleError), so without this the real error is invisible
+	// — it only surfaced as a masked "Cannot read properties of null (reading
+	// 'error')" from Svelte's own propagation when no boundary handled it. Log
+	// the genuine error (console + PostHog) so client crashes are diagnosable,
+	// while the boundary's `failed` snippet degrades the UI gracefully.
+	function reportClientError(error: unknown): void {
+		const message = error instanceof Error ? error.message : String(error);
+		console.error('[MeridianIQ boundary]', error);
+		trackEvent('client_render_error', {
+			message,
+			stack: error instanceof Error ? error.stack?.slice(0, 2000) : undefined,
+			path: browser ? window.location.pathname : undefined,
+		});
 	}
 
 	interface NavItem { href: string; labelKey: string; icon: string; auth?: boolean; }
@@ -367,9 +384,9 @@
 				{$t('warmup.message')}
 			</div>
 		{/if}
-		<Breadcrumb />
-		<ComputingBanner />
-		<svelte:boundary>
+		<svelte:boundary onerror={reportClientError}>
+			<Breadcrumb />
+			<ComputingBanner />
 			{@render children()}
 			{#snippet failed(error, reset)}
 				<div class="max-w-2xl mx-auto px-4 py-16 text-center">


### PR DESCRIPTION
## Symptom
Prod console: `Uncaught TypeError: Cannot read properties of null (reading 'error')`.

## Root cause (traced via sourcemaps)
The minified stack maps to **Svelte's own** `src/internal/client/error-handling.js` (`invoke_error_boundary`), not app code. A throw inside a reactive effect bubbles through Svelte's `<svelte:boundary>` propagation — a **different path** than SvelteKit's `hooks.client.ts handleError`. When the bubbling error reaches an effect that has the boundary flag set but a **null** `Boundary` instance (i.e. it escaped the layout boundary and hit the SvelteKit root), Svelte does `(effect.b).error(e)` → `b` is null → the masking TypeError. The **real** error was never logged.

## Fix
- Add `onerror` to the layout `<svelte:boundary>` → logs the genuine error (console + PostHog `client_render_error` with message/stack/path) so client crashes are diagnosable instead of masked.
- Move `<Breadcrumb />` + `<ComputingBanner />` **inside** the boundary so a throw in the reactive layout chrome is caught + degraded gracefully (existing `failed` snippet) instead of escaping to the root unmasked.

## Scope / honesty
This **stops the hard crash and surfaces the real error** — it does not itself fix the underlying component throw. That throw was **not reproducible** logged-out / without data (a full sweep of ~40 routes via a local headless browser produced zero errors), so it needs real schedule data + interaction (likely the schedule/chart/WBS view the owner was using). With this merged, the next occurrence logs the actual cause (look for `[MeridianIQ boundary]` / the `client_render_error` event). A parallel viz audit is identifying fragile chart/ScheduleViewer code.

## Verification
svelte-check 0/0, production build clean.