### PR TITLE
fix(charts): dark-mode variants for SVG gray text/axes in 10 charts (W1)

### DIFF
--- a/web/src/lib/components/charts/BarChart.svelte
+++ b/web/src/lib/components/charts/BarChart.svelte
@@ -47,7 +47,7 @@
 	}
 </script>
 
-<div class="bg-white border border-gray-200 rounded-lg p-4">
+<div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
 	{#if title}
 		<p class="text-sm font-medium text-gray-700 mb-3">{title}</p>
 	{/if}
@@ -63,7 +63,7 @@
 					{@const y = i * (hBarH + 4)}
 					{@const w = (item.value / yMax) * (chartWidth - 40)}
 					<!-- Label -->
-					<text x="-4" y={y + hBarH / 2} text-anchor="end" dominant-baseline="middle" font-size="10" fill="#6b7280">
+					<text x="-4" y={y + hBarH / 2} text-anchor="end" dominant-baseline="middle" font-size="10" fill="#6b7280" class="dark:fill-gray-400">
 						{item.label.length > 12 ? item.label.slice(0, 12) + '...' : item.label}
 					</text>
 					<!-- Bar -->
@@ -77,7 +77,7 @@
 					{/if}
 					<!-- Value label -->
 					{#if showValues}
-						<text x={Math.max(0, w) + 4} y={y + hBarH / 2} dominant-baseline="middle" font-size="10" fill="#374151">
+						<text x={Math.max(0, w) + 4} y={y + hBarH / 2} dominant-baseline="middle" font-size="10" fill="#374151" class="dark:fill-gray-300">
 							{formatValue(item.value)}
 						</text>
 					{/if}
@@ -103,18 +103,18 @@
 					{/if}
 					<!-- Value label -->
 					{#if showValues}
-						<text x={x + vBarW / 2} y={y - 4} text-anchor="middle" font-size="9" fill="#374151">
+						<text x={x + vBarW / 2} y={y - 4} text-anchor="middle" font-size="9" fill="#374151" class="dark:fill-gray-300">
 							{formatValue(item.value)}
 						</text>
 					{/if}
 					<!-- X label -->
-					<text x={x + vBarW / 2} y={chartHeight + 14} text-anchor="middle" font-size="9" fill="#6b7280"
+					<text x={x + vBarW / 2} y={chartHeight + 14} text-anchor="middle" font-size="9" fill="#6b7280" class="dark:fill-gray-400"
 						transform="rotate(-30, {x + vBarW / 2}, {chartHeight + 14})">
 						{item.label.length > 10 ? item.label.slice(0, 10) + '..' : item.label}
 					</text>
 				{/each}
 				<!-- Baseline -->
-				<line x1="0" y1={chartHeight} x2={chartWidth} y2={chartHeight} stroke="#d1d5db" stroke-width="1" />
+				<line x1="0" y1={chartHeight} x2={chartWidth} y2={chartHeight} stroke="#d1d5db" stroke-width="1" class="dark:stroke-gray-600" />
 			</g>
 		</svg>
 	{/if}

--- a/web/src/lib/components/charts/GanttChart.svelte
+++ b/web/src/lib/components/charts/GanttChart.svelte
@@ -44,7 +44,7 @@
 	});
 </script>
 
-<div class="bg-white border border-gray-200 rounded-lg p-4">
+<div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
 	{#if title}
 		<p class="text-sm font-semibold text-gray-700 mb-2">{title}</p>
 	{/if}
@@ -58,7 +58,7 @@
 				<line
 					x1={xScale(mark)} y1={PAD.top - 5}
 					x2={xScale(mark)} y2={svgH - PAD.bottom}
-					stroke="#f3f4f6" stroke-width="1"
+					stroke="#f3f4f6" stroke-width="1" class="dark:stroke-gray-800"
 				/>
 				<text x={xScale(mark)} y={PAD.top - 10} text-anchor="middle" class="text-[8px] fill-gray-400">
 					D{mark}
@@ -73,7 +73,7 @@
 				{@const fill = item.color || (item.isCritical ? '#ef4444' : '#3b82f6')}
 
 				<!-- Label -->
-				<text x={PAD.left - 5} y={y + barH / 2 + 4} text-anchor="end" class="text-[9px] fill-gray-600">
+				<text x={PAD.left - 5} y={y + barH / 2 + 4} text-anchor="end" class="text-[9px] fill-gray-600 dark:fill-gray-300">
 					{item.label.length > 18 ? item.label.slice(0, 18) + '...' : item.label}
 				</text>
 
@@ -96,7 +96,7 @@
 			{/each}
 
 			<!-- Axes -->
-			<line x1={PAD.left} y1={PAD.top} x2={PAD.left} y2={svgH - PAD.bottom} stroke="#d1d5db" stroke-width="1" />
+			<line x1={PAD.left} y1={PAD.top} x2={PAD.left} y2={svgH - PAD.bottom} stroke="#d1d5db" stroke-width="1" class="dark:stroke-gray-600" />
 		</svg>
 	{/if}
 </div>

--- a/web/src/lib/components/charts/GaugeChart.svelte
+++ b/web/src/lib/components/charts/GaugeChart.svelte
@@ -69,9 +69,9 @@
 	})());
 </script>
 
