### PR TITLE
feat(schedule-viewer): two-tier time axis + uncapped gridlines (W1)

### DIFF
--- a/web/src/lib/components/ScheduleViewer/GanttCanvas.svelte
+++ b/web/src/lib/components/ScheduleViewer/GanttCanvas.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { ActivityView, RelationshipView, WBSAggregate, FlatRow } from './types';
-	import { daysBetween, parseDate, getBarColor, formatDateShort } from './utils';
+	import { daysBetween, parseDate, getBarColor, formatDateShort, generateTimeTicks } from './utils';
 	import TimeScale from './TimeScale.svelte';
 
 	interface Props {
@@ -47,7 +47,7 @@
 
 	const WIDTH = 1200;
 	const PAD_LEFT = 0;
-	const HEADER_H = 28;
+	const HEADER_H = 40; // two-tier time-axis header (coarse band over fine band)
 	const BAR_H = 14;
 	const BAR_PAD = $derived((rowHeight - BAR_H) / 2);
 	const BUFFER_ROWS = 20;
@@ -60,6 +60,9 @@
 	}
 
 	const totalDays = $derived(Math.max(1, daysBetween(startDate, endDate)));
+	// Same two-tier axis the header uses — drives gridlines so they align under
+	// the labels and span the whole schedule (no fixed day-count cap).
+	const axis = $derived(generateTimeTicks(startDate, endDate, zoomLevel, WIDTH));
 
 	function xPos(dateStr: string): number {
 		if (!dateStr) return 0;
@@ -131,12 +134,13 @@
 		{dataDate}
 	/>
 
-	<!-- Grid lines (every tick) -->
-	{#each Array(Math.min(totalDays + 1, 100)) as _, d}
-		{@const x = (d / totalDays) * WIDTH}
-		{#if d % (zoomLevel === 'day' ? 1 : zoomLevel === 'week' ? 7 : 30) === 0}
-			<line x1={x} y1={HEADER_H} x2={x} y2={svgHeight} stroke="#f3f4f6" stroke-width="0.5" class="dark:stroke-gray-800" />
-		{/if}
+	<!-- Grid lines: one per axis tick, spanning the FULL schedule (the old
+	     Array(min(totalDays,100)) loop left everything past day 100 ungridded). -->
+	{#each axis.minor as tick}
+		<line x1={tick.x * WIDTH} y1={HEADER_H} x2={tick.x * WIDTH} y2={svgHeight} stroke="#f3f4f6" stroke-width="0.5" class="dark:stroke-gray-800" />
+	{/each}
+	{#each axis.major as m}
+		<line x1={m.x * WIDTH} y1={HEADER_H} x2={m.x * WIDTH} y2={svgHeight} stroke="#e5e7eb" stroke-width="0.75" class="dark:stroke-gray-700" />
 	{/each}
 
 	<!-- Weekend shading -->

--- a/web/src/lib/components/ScheduleViewer/TimeScale.svelte
+++ b/web/src/lib/components/ScheduleViewer/TimeScale.svelte
@@ -20,7 +20,7 @@
 	}: Props = $props();
 
 	const chartWidth = $derived(width - padLeft);
-	const ticks = $derived(generateTimeTicks(startDate, endDate, zoomLevel));
+	const axis = $derived(generateTimeTicks(startDate, endDate, zoomLevel));
 
 	const todayX = $derived(() => {
 		if (!startDate || !endDate) return -1;
@@ -42,14 +42,27 @@
 </script>
 
 <g class="time-scale">
-	<!-- Background -->
-	<rect x={padLeft} y="0" width={chartWidth} height="28" fill="#f8fafc" class="dark:fill-gray-800" />
+	<!-- Background (two-tier header: coarse band over fine band) -->
+	<rect x={padLeft} y="0" width={chartWidth} height="40" fill="#f8fafc" class="dark:fill-gray-800" />
 
-	<!-- Tick lines and labels -->
-	{#each ticks as tick}
+	<!-- Major tier: coarse context bands (year over month, or month over week/day) -->
+	{#each axis.major as m}
+		{@const mx = padLeft + m.x * chartWidth}
+		{@const mxEnd = padLeft + m.xEnd * chartWidth}
+		<line x1={mx} y1="0" x2={mx} y2="40" stroke="#e5e7eb" stroke-width="1" class="dark:stroke-gray-700" />
+		<text x={(mx + mxEnd) / 2} y="13" text-anchor="middle" class="text-[9px] font-semibold fill-gray-600 dark:fill-gray-300 select-none">
+			{m.label}
+		</text>
+	{/each}
+
+	<!-- Divider between the two tiers -->
+	<line x1={padLeft} y1="20" x2={width} y2="20" stroke="#e5e7eb" stroke-width="1" class="dark:stroke-gray-700" />
+
+	<!-- Minor tier: fine ticks + labels -->
+	{#each axis.minor as tick}
 		{@const x = padLeft + tick.x * chartWidth}
-		<line x1={x} y1="28" x2={x} y2="32" stroke="#d1d5db" stroke-width="1" />
-		<text {x} y="18" text-anchor="middle" class="text-[8px] fill-gray-500 dark:fill-gray-400 select-none">
+		<line x1={x} y1="34" x2={x} y2="40" stroke="#d1d5db" stroke-width="1" class="dark:stroke-gray-600" />
+		<text {x} y="31" text-anchor="middle" class="text-[8px] fill-gray-500 dark:fill-gray-400 select-none">
 			{tick.label}
 		</text>
 	{/each}
@@ -67,5 +80,5 @@
 	{/if}
 
 	<!-- Bottom border -->
-	<line x1={padLeft} y1="28" x2={width} y2="28" stroke="#e5e7eb" stroke-width="1" />
+	<line x1={padLeft} y1="40" x2={width} y2="40" stroke="#e5e7eb" stroke-width="1" class="dark:stroke-gray-700" />
 </g>

--- a/web/src/lib/components/ScheduleViewer/WBSTree.svelte
+++ b/web/src/lib/components/ScheduleViewer/WBSTree.svelte
@@ -50,8 +50,9 @@
 	class="wbs-tree overflow-hidden border-r border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900"
 	style="width: 550px; min-width: 550px; height: 100%; position: relative;"
 >
-	<!-- Header -->
-	<div class="h-7 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 flex items-center text-[9px] font-semibold text-gray-500 dark:text-gray-400 uppercase">
+	<!-- Header — height matches GanttCanvas HEADER_H (40px, two-tier axis) so
+	     the left-panel rows align with the right-panel bars. -->
+	<div class="h-10 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 flex items-end pb-1 text-[9px] font-semibold text-gray-500 dark:text-gray-400 uppercase">
 		<span class="w-[72px] text-center shrink-0 px-1">ID</span>
 		<span class="flex-1 min-w-0 px-1">Name</span>
 		<span class="w-9 text-center shrink-0">Dur</span>
@@ -62,7 +63,7 @@
 	</div>
 
 	<!-- Scrollable content (virtual scrolling) -->
-	<div class="overflow-hidden" style="height: calc(100% - 28px); position: relative;">
+	<div class="overflow-hidden" style="height: calc(100% - 40px); position: relative;">
 		<!-- Spacer for full scroll height -->
 		<div style="height: {totalHeight}px; position: relative; transform: translateY(-{scrollTop}px);">
 			{#each renderedRows as row, i}

--- a/web/src/lib/components/ScheduleViewer/utils.test.ts
+++ b/web/src/lib/components/ScheduleViewer/utils.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { generateTimeTicks } from './utils';
+
+describe('generateTimeTicks — two-tier time axis', () => {
+	it('returns both a minor and a major tier', () => {
+		const axis = generateTimeTicks('2026-01-01', '2026-12-31', 'month');
+		expect(Array.isArray(axis.minor)).toBe(true);
+		expect(Array.isArray(axis.major)).toBe(true);
+		expect(axis.minor.length).toBeGreaterThan(0);
+		expect(axis.major.length).toBeGreaterThan(0);
+	});
+
+	it('major bands are contiguous and span the whole chart (first x=0, last xEnd=1)', () => {
+		const axis = generateTimeTicks('2026-03-15', '2028-06-30', 'month');
+		expect(axis.major[0].x).toBe(0);
+		expect(axis.major[axis.major.length - 1].xEnd).toBe(1);
+		for (let i = 0; i < axis.major.length - 1; i++) {
+			// each band's right edge is the next band's left edge — no gaps
+			expect(axis.major[i].xEnd).toBeCloseTo(axis.major[i + 1].x, 6);
+		}
+	});
+
+	it('month zoom uses YEAR major bands', () => {
+		const axis = generateTimeTicks('2026-01-01', '2028-12-31', 'month');
+		expect(axis.major.map((m) => m.label)).toEqual(['2026', '2027', '2028']);
+	});
+
+	it('week zoom uses MONTH major bands', () => {
+		const axis = generateTimeTicks('2026-01-01', '2026-03-31', 'week');
+		expect(axis.major[0].label).toMatch(/Jan/);
+		expect(axis.major.length).toBeGreaterThanOrEqual(3); // Jan, Feb, Mar
+	});
+
+	it('minor tick fractions are within [0,1] and strictly ascending', () => {
+		const axis = generateTimeTicks('2026-01-01', '2026-06-30', 'week');
+		const xs = axis.minor.map((t) => t.x);
+		expect(Math.min(...xs)).toBeGreaterThanOrEqual(0);
+		expect(Math.max(...xs)).toBeLessThanOrEqual(1.0001);
+		for (let i = 1; i < xs.length; i++) {
+			expect(xs[i]).toBeGreaterThan(xs[i - 1]);
+		}
+	});
+
+	it('long schedules keep full coverage (gridlines are no longer capped at 100 days)', () => {
+		// A 3-year month-zoom schedule. The old Array(min(totalDays, 100)) loop
+		// stopped gridding past day 100; the major tier must still reach xEnd=1.
+		const axis = generateTimeTicks('2026-01-01', '2029-01-01', 'month');
+		expect(axis.major[axis.major.length - 1].xEnd).toBe(1);
+		expect(axis.major.length).toBeGreaterThanOrEqual(3);
+	});
+});

--- a/web/src/lib/components/ScheduleViewer/utils.ts
+++ b/web/src/lib/components/ScheduleViewer/utils.ts
@@ -22,17 +22,78 @@ export function formatDateFull(iso: string): string {
 	return iso?.slice(0, 10) || '';
 }
 
-/** Generate tick marks for the time axis with dynamic density. */
+export interface TimeTick {
+	date: string;
+	label: string;
+	x: number; // fraction 0..1 of the chart width
+}
+
+export interface MajorTick {
+	label: string;
+	x: number; // fraction 0..1 — left edge of the band
+	xEnd: number; // fraction 0..1 — right edge of the band
+}
+
+export interface TimeAxis {
+	minor: TimeTick[];
+	major: MajorTick[];
+}
+
+/** Build the coarse "major" tier: contiguous year (or month) bands for context. */
+function buildMajorTier(
+	start: Date,
+	end: Date,
+	startIso: string,
+	totalDays: number,
+	unit: 'year' | 'month',
+): MajorTick[] {
+	// Boundary dates: the chart start, then each first-of-next-unit up to end.
+	const boundaries: Date[] = [new Date(start)];
+	const cursor = new Date(start);
+	if (unit === 'year') {
+		cursor.setMonth(0, 1);
+		cursor.setFullYear(cursor.getFullYear() + 1);
+	} else {
+		cursor.setDate(1);
+		cursor.setMonth(cursor.getMonth() + 1);
+	}
+	while (cursor <= end) {
+		boundaries.push(new Date(cursor));
+		if (unit === 'year') cursor.setFullYear(cursor.getFullYear() + 1);
+		else cursor.setMonth(cursor.getMonth() + 1);
+	}
+
+	const major: MajorTick[] = [];
+	for (let i = 0; i < boundaries.length; i++) {
+		const b = boundaries[i];
+		// First band starts at the chart's left edge regardless of where the
+		// start date falls within its unit.
+		const x = i === 0 ? 0 : daysBetween(startIso, b.toISOString().slice(0, 10)) / totalDays;
+		const next = boundaries[i + 1];
+		const xEnd = next ? daysBetween(startIso, next.toISOString().slice(0, 10)) / totalDays : 1;
+		const label =
+			unit === 'year'
+				? String(b.getFullYear())
+				: b.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
+		major.push({ label, x, xEnd });
+	}
+	return major;
+}
+
+/** Generate a TWO-TIER time axis: a coarse `major` tier (year over month, or
+ *  month over week/day) for context, plus a fine `minor` tier with adaptive
+ *  density. A single flat tier is the most-cited reason a Gantt "looks off".
+ */
 export function generateTimeTicks(
 	startDate: string,
 	endDate: string,
 	zoomLevel: 'day' | 'week' | 'month',
 	svgWidth: number = 1200,
-): { date: string; label: string; x: number }[] {
+): TimeAxis {
 	const start = parseDate(startDate);
 	const end = parseDate(endDate);
 	const totalDays = Math.max(1, daysBetween(startDate, endDate));
-	const ticks: { date: string; label: string; x: number }[] = [];
+	const minor: TimeTick[] = [];
 
 	// Minimum pixel distance between labels (prevents overlap)
 	const MIN_PX = 48;
@@ -48,28 +109,27 @@ export function generateTimeTicks(
 	}
 
 	const current = new Date(start);
-
 	while (current <= end) {
 		const iso = current.toISOString().slice(0, 10);
-		const dayOffset = daysBetween(startDate, iso);
-		const x = dayOffset / totalDays;
+		const x = daysBetween(startDate, iso) / totalDays;
 
+		// The year/long context now lives in the major tier, so the minor label
+		// stays compact (month name, or month+day at finer zooms).
 		let label: string;
-		if (stepDays >= 90) {
-			label = current.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
-		} else if (stepDays >= 28 || zoomLevel === 'month') {
-			label = current.toLocaleDateString('en-US', { month: 'short', year: '2-digit' });
+		if (stepDays >= 28 || zoomLevel === 'month') {
+			label = current.toLocaleDateString('en-US', { month: 'short' });
 		} else if (stepDays >= 5) {
 			label = current.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 		} else {
 			label = current.toLocaleDateString('en-US', { weekday: 'short', day: 'numeric' });
 		}
 
-		ticks.push({ date: iso, label, x });
+		minor.push({ date: iso, label, x });
 		current.setDate(current.getDate() + stepDays);
 	}
 
-	return ticks;
+	const majorUnit: 'year' | 'month' = zoomLevel === 'month' ? 'year' : 'month';
+	return { minor, major: buildMajorTier(start, end, startDate, totalDays, majorUnit) };
 }
 
 /** Format date as compact column label (e.g. "15-Jan-26"). */


### PR DESCRIPTION
## W1 — items #2 + #3 from the visualization audit
The two top "this Gantt looks off" tells, both presentation-only over already-correct geometry.

### 1. Two-tier time axis
`generateTimeTicks` now returns `{ minor, major }`: the fine tier (adaptive density, unchanged) **plus a coarse context tier** — **year** bands at month zoom, **month** bands at week/day zoom. `TimeScale` renders both (coarse over fine, header **28→40px**). A single flat date row is the single most-cited reason a Gantt reads as a generic bar chart instead of a schedule.

### 2. Uncapped gridlines
`GanttCanvas` drew gridlines from `Array(Math.min(totalDays + 1, 100))` — so any schedule **>100 days** (≈ all real ones) had **no time reference past day 100** and bars appeared to float. Gridlines now derive from the **same tick set** as the header (one per minor tick + a stronger line per major boundary), spanning the full span and aligning under the labels.

### Alignment
`HEADER_H` 28→40 in GanttCanvas; WBSTree column header `h-7`→`h-10` + `calc(100% - 40px)` so the left-panel rows stay aligned with the right-panel bars (the one cross-panel coupling).

### Verification
`+6` vitest cases on the axis math (contiguous full-span major bands; year-vs-month tier by zoom; ascending in-range minor fractions). svelte-check **0/0**, build clean, **136** frontend tests green.

**Note:** logic + compile + alignment math are verified headless; a quick visual confirm on a real >1-year schedule (light + dark) is the recommended final check since the viewer needs auth+data to render.

Next W1 item: chart dark mode (10 components).