### PR TITLE
fix(schedule-view): order WBS by code-path (1.2 before 1.10), not alphabetically

### DIFF
--- a/src/analytics/schedule_view.py
+++ b/src/analytics/schedule_view.py
@@ -231,6 +231,29 @@ def _apply_grouping(
     return schedule.model_copy(update={"wbs_nodes": new_wbs_nodes, "activities": new_activities})
 
 
+def _wbs_code_key(code: str) -> list[tuple[int, int, str]]:
+    """Natural sort key for a WBS code so ``1.2`` precedes ``1.10``.
+
+    Splits the code into numeric and text runs: numeric runs compare by value
+    (1, 2, 10) rather than lexically (1, 10, 2), and text runs sort after
+    numerics. WBS code-path order — not alphabetical name order — is what P6
+    users expect in the outline, and what GAO / DCMA schedule-presentation
+    review assumes; alpha-sorting otherwise-correct data reads as broken.
+
+    Each segment is normalised to a uniform ``(kind, number, text)`` tuple so
+    the keys are always mutually comparable.
+    """
+    parts: list[tuple[int, int, str]] = []
+    for seg in re.split(r"(\d+)", code or ""):
+        if seg == "":
+            continue
+        if seg.isdigit():
+            parts.append((0, int(seg), ""))
+        else:
+            parts.append((1, 0, seg.lower()))
+    return parts
+
+
 def build_schedule_view(
     schedule: ParsedSchedule,
     baseline: ParsedSchedule | None = None,
@@ -314,9 +337,11 @@ def build_schedule_view(
             node = wbs_map[child_id]
             node.children = _build_tree(child_id)
             children.append(node)
-        return sorted(children, key=lambda n: n.short_name or n.name)
+        return sorted(children, key=lambda n: _wbs_code_key(n.short_name or n.name))
 
-    for rid in sorted(root_ids):
+    for rid in sorted(
+        root_ids, key=lambda r: _wbs_code_key(wbs_map[r].short_name or wbs_map[r].name)
+    ):
         if rid in wbs_map:
             root = wbs_map[rid]
             root.children = _build_tree(rid)
@@ -336,6 +361,18 @@ def build_schedule_view(
     for root in result.wbs_tree:
         _build_path(root, "")
 
+    # Depth-first ordinal of each WBS node in the (now code-ordered) tree, so
+    # activities sort in true outline order. A plain wbs_path string sort would
+    # regress to lexical order (it would place '1/10' before '1/2').
+    wbs_order: dict[str, int] = {}
+
+    def _assign_order(nodes: list[WBSNode]) -> None:
+        for node in nodes:
+            wbs_order[node.wbs_id] = len(wbs_order)
+            _assign_order(node.children)
+
+    _assign_order(result.wbs_tree)
+
     # Build baseline lookup
     baseline_dates: dict[str, tuple[str, str]] = {}
     if baseline:
@@ -350,11 +387,11 @@ def build_schedule_view(
     if schedule.calendars:
         day_hours = schedule.calendars[0].day_hr_cnt or 8.0
 
-    # Flatten activities sorted by WBS path + early start
+    # Flatten activities sorted by WBS outline order (code-path), then early start
     sorted_tasks = sorted(
         schedule.activities,
         key=lambda t: (
-            wbs_path.get(t.wbs_id, ""),
+            wbs_order.get(t.wbs_id, len(wbs_order)),
             t.early_start_date or t.target_start_date or datetime.max,
         ),
     )

--- a/tests/analytics/test_schedule_view.py
+++ b/tests/analytics/test_schedule_view.py
@@ -149,6 +149,74 @@ class TestScheduleView:
         w3_indices = [i for i, w in enumerate(wbs_ids) if w == "W3"]
         assert max(w2_indices) < min(w3_indices)
 
+    def test_wbs_natural_code_ordering(self) -> None:
+        """WBS siblings + activities must order by code NUMERICALLY (1.2 before
+        1.10, not lexically), and roots 1 before 2 — the P6 outline order GAO /
+        DCMA presentation review assumes."""
+
+        def _task(tid: str, wbs: str) -> Task:
+            return Task(
+                task_id=tid,
+                proj_id="P",
+                wbs_id=wbs,
+                task_code=tid,
+                task_name=tid,
+                task_type="TT_Task",
+                status_code="TK_NotStart",
+                early_start_date=_date(0),
+                early_end_date=_date(1),
+                target_drtn_hr_cnt=8,
+            )
+
+        schedule = ParsedSchedule(
+            projects=[Project(proj_id="P", proj_short_name="Coded", last_recalc_date=_date(0))],
+            calendars=[Calendar(clndr_id="C", day_hr_cnt=8, week_hr_cnt=40, default_flag="Y")],
+            wbs_nodes=[
+                WBS(
+                    wbs_id="R1", proj_id="P", wbs_short_name="1", wbs_name="One", proj_node_flag="Y"
+                ),
+                WBS(
+                    wbs_id="R2", proj_id="P", wbs_short_name="2", wbs_name="Two", proj_node_flag="Y"
+                ),
+                WBS(
+                    wbs_id="W_1_1",
+                    proj_id="P",
+                    parent_wbs_id="R1",
+                    wbs_short_name="1.1",
+                    wbs_name="A",
+                ),
+                WBS(
+                    wbs_id="W_1_2",
+                    proj_id="P",
+                    parent_wbs_id="R1",
+                    wbs_short_name="1.2",
+                    wbs_name="B",
+                ),
+                WBS(
+                    wbs_id="W_1_10",
+                    proj_id="P",
+                    parent_wbs_id="R1",
+                    wbs_short_name="1.10",
+                    wbs_name="C",
+                ),
+            ],
+            # inserted deliberately out of order to prove ordering is computed
+            activities=[
+                _task("T10", "W_1_10"),
+                _task("T2", "W_1_2"),
+                _task("T1", "W_1_1"),
+                _task("Troot2", "R2"),
+            ],
+        )
+        result = build_schedule_view(schedule)
+
+        # roots ordered by code: 1 before 2
+        assert [n.short_name for n in result.wbs_tree] == ["1", "2"]
+        # children of "1" natural-ordered: 1.1, 1.2, 1.10 (NOT 1.1, 1.10, 1.2)
+        assert [c.short_name for c in result.wbs_tree[0].children] == ["1.1", "1.2", "1.10"]
+        # activities follow the corrected outline order
+        assert [a.task_id for a in result.activities] == ["T1", "T2", "T10", "Troot2"]
+
     def test_activity_types(self) -> None:
         result = build_schedule_view(_make_schedule())
         types = {a.task_id: a.task_type for a in result.activities}


### PR DESCRIPTION
## W1 — top recommendation from the visualization audit

The ScheduleViewer left tree **and** the flattened activity order were sorted by WBS **name lexically**, so code `1.10` sorted before `1.2` and `Sitework` before `Foundations`. The frontend trusts server order, so the outline read as scrambled — the most visceral "this tool is broken" signal to a planner who lives in P6 outline order. GAO / DCMA schedule-presentation review assumes WBS code-path order, so this was a standards-compliance gap, not just cosmetics, even though the CPM underneath is correct.

## One root cause, three sites (`src/analytics/schedule_view.py`)
- sibling sort (`_build_tree`): `key = n.short_name or n.name` (alphabetical)
- root sort: `sorted(root_ids)` (by P6 internal id)
- activity sort: keyed off the name-derived `wbs_path` string

## Fix
- `_wbs_code_key()` — natural WBS-code key; numeric segments compare by value (1, 2, 10), used for both sibling and root ordering.
- `wbs_order` — a depth-first ordinal over the corrected tree drives the activity sort, so activities follow true outline order regardless of code formatting (a plain path-string sort would still put `1/10` before `1/2`).
- No schema / migration change.

## Tests
`+1` test (`test_wbs_natural_code_ordering`) asserting 1.2 precedes 1.10, roots 1 before 2, and the activity outline order. **Full backend suite green: 1687 passed, 6 skipped.** ruff + format clean; no new mypy-strict errors.

## Note
This makes the CLAUDE.md / project_state.md claim "correct two-key activity ordering server-side" actually TRUE (the audit flagged it was false before this). Next W1 items: two-tier time axis, gridline 100-day cap, chart dark mode.