-<div class="bg-white border border-gray-200 rounded-lg p-4 text-center">
+<div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg p-4 text-center">
 	{#if title}
-		<p class="text-sm font-medium text-gray-700 mb-2">{title}</p>
+		<p class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">{title}</p>
 	{/if}
 	<svg viewBox="0 0 {size} {size / 2 + 30}" class="mx-auto" style="width: {size}px; height: {size / 2 + 30}px" role="img" aria-label="{title}: {value}">
 		<!-- Band arcs -->
@@ -96,13 +96,13 @@
 			{Math.round(value)}
 		</text>
 		{#if label}
-			<text x={cx} y={cy + 14} text-anchor="middle" font-size="11" fill="#9ca3af">
+			<text x={cx} y={cy + 14} text-anchor="middle" font-size="11" fill="#9ca3af" class="dark:fill-gray-500">
 				{label}
 			</text>
 		{/if}
 
 		<!-- Min/Max labels -->
-		<text x={cx - r} y={cy + 14} text-anchor="middle" font-size="9" fill="#d1d5db">{min}</text>
-		<text x={cx + r} y={cy + 14} text-anchor="middle" font-size="9" fill="#d1d5db">{max}</text>
+		<text x={cx - r} y={cy + 14} text-anchor="middle" font-size="9" fill="#d1d5db" class="dark:fill-gray-600">{min}</text>
+		<text x={cx + r} y={cy + 14} text-anchor="middle" font-size="9" fill="#d1d5db" class="dark:fill-gray-600">{max}</text>
 	</svg>
 </div>

--- a/web/src/lib/components/charts/HeatMapChart.svelte
+++ b/web/src/lib/components/charts/HeatMapChart.svelte
@@ -67,7 +67,7 @@
 	});
 </script>
 
-<div class="bg-white border border-gray-200 rounded-lg p-4">
+<div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
 	{#if title}
 		<p class="text-sm font-semibold text-gray-700 mb-2">{title}</p>
 	{/if}
@@ -86,6 +86,7 @@
 					stroke="#e5e7eb"
 					stroke-width="0.5"
 					rx="2"
+					class="dark:stroke-gray-700"
 				>
 					<title>{probLabels[row]} / {impactLabels[col]}: {count} risks</title>
 				</rect>
@@ -94,7 +95,7 @@
 						x={x + cellW / 2}
 						y={y + cellH / 2 + 5}
 						text-anchor="middle"
-						class="text-[12px] font-bold fill-gray-700"
+						class="text-[12px] font-bold fill-gray-700 dark:fill-gray-300"
 					>{count}</text>
 				{/if}
 			{/each}
@@ -106,7 +107,7 @@
 				x={PAD.left - 5}
 				y={PAD.top + (gridSize - 1 - i) * cellH + cellH / 2 + 3}
 				text-anchor="end"
-				class="text-[8px] fill-gray-500"
+				class="text-[8px] fill-gray-500 dark:fill-gray-400"
 			>{label}</text>
 		{/each}
 
@@ -116,18 +117,18 @@
 				x={PAD.left + i * cellW + cellW / 2}
 				y={size - PAD.bottom + 15}
 				text-anchor="middle"
-				class="text-[8px] fill-gray-500"
+				class="text-[8px] fill-gray-500 dark:fill-gray-400"
 			>{label}</text>
 		{/each}
 
 		<!-- Axis titles -->
-		<text x={size / 2} y={size - 5} text-anchor="middle" class="text-[9px] fill-gray-400 font-medium">{xLabel}</text>
+		<text x={size / 2} y={size - 5} text-anchor="middle" class="text-[9px] fill-gray-400 dark:fill-gray-500 font-medium">{xLabel}</text>
 		<text
 			x="12"
 			y={size / 2}
 			text-anchor="middle"
 			transform="rotate(-90, 12, {size / 2})"
-			class="text-[9px] fill-gray-400 font-medium"
+			class="text-[9px] fill-gray-400 dark:fill-gray-500 font-medium"
 		>{yLabel}</text>
 
 		<!-- Risk dots -->

--- a/web/src/lib/components/charts/ParetoChart.svelte
+++ b/web/src/lib/components/charts/ParetoChart.svelte
@@ -90,7 +90,7 @@
 	}
 </script>
 
