### PR TITLE
feat(schedule-viewer): in-viewer empty-state + mobile-responsive tree + toolbar wrap (W4 PR-B)

### DIFF
--- a/web/src/lib/components/ScheduleViewer/ScheduleViewer.svelte
+++ b/web/src/lib/components/ScheduleViewer/ScheduleViewer.svelte
@@ -163,6 +163,15 @@
 		isFiltered,
 	));
 
+	// "No activities visible" = empty. Use viewData.activities (the post-search /
+	// critical / group activity set), NOT flatRows.length: when the PAGE's statusFilter
+	// prunes activities to [] but leaves the full WBS tree, isFiltered is false so
+	// buildFlatRows keeps every WBS row → flatRows.length>0 and the empty-state would
+	// wrongly stay hidden (a tree of childless rows over a bar-less Gantt — the most
+	// common empty path). Collapse-all does NOT false-trigger this: collapsing hides
+	// activity ROWS but keeps them in viewData.activities.
+	const isEmpty = $derived(viewData.activities.length === 0);
+
 	function toggleWbs(wbsId: string) {
 		const next = new Set(collapsedWbs);
 		if (next.has(wbsId)) {
@@ -237,10 +246,16 @@
 	// Keyboard shortcuts
 	onMount(() => {
 		function handleKey(e: KeyboardEvent) {
-			// Don't hijack keystrokes while a form control is focused (search box, the new
-			// group-by / roll-up selects) — typing 'e'/'c'/'+'/'-' there must not fire viewer actions.
+			// Don't hijack keystrokes while a form control is focused (search box, the
+			// group-by / roll-up selects) — typing 'e'/'c'/'+'/'-' there must not fire viewer
+			// actions. isContentEditable is defensive future-proofing: no contenteditable host
+			// exists in the viewer today, but it keeps the guard correct if one is ever added.
 			const tgt = e.target;
-			if (tgt instanceof HTMLElement && ['INPUT', 'SELECT', 'TEXTAREA'].includes(tgt.tagName)) return;
+			if (
+				tgt instanceof HTMLElement &&
+				(['INPUT', 'SELECT', 'TEXTAREA'].includes(tgt.tagName) || tgt.isContentEditable)
+			)
+				return;
 			if (e.key === '+' || e.key === '=') {
 				if (zoomLevel === 'month') zoomLevel = 'week';
 				else if (zoomLevel === 'week') zoomLevel = 'day';
@@ -541,7 +556,7 @@ ${sections.join('\n')}
 	onmousemove={(e) => { mouseX = e.clientX; mouseY = e.clientY; }}
 >
 	<!-- Toolbar -->
-	<div class="flex items-center justify-between px-3 py-2 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800">
+	<div class="flex flex-wrap items-center justify-between gap-y-2 px-3 py-2 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800">
 		<div class="flex items-center gap-3">
 			<h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100">{data.project_name || $t('schedule.viewer.default_project_name')}</h3>
 			<span class="text-[10px] text-gray-500 dark:text-gray-400 flex items-center gap-1.5">
@@ -562,7 +577,7 @@ ${sections.join('\n')}
 				</span>
 			{/if}
 		</div>
-		<div class="flex items-center gap-2">
+		<div class="flex flex-wrap items-center gap-2 gap-y-2">
 			<!-- Search -->
 			<div class="relative">
 				<input
@@ -639,7 +654,8 @@ ${sections.join('\n')}
 			<!-- Export SVG -->
 			<button
 				onclick={exportSvg}
-				class="text-[10px] text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
+				disabled={isEmpty}
+				class="text-[10px] text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 disabled:opacity-40 disabled:cursor-not-allowed"
 				title={$t('schedule.viewer.export_svg')}
 				aria-label={$t('schedule.viewer.export_svg')}
 			>
@@ -648,14 +664,15 @@ ${sections.join('\n')}
 			<!-- Export PNG -->
 			<button
 				onclick={exportPng}
-				class="text-[10px] text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
+				disabled={isEmpty}
+				class="text-[10px] text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 disabled:opacity-40 disabled:cursor-not-allowed"
 				title={$t('schedule.viewer.export_png')}
 				aria-label={$t('schedule.viewer.export_png')}
 			>
 				<span class="text-[10px] font-bold">PNG</span>
 			</button>
 			<!-- Export PDF (print, single-page Gantt SVG) -->
-			<button onclick={exportPdf} class="text-[10px] text-gray-500 hover:text-gray-700 dark:hover:text-gray-300" title={$t('schedule.viewer.print_gantt')} aria-label={$t('schedule.viewer.print_gantt_aria')}>
+			<button onclick={exportPdf} disabled={isEmpty} class="text-[10px] text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 disabled:opacity-40 disabled:cursor-not-allowed" title={$t('schedule.viewer.print_gantt')} aria-label={$t('schedule.viewer.print_gantt_aria')}>
 				<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z" />
 				</svg>
@@ -663,7 +680,8 @@ ${sections.join('\n')}
 			<!-- Print by WBS (one page per top-level WBS) -->
 			<button
 				onclick={exportPdfByWbs}
-				class="text-[10px] text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 font-bold"
+				disabled={isEmpty}
+				class="text-[10px] text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 font-bold disabled:opacity-40 disabled:cursor-not-allowed"
 				title={$t('schedule.viewer.print_by_wbs')}
 				aria-label={$t('schedule.viewer.print_by_wbs_aria')}
 			>
@@ -672,7 +690,28 @@ ${sections.join('\n')}
 		</div>
 	</div>
 
-	<!-- Main content: WBS Tree (left) + Gantt (right) -->
+	<!-- Main content: WBS Tree (left) + Gantt (right), or an empty-state when a
+	     filter/grouping prunes the whole view. Dark-aware tokens mirror the chart
+	     empty-states (ResourceChart); the app.css global remap covers the rest. -->
+	{#if isEmpty}
+		<div role="status" aria-live="polite" class="flex flex-col items-center justify-center text-center gap-2 px-6" style="height: {viewerHeight}px;">
+			<p class="text-sm text-gray-400 dark:text-gray-500 max-w-xs">
+				{searchQuery.trim()
+					? $t('schedule.viewer.empty_search')
+					: criticalOnly
+						? $t('schedule.viewer.empty_critical')
+						: $t('schedule.viewer.empty_generic')}
+			</p>
+			{#if searchQuery.trim()}
+				<button
+					onclick={() => (searchQuery = '')}
+					class="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+				>
+					{$t('schedule.viewer.clear_search')}
+				</button>
+			{/if}
+		</div>
+	{:else}
 	<div class="flex" style="height: {viewerHeight}px;">
 		<!-- WBS Tree -->
 		<WBSTree
@@ -694,7 +733,7 @@ ${sections.join('\n')}
 			onmousemove={handleMouseMove}
 			onmouseup={handleMouseUp}
 			onmouseleave={handleMouseUp}
-			class="flex-1 overflow-auto"
+			class="flex-1 overflow-auto min-w-0"
 			style="cursor: grab;"
 		>
 			<GanttCanvas
@@ -718,6 +757,7 @@ ${sections.join('\n')}
 			/>
 		</div>
 	</div>
+	{/if}
 
 	<!-- Status bar (compact) -->
 	{#if hoveredActivity}

--- a/web/src/lib/components/ScheduleViewer/WBSTree.svelte
+++ b/web/src/lib/components/ScheduleViewer/WBSTree.svelte
@@ -48,17 +48,20 @@
 </script>
 
 <div
-	class="wbs-tree overflow-hidden border-r border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900"
-	style="width: 550px; min-width: 550px; height: 100%; position: relative;"
+	class="wbs-tree w-[300px] sm:w-[440px] lg:w-[550px] shrink-0 overflow-hidden border-r border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900"
+	style="height: 100%; position: relative;"
 >
 	<!-- Header — height matches GanttCanvas HEADER_H (40px, two-tier axis) so
 	     the left-panel rows align with the right-panel bars. -->
 	<div class="h-10 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 flex items-end pb-1 text-[9px] font-semibold text-gray-500 dark:text-gray-400 uppercase">
+		<!-- Below sm the OD/ES/EF columns are hidden (here AND in every body row, so the
+		     panes stay pixel-aligned) to keep Name legible on a narrow tree. Code/Name/TF/%
+		     stay — TF is the float column the field/claims persona scans for on mobile. -->
 		<span class="w-[72px] text-center shrink-0 px-1">{$t('schedule.col_code')}</span>
 		<span class="flex-1 min-w-0 px-1">{$t('schedule.col_name')}</span>
-		<span class="w-9 text-center shrink-0">{$t('schedule.col_od')}</span>
-		<span class="w-[62px] text-center shrink-0">{$t('schedule.col_es')}</span>
-		<span class="w-[62px] text-center shrink-0">{$t('schedule.col_ef')}</span>
+		<span class="w-9 text-center shrink-0 hidden sm:block">{$t('schedule.col_od')}</span>
+		<span class="w-[62px] text-center shrink-0 hidden sm:block">{$t('schedule.col_es')}</span>
+		<span class="w-[62px] text-center shrink-0 hidden sm:block">{$t('schedule.col_ef')}</span>
 		<span class="w-9 text-center shrink-0">{$t('schedule.col_tf')}</span>
 		<span class="w-8 text-center shrink-0 pr-1">{$t('schedule.col_pct')}</span>
 	</div>
@@ -89,15 +92,15 @@
 							<span class="text-[7px] text-gray-400 shrink-0 ml-auto">{row.wbsNode.activity_count}</span>
 						</div>
 						{#if isCollapsed && agg}
-							<span class="w-9 text-center text-[8px] font-mono text-gray-500 dark:text-gray-400 shrink-0">{Math.round(agg.total_duration)}d</span>
-							<span class="w-[62px] text-center text-[7px] font-mono text-gray-500 dark:text-gray-400 shrink-0">{formatDateCompact(agg.start)}</span>
-							<span class="w-[62px] text-center text-[7px] font-mono text-gray-500 dark:text-gray-400 shrink-0">{formatDateCompact(agg.finish)}</span>
+							<span class="w-9 text-center text-[8px] font-mono text-gray-500 dark:text-gray-400 shrink-0 hidden sm:block">{Math.round(agg.total_duration)}d</span>
+							<span class="w-[62px] text-center text-[7px] font-mono text-gray-500 dark:text-gray-400 shrink-0 hidden sm:block">{formatDateCompact(agg.start)}</span>
+							<span class="w-[62px] text-center text-[7px] font-mono text-gray-500 dark:text-gray-400 shrink-0 hidden sm:block">{formatDateCompact(agg.finish)}</span>
 							<span class="w-9 text-center text-[8px] font-mono shrink-0 {floatColor(agg.min_float)}">{Math.round(agg.min_float)}d</span>
 							<span class="w-8 text-center text-[8px] font-mono shrink-0 pr-1 {progressColor(agg.total_weight > 0 ? agg.weighted_progress / agg.total_weight : 0)}">{agg.total_weight > 0 ? Math.round(agg.weighted_progress / agg.total_weight) : 0}</span>
 						{:else}
-							<span class="w-9 shrink-0"></span>
-							<span class="w-[62px] shrink-0"></span>
-							<span class="w-[62px] shrink-0"></span>
+							<span class="w-9 shrink-0 hidden sm:block"></span>
+							<span class="w-[62px] shrink-0 hidden sm:block"></span>
+							<span class="w-[62px] shrink-0 hidden sm:block"></span>
 							<span class="w-9 shrink-0"></span>
 							<span class="w-8 shrink-0"></span>
 						{/if}
@@ -124,9 +127,9 @@
 							{/if}
 							<span class="text-[9px] text-gray-600 dark:text-gray-400 truncate">{act.task_name || act.task_code}</span>
 						</div>
-						<span class="w-9 text-center text-[8px] font-mono text-gray-500 dark:text-gray-400 shrink-0">{act.duration_days}d</span>
-						<span class="w-[62px] text-center text-[7px] font-mono text-gray-500 dark:text-gray-400 shrink-0">{formatDateCompact(act.early_start)}</span>
-						<span class="w-[62px] text-center text-[7px] font-mono text-gray-500 dark:text-gray-400 shrink-0">{formatDateCompact(act.early_finish)}</span>
+						<span class="w-9 text-center text-[8px] font-mono text-gray-500 dark:text-gray-400 shrink-0 hidden sm:block">{act.duration_days}d</span>
+						<span class="w-[62px] text-center text-[7px] font-mono text-gray-500 dark:text-gray-400 shrink-0 hidden sm:block">{formatDateCompact(act.early_start)}</span>
+						<span class="w-[62px] text-center text-[7px] font-mono text-gray-500 dark:text-gray-400 shrink-0 hidden sm:block">{formatDateCompact(act.early_finish)}</span>
 						<span class="w-9 text-center text-[8px] font-mono shrink-0 {floatColor(act.total_float_days)}">{act.total_float_days}d</span>
 						<span class="w-8 text-center text-[8px] font-mono shrink-0 pr-1 {progressColor(act.progress_pct)}">{act.progress_pct > 0 ? act.progress_pct : ''}</span>
 					</div>


### PR DESCRIPTION
## W4 PR-B — ScheduleViewer empty-state + mobile responsive (PR 2 of 2)

The behavioral/layout half of the W4 viewer hardening (PR-A #175 was the string-only i18n backfill). Closes **#172** (in-viewer empty state).

### What changed
- **In-viewer empty-state (#172)** — `isEmpty = viewData.activities.length === 0`. This signal covers all empty paths: search-no-match, critical-only, the **page `statusFilter` pruning activities to `[]` over a full WBS tree** (the most common case, which `flatRows.length===0` would have missed), and genuinely-empty schedules. It does **not** false-trigger on collapse-all (collapsing hides activity rows but keeps them in `viewData.activities`). The empty branch is a centered, full-height, dark-aware block (`text-gray-400 dark:text-gray-500`, mirroring ResourceChart) with a branched message and a **one-click Clear-search** recovery; `role="status" aria-live="polite"` so SR users hear the transition.
- **Mobile responsive** (entry-council approach a') — WBSTree width moved off the inline `550px` floor onto `w-[300px] sm:w-[440px] lg:w-[550px] shrink-0`; **`min-w-0` on the gantt wrapper** (the actual fix — lets the `flex-1` pane shrink below the fixed 1200px SVG instead of overflowing the `overflow-hidden` card). The `OD/ES/EF` columns are hidden below `sm` **symmetrically across header + collapsed-agg + spacer + activity rows** (panes stay pixel-aligned); `Code/Name/TF/%` stay visible at all widths (**TF kept** per product-validator — it's the float column the field/claims persona scans on mobile). The 1200px gantt SVG stays fixed and scrolls horizontally inside its now-`min-w-0` wrapper.
- **Toolbar wrap** — `flex-wrap gap-y-2` on the toolbar container + control group so the ~13 controls wrap instead of overflowing a phone.
- **Export buttons disabled when empty** (they no-op without a rendered canvas); `isContentEditable` added to the keydown editable-target guard (future-proofing).

### Council
- **Entry-council** ruled the mobile approach (a': responsive width + `min-w-0` + symmetric column-hide) and the empty-state recovery affordance.
- **Exit-council**: frontend-ux **SHIP**; devils-advocate **SHIP-with-1-mandatory** — caught a **P1**: the original `flatRows.length===0` empty signal missed the page-`statusFilter`-empty case (full WBS tree, zero activities). **Fixed** by switching to `viewData.activities.length===0`. Also applied the export-button disable (P2) and `role=status` a11y (P3).

### Verification
`svelte-check 0 errors/0 warnings · vitest 175 pass · build clean (adapter-static)`

### ⚠️ Pending operator visual check
The **375px mobile layout + the empty-state** need a real-viewport visual check — the ScheduleViewer is behind auth and needs a loaded project, so it isn't headless-screenshottable here (consistent with how W1/W2/W3 were visually signed off in prod). Both councils verified the layout *reasoning* holds from the code; the pixel render is the operator's check.

### Minor accepted gaps (council "ship")
- search + critical-only both active → Clear-search resolves search but not critical-only (a page-owned prop the viewer can't clear); recoverable via the page checkbox.
- page-`statusFilter`-empty shows the generic message (the viewer can't see *why* it's empty); accurate but not filter-specific.