-<div class="bg-white border border-gray-200 rounded-lg p-4">
+<div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
 	{#if title}
 		<p class="text-sm font-semibold text-gray-700 mb-2">{title}</p>
 	{/if}
@@ -104,7 +104,7 @@
 				<line
 					x1={PAD.left} y1={PAD.top + pct * chartH}
 					x2={WIDTH - PAD.right} y2={PAD.top + pct * chartH}
-					stroke="#f3f4f6" stroke-width="1"
+					stroke="#f3f4f6" stroke-width="1" class="dark:stroke-gray-800"
 				/>
 				<text x={PAD.left - 5} y={PAD.top + pct * chartH + 3} text-anchor="end" class="text-[8px] fill-gray-400">
 					{formatCost(yMax - pct * (yMax - yMin))}
@@ -147,8 +147,8 @@
 			<text x="12" y={height / 2} text-anchor="middle" transform="rotate(-90, 12, {height / 2})" class="text-[9px] fill-gray-400 font-medium">{yLabel}</text>
 
 			<!-- Axes -->
-			<line x1={PAD.left} y1={PAD.top} x2={PAD.left} y2={PAD.top + chartH} stroke="#d1d5db" stroke-width="1" />
-			<line x1={PAD.left} y1={PAD.top + chartH} x2={WIDTH - PAD.right} y2={PAD.top + chartH} stroke="#d1d5db" stroke-width="1" />
+			<line x1={PAD.left} y1={PAD.top} x2={PAD.left} y2={PAD.top + chartH} stroke="#d1d5db" stroke-width="1" class="dark:stroke-gray-600" />
+			<line x1={PAD.left} y1={PAD.top + chartH} x2={WIDTH - PAD.right} y2={PAD.top + chartH} stroke="#d1d5db" stroke-width="1" class="dark:stroke-gray-600" />
 		</svg>
 
 		<div class="flex items-center gap-4 mt-2 text-xs text-gray-500">

--- a/web/src/lib/components/charts/PieChart.svelte
+++ b/web/src/lib/components/charts/PieChart.svelte
@@ -64,7 +64,7 @@
 	})());
 </script>
 
-<div class="bg-white border border-gray-200 rounded-lg p-4">
+<div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
 	{#if title}
 		<p class="text-sm font-medium text-gray-700 mb-3">{title}</p>
 	{/if}
@@ -76,15 +76,15 @@
 		<div class="flex items-center gap-4 flex-wrap justify-center">
 			<svg viewBox="0 0 {size} {size}" class="shrink-0" style="width: {size}px; height: {size}px" role="img" aria-label="{title}">
 				{#each arcs as arc}
-					<path d={arc.path} fill={arc.color} stroke="white" stroke-width="2">
+					<path d={arc.path} fill={arc.color} stroke="white" stroke-width="2" class="dark:stroke-gray-900">
 						<title>{arc.label}: {arc.value} ({arc.pct}%)</title>
 					</path>
 				{/each}
 				{#if donut}
-					<text x={cx} y={cy - 6} text-anchor="middle" font-size="20" font-weight="700" fill="#1f2937">
+					<text x={cx} y={cy - 6} text-anchor="middle" font-size="20" font-weight="700" fill="#1f2937" class="dark:fill-gray-200">
 						{total}
 					</text>
-					<text x={cx} y={cy + 12} text-anchor="middle" font-size="10" fill="#9ca3af">
+					<text x={cx} y={cy + 12} text-anchor="middle" font-size="10" fill="#9ca3af" class="dark:fill-gray-500">
 						total
 					</text>
 				{/if}

--- a/web/src/lib/components/charts/ResourceChart.svelte
+++ b/web/src/lib/components/charts/ResourceChart.svelte
@@ -60,7 +60,7 @@
 	});
 </script>
 
-<div class="bg-white border border-gray-200 rounded-lg p-4">
+<div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
 	{#if title}
 		<p class="text-sm font-semibold text-gray-700 mb-2">{title}{rsrcName ? ` — ${rsrcName}` : ''}</p>
 	{/if}
@@ -68,8 +68,8 @@
 		<!-- Y axis ticks -->
 		{#each yTicks() as tick}
 			<line x1={PAD.left} y1={yScale(tick)} x2={WIDTH - PAD.right} y2={yScale(tick)}
-				stroke="#f3f4f6" stroke-width="1" />
-			<text x={PAD.left - 5} y={yScale(tick) + 3} text-anchor="end" class="text-[9px] fill-gray-400">
+				stroke="#f3f4f6" stroke-width="1" class="dark:stroke-gray-800" />
+			<text x={PAD.left - 5} y={yScale(tick) + 3} text-anchor="end" class="text-[9px] fill-gray-400 dark:fill-gray-500">
 				{tick}
 			</text>
 		{/each}
@@ -102,14 +102,14 @@
 
 		<!-- X axis labels -->
 		{#each xLabels() as label}
-			<text x={label.x} y={height - 8} text-anchor="middle" class="text-[9px] fill-gray-400">
+			<text x={label.x} y={height - 8} text-anchor="middle" class="text-[9px] fill-gray-400 dark:fill-gray-500">
 				{label.text}
 			</text>
 		{/each}
 
 		<!-- Axes -->
-		<line x1={PAD.left} y1={PAD.top} x2={PAD.left} y2={PAD.top + chartH} stroke="#d1d5db" stroke-width="1" />
-		<line x1={PAD.left} y1={PAD.top + chartH} x2={WIDTH - PAD.right} y2={PAD.top + chartH} stroke="#d1d5db" stroke-width="1" />
+		<line x1={PAD.left} y1={PAD.top} x2={PAD.left} y2={PAD.top + chartH} stroke="#d1d5db" stroke-width="1" class="dark:stroke-gray-600" />
+		<line x1={PAD.left} y1={PAD.top + chartH} x2={WIDTH - PAD.right} y2={PAD.top + chartH} stroke="#d1d5db" stroke-width="1" class="dark:stroke-gray-600" />
 	</svg>
 
 	<!-- Legend -->

--- a/web/src/lib/components/charts/ScatterChart.svelte
+++ b/web/src/lib/components/charts/ScatterChart.svelte
@@ -83,9 +83,9 @@
 	}));
 </script>
 
-<div class="bg-white border border-gray-200 rounded-lg p-4">
+<div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
 	{#if title}
-		<p class="text-sm font-medium text-gray-700 mb-3">{title}</p>
+		<p class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">{title}</p>
 	{/if}
 	{#if finiteData.length === 0}
 		<div class="flex items-center justify-center text-gray-400 text-sm" style="height: {height}px">
@@ -96,21 +96,21 @@
 			<g transform="translate({PADDING.left}, {PADDING.top})">
 				<!-- Grid -->
 				{#each gridLinesY as gl}
-					<line x1="0" y1={gl.y} x2={chartWidth} y2={gl.y} stroke="#f3f4f6" stroke-width="1" />
-					<text x="-6" y={gl.y} text-anchor="end" dominant-baseline="middle" font-size="9" fill="#9ca3af">
+					<line x1="0" y1={gl.y} x2={chartWidth} y2={gl.y} stroke="#f3f4f6" stroke-width="1" class="dark:stroke-gray-800" />
+					<text x="-6" y={gl.y} text-anchor="end" dominant-baseline="middle" font-size="9" fill="#9ca3af" class="dark:fill-gray-500">
 						{gl.val.toFixed(0)}
 					</text>
 				{/each}
 				{#each gridLinesX as gl}
-					<line x1={gl.x} y1="0" x2={gl.x} y2={chartHeight} stroke="#f3f4f6" stroke-width="1" />
-					<text x={gl.x} y={chartHeight + 14} text-anchor="middle" font-size="9" fill="#9ca3af">
+					<line x1={gl.x} y1="0" x2={gl.x} y2={chartHeight} stroke="#f3f4f6" stroke-width="1" class="dark:stroke-gray-800" />
+					<text x={gl.x} y={chartHeight + 14} text-anchor="middle" font-size="9" fill="#9ca3af" class="dark:fill-gray-500">
 						{gl.val.toFixed(0)}
 					</text>
 				{/each}
 
 				<!-- Axes -->
-				<line x1="0" y1={chartHeight} x2={chartWidth} y2={chartHeight} stroke="#d1d5db" stroke-width="1" />
-				<line x1="0" y1="0" x2="0" y2={chartHeight} stroke="#d1d5db" stroke-width="1" />
+				<line x1="0" y1={chartHeight} x2={chartWidth} y2={chartHeight} stroke="#d1d5db" stroke-width="1" class="dark:stroke-gray-600" />
+				<line x1="0" y1="0" x2="0" y2={chartHeight} stroke="#d1d5db" stroke-width="1" class="dark:stroke-gray-600" />
 
 				<!-- Points (filtered to finite values to avoid SVG NaN attributes) -->
 				{#each finiteData as pt}
@@ -130,10 +130,10 @@
 
 				<!-- Axis labels -->
 				{#if xLabel}
-					<text x={chartWidth / 2} y={chartHeight + 32} text-anchor="middle" font-size="10" fill="#6b7280">{xLabel}</text>
+					<text x={chartWidth / 2} y={chartHeight + 32} text-anchor="middle" font-size="10" fill="#6b7280" class="dark:fill-gray-400">{xLabel}</text>
 				{/if}
 				{#if yLabel}
-					<text x="-36" y={chartHeight / 2} text-anchor="middle" font-size="10" fill="#6b7280"
+					<text x="-36" y={chartHeight / 2} text-anchor="middle" font-size="10" fill="#6b7280" class="dark:fill-gray-400"
 						transform="rotate(-90, -36, {chartHeight / 2})">{yLabel}</text>
 				{/if}
 			</g>

--- a/web/src/lib/components/charts/TimelineChart.svelte
+++ b/web/src/lib/components/charts/TimelineChart.svelte
@@ -61,7 +61,7 @@
 	})());
 </script>
 
-<div class="bg-white border border-gray-200 rounded-lg p-4">
+<div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
 	{#if title}
 		<p class="text-sm font-medium text-gray-700 mb-3">{title}</p>
 	{/if}
@@ -74,8 +74,8 @@
 			<g transform="translate({PADDING.left}, {PADDING.top})">
 				<!-- Time axis ticks -->
 				{#each timeTicks as tick}
-					<line x1={tick.x} y1="0" x2={tick.x} y2={chartHeight} stroke="#f3f4f6" stroke-width="1" />
-					<text x={tick.x} y={chartHeight + 16} text-anchor="middle" font-size="9" fill="#9ca3af">{tick.label}</text>
+					<line x1={tick.x} y1="0" x2={tick.x} y2={chartHeight} stroke="#f3f4f6" stroke-width="1" class="dark:stroke-gray-800" />
+					<text x={tick.x} y={chartHeight + 16} text-anchor="middle" font-size="9" fill="#9ca3af" class="dark:fill-gray-500">{tick.label}</text>
 				{/each}
 
 				<!-- Items -->
@@ -84,7 +84,7 @@
 					{@const color = item.color ?? defaultColors[i % defaultColors.length]}
 
 					<!-- Label -->
-					<text x="-8" y={y + rowH / 2} text-anchor="end" dominant-baseline="middle" font-size="10" fill="#374151">
+					<text x="-8" y={y + rowH / 2} text-anchor="end" dominant-baseline="middle" font-size="10" fill="#374151" class="dark:fill-gray-300">
 						{item.label.length > 16 ? item.label.slice(0, 16) + '..' : item.label}
 					</text>
 
@@ -117,7 +117,7 @@
 				{/each}
 
 				<!-- Baseline -->
-				<line x1="0" y1={chartHeight} x2={chartWidth} y2={chartHeight} stroke="#d1d5db" stroke-width="1" />
+				<line x1="0" y1={chartHeight} x2={chartWidth} y2={chartHeight} stroke="#d1d5db" stroke-width="1" class="dark:stroke-gray-600" />
 			</g>
 		</svg>
 	{/if}

--- a/web/src/lib/components/charts/WaterfallChart.svelte
+++ b/web/src/lib/components/charts/WaterfallChart.svelte
@@ -79,7 +79,7 @@
 	const gap = $derived((chartWidth - barW * data.length) / (data.length + 1));
 </script>
 
-<div class="bg-white border border-gray-200 rounded-lg p-4">
+<div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
 	{#if title}
 		<p class="text-sm font-medium text-gray-700 mb-3">{title}</p>
 	{/if}
@@ -91,7 +91,7 @@
 		<svg viewBox="0 0 {WIDTH} {height}" preserveAspectRatio="xMidYMid meet" class="w-full" style="height: {height}px" role="img" aria-label="{title}">
 			<g transform="translate({PADDING.left}, {PADDING.top})">
 				<!-- Zero line -->
-				<line x1="0" y1={py(0)} x2={chartWidth} y2={py(0)} stroke="#d1d5db" stroke-width="1" />
+				<line x1="0" y1={py(0)} x2={chartWidth} y2={py(0)} stroke="#d1d5db" stroke-width="1" class="dark:stroke-gray-600" />
 
 				{#each bars as bar, i}
 					{@const x = gap + i * (barW + gap)}
@@ -124,6 +124,7 @@
 						text-anchor="middle"
 						font-size="9"
 						fill="#374151"
+						class="dark:fill-gray-300"
 					>
 						{bar.value >= 0 ? '+' : ''}{formatValue(bar.value)}
 					</text>
@@ -135,6 +136,7 @@
 						text-anchor="middle"
 						font-size="9"
 						fill="#6b7280"
+						class="dark:fill-gray-400"
 						transform="rotate(-30, {x + barW / 2}, {chartHeight + 14})"
 					>
 						{bar.label.length > 10 ? bar.label.slice(0, 10) + '..' : bar.label}


### PR DESCRIPTION
## W1 — final item (#4)

### The audit was half-wrong, so the scope changed
The audit said *"10 charts render as white cards on the dark theme."* That part is a **false positive**: `web/src/app.css` already remaps the `.dark .bg-white` / `.border-gray-200` / `.text-gray-*` **classes**, so wrappers and class-based text are handled.

The **real, verified** bug is what a class-based CSS override **cannot reach**: SVG **inline attributes**. A `<text fill="#374151">` (gray-700) bar value-label on the dark `gray-900` card is **~1.3:1 contrast — effectively invisible** in dark mode (the labels vanish).

### Fix
Add `dark:fill-*` / `dark:stroke-*` variants to the **neutral-gray** SVG fills/strokes across all 10 legacy charts, matching the already-themed `EVMSCurveChart`:
`fill="#374151"→dark:fill-gray-300`, `#6b7280→gray-400`, `#9ca3af→gray-500`; `stroke="#d1d5db"→dark:stroke-gray-600`, `#e5e7eb→gray-700`, `#f3f4f6→gray-800`. (Wrappers also got explicit dark tokens for robustness, though the override covers them.)

### Safety
**Data-series / semantic colors are untouched** — verified by diffing: every changed line only *appends* a `dark:` variant; no color value was modified. Charts: BarChart, GaugeChart, ScatterChart, ResourceChart, HeatMapChart, ParetoChart, PieChart, WaterfallChart, TimelineChart, GanttChart.

svelte-check **0/0**, **136** frontend tests green, build clean.

This closes **W1** (presentation floor): WBS code-path order (#167) + two-tier axis & uncapped gridlines (#168) + chart dark mode (this).