### PR TITLE
fix(schedule-viewer): localize date VALUES to the app locale

### DIFF
--- a/web/src/lib/components/ScheduleViewer/ActivityTooltip.svelte
+++ b/web/src/lib/components/ScheduleViewer/ActivityTooltip.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { ActivityView } from './types';
 	import { formatDateShort } from './utils';
-	import { t } from '$lib/i18n';
+	import { t, locale, dateLocale } from '$lib/i18n';
 
 	interface Props {
 		activity: ActivityView;
@@ -13,6 +13,9 @@
 
 	const TOOLTIP_W = 320;
 	const TOOLTIP_H_EST = 260;
+
+	// BCP-47 tag for date VALUE localization (#176) — labels come from $t.
+	const dl = $derived(dateLocale($locale));
 
 	// Viewport edge detection — flip position if near edges
 	const pos = $derived.by(() => {
@@ -67,32 +70,32 @@
 		<div class="grid grid-cols-2 gap-x-4 gap-y-0.5 text-[10px]">
 			<div class="flex justify-between">
 				<span class="text-gray-400">{$t('schedule.col_es')}</span>
-				<span class="font-mono text-gray-700 dark:text-gray-300">{formatDateShort(activity.early_start)}</span>
+				<span class="font-mono text-gray-700 dark:text-gray-300">{formatDateShort(activity.early_start, dl)}</span>
 			</div>
 			<div class="flex justify-between">
 				<span class="text-gray-400">{$t('schedule.col_ef')}</span>
-				<span class="font-mono text-gray-700 dark:text-gray-300">{formatDateShort(activity.early_finish)}</span>
+				<span class="font-mono text-gray-700 dark:text-gray-300">{formatDateShort(activity.early_finish, dl)}</span>
 			</div>
 			{#if activity.late_start && activity.late_finish}
 				<div class="flex justify-between">
 					<span class="text-gray-400">{$t('schedule.col_ls')}</span>
-					<span class="font-mono text-gray-700 dark:text-gray-300">{formatDateShort(activity.late_start)}</span>
+					<span class="font-mono text-gray-700 dark:text-gray-300">{formatDateShort(activity.late_start, dl)}</span>
 				</div>
 				<div class="flex justify-between">
 					<span class="text-gray-400">{$t('schedule.col_lf')}</span>
-					<span class="font-mono text-gray-700 dark:text-gray-300">{formatDateShort(activity.late_finish)}</span>
+					<span class="font-mono text-gray-700 dark:text-gray-300">{formatDateShort(activity.late_finish, dl)}</span>
 				</div>
 			{/if}
 			{#if activity.actual_start}
 				<div class="flex justify-between">
 					<span class="text-gray-400">{$t('schedule.col_as')}</span>
-					<span class="font-mono text-green-600">{formatDateShort(activity.actual_start)}</span>
+					<span class="font-mono text-green-600">{formatDateShort(activity.actual_start, dl)}</span>
 				</div>
 			{/if}
 			{#if activity.actual_finish}
 				<div class="flex justify-between">
 					<span class="text-gray-400">{$t('schedule.col_af')}</span>
-					<span class="font-mono text-green-600">{formatDateShort(activity.actual_finish)}</span>
+					<span class="font-mono text-green-600">{formatDateShort(activity.actual_finish, dl)}</span>
 				</div>
 			{/if}
 		</div>
@@ -133,13 +136,13 @@
 				{#if activity.baseline_start}
 					<div class="flex justify-between">
 						<span class="text-gray-400">{$t('schedule.col_bs')}</span>
-						<span class="font-mono text-gray-500">{formatDateShort(activity.baseline_start)}</span>
+						<span class="font-mono text-gray-500">{formatDateShort(activity.baseline_start, dl)}</span>
 					</div>
 				{/if}
 				{#if activity.baseline_finish}
 					<div class="flex justify-between">
 						<span class="text-gray-400">{$t('schedule.col_bf')}</span>
-						<span class="font-mono text-gray-500">{formatDateShort(activity.baseline_finish)}</span>
+						<span class="font-mono text-gray-500">{formatDateShort(activity.baseline_finish, dl)}</span>
 					</div>
 				{/if}
 				{#if activity.start_variance_days != null}
@@ -163,7 +166,7 @@
 		<div class="px-3 py-1 text-[9px]">
 			<span class="text-purple-600 font-medium">{$t('schedule.detail_constraint')}: {activity.constraint_type}</span>
 			{#if activity.constraint_date}
-				<span class="text-gray-400 ml-1">{formatDateShort(activity.constraint_date)}</span>
+				<span class="text-gray-400 ml-1">{formatDateShort(activity.constraint_date, dl)}</span>
 			{/if}
 		</div>
 	{/if}

--- a/web/src/lib/components/ScheduleViewer/GanttCanvas.svelte
+++ b/web/src/lib/components/ScheduleViewer/GanttCanvas.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import type { ActivityView, RelationshipView, WBSAggregate, FlatRow } from './types';
-	import { daysBetween, parseDate, getBarColor, formatDateShort, generateTimeTicks } from './utils';
+	import { daysBetween, parseDate, getBarColor, generateTimeTicks } from './utils';
 	import TimeScale from './TimeScale.svelte';
-	import { t } from '$lib/i18n';
+	import { t, locale, dateLocale } from '$lib/i18n';
 
 	interface Props {
 		flatRows: FlatRow[];
@@ -63,7 +63,9 @@
 	const totalDays = $derived(Math.max(1, daysBetween(startDate, endDate)));
 	// Same two-tier axis the header uses — drives gridlines so they align under
 	// the labels and span the whole schedule (no fixed day-count cap).
-	const axis = $derived(generateTimeTicks(startDate, endDate, zoomLevel, WIDTH));
+	// BCP-47 tag for date VALUE localization (#176) — labels come from $t.
+	const dl = $derived(dateLocale($locale));
+	const axis = $derived(generateTimeTicks(startDate, endDate, zoomLevel, WIDTH, dl));
 
 	function xPos(dateStr: string): number {
 		if (!dateStr) return 0;

--- a/web/src/lib/components/ScheduleViewer/ScheduleViewer.svelte
+++ b/web/src/lib/components/ScheduleViewer/ScheduleViewer.svelte
@@ -4,7 +4,7 @@
 	import GanttCanvas from './GanttCanvas.svelte';
 	import ActivityTooltip from './ActivityTooltip.svelte';
 	import { onMount, untrack } from 'svelte';
-	import { t } from '$lib/i18n';
+	import { t, locale, dateLocale } from '$lib/i18n';
 	import { daysBetween, formatDateShort, computeWBSAggregates, buildFlatRows, getMaxWBSDepth, collectActivitiesByWbs, applyClientGrouping, presetCollapse, defaultGroupLabel } from './utils';
 
 	interface Props {
@@ -24,6 +24,9 @@
 		criticalOnly = false,
 		onActivityClick,
 	}: Props = $props();
+
+	// BCP-47 tag for date VALUE localization (#176) — labels come from $t.
+	const dl = $derived(dateLocale($locale));
 
 	// Filter activities if criticalOnly
 	const filteredData = $derived.by(() => {
@@ -388,13 +391,15 @@
 		const projectName = escapeHtml(data.project_name || $t('schedule.viewer.default_project_name'));
 		const ganttLabel = escapeHtml($t('schedule.viewer.print_title_gantt'));
 		const dateStr = data.data_date
-			? ` — ${escapeHtml($t('schedule.viewer.data_date'))}: ${escapeHtml(formatDateShort(data.data_date))}`
+			? ` — ${escapeHtml($t('schedule.viewer.data_date'))}: ${escapeHtml(formatDateShort(data.data_date, dl))}`
 			: '';
 		const activitiesLabel = escapeHtml($t('schedule.viewer.print_activities'));
 		const printedLabel = escapeHtml($t('schedule.viewer.print_printed'));
 		// Convention for both print functions: every interpolated value is escaped
 		// at DEFINITION and interpolated bare below — so no use site can forget it.
-		const printedDate = escapeHtml(new Date().toLocaleDateString());
+		// printedDate is a CLOCK date (full d/m/y), app-locale so the print header
+		// agrees with the localized schedule dates (#176).
+		const printedDate = escapeHtml(new Date().toLocaleDateString(dl));
 
 		const printWindow = window.open('', '_blank');
 		if (!printWindow) return;
@@ -451,9 +456,9 @@ ${svgClone.outerHTML}
 			headingByWbs: escapeHtml($t('schedule.viewer.print_heading_by_wbs')),
 		};
 		const dateStr = data.data_date
-			? `${escapeHtml($t('schedule.viewer.data_date'))}: ${escapeHtml(formatDateShort(data.data_date))}`
+			? `${escapeHtml($t('schedule.viewer.data_date'))}: ${escapeHtml(formatDateShort(data.data_date, dl))}`
 			: '';
-		const printedDate = escapeHtml(new Date().toLocaleDateString());
+		const printedDate = escapeHtml(new Date().toLocaleDateString(dl));
 
 		const sections: string[] = [];
 		let firstPage = true;
@@ -473,8 +478,8 @@ ${svgClone.outerHTML}
 					return `<tr${critCls}>
 						<td>${escapeHtml(a.task_code)}</td>
 						<td>${escapeHtml(a.task_name)}</td>
-						<td>${escapeHtml(formatDateShort(a.early_start))}</td>
-						<td>${escapeHtml(formatDateShort(a.early_finish))}</td>
+						<td>${escapeHtml(formatDateShort(a.early_start, dl))}</td>
+						<td>${escapeHtml(formatDateShort(a.early_finish, dl))}</td>
 						<td class="num">${a.duration_days.toFixed(0)}</td>
 						<td class="num">${a.total_float_days.toFixed(0)}</td>
 						<td class="num">${a.progress_pct.toFixed(0)}%</td>
@@ -764,7 +769,7 @@ ${sections.join('\n')}
 		<div class="border-t border-gray-200 dark:border-gray-700 px-3 py-1.5 bg-gray-50 dark:bg-gray-800 flex items-center gap-3 text-[10px]">
 			<span class="font-semibold text-gray-900 dark:text-gray-100">{hoveredActivity.task_code}</span>
 			<span class="text-gray-600 dark:text-gray-400 truncate max-w-xs">{hoveredActivity.task_name}</span>
-			<span class="text-gray-500">{formatDateShort(hoveredActivity.early_start)} — {formatDateShort(hoveredActivity.early_finish)}</span>
+			<span class="text-gray-500">{formatDateShort(hoveredActivity.early_start, dl)} — {formatDateShort(hoveredActivity.early_finish, dl)}</span>
 			<span class="text-gray-500">{hoveredActivity.duration_days}d</span>
 			<span class="{hoveredActivity.total_float_days < 0 ? 'text-red-600 font-bold' : hoveredActivity.total_float_days === 0 ? 'text-amber-600' : 'text-green-600'}">{$t('schedule.col_tf')}:{hoveredActivity.total_float_days}d</span>
 			{#if hoveredActivity.progress_pct > 0}
@@ -794,7 +799,7 @@ ${sections.join('\n')}
 			<span class="flex items-center gap-1"><span class="w-3 h-1 rounded-sm bg-amber-400 opacity-60"></span> {$t('schedule.viewer.legend_float')}</span>
 		{/if}
 		{#if data.data_date}
-			<span class="ml-auto text-amber-600">{$t('schedule.viewer.data_date')}: {formatDateShort(data.data_date)}</span>
+			<span class="ml-auto text-amber-600">{$t('schedule.viewer.data_date')}: {formatDateShort(data.data_date, dl)}</span>
 		{/if}
 	</div>
 </div>

--- a/web/src/lib/components/ScheduleViewer/TimeScale.svelte
+++ b/web/src/lib/components/ScheduleViewer/TimeScale.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { generateTimeTicks } from './utils';
-	import { t } from '$lib/i18n';
+	import { t, locale, dateLocale } from '$lib/i18n';
 
 	interface Props {
 		startDate: string;
@@ -20,8 +20,11 @@
 		dataDate = '',
 	}: Props = $props();
 
+	// BCP-47 tag for date VALUE localization (#176) — labels come from $t.
+	const dl = $derived(dateLocale($locale));
+
 	const chartWidth = $derived(width - padLeft);
-	const axis = $derived(generateTimeTicks(startDate, endDate, zoomLevel));
+	const axis = $derived(generateTimeTicks(startDate, endDate, zoomLevel, undefined, dl));
 
 	const todayX = $derived(() => {
 		if (!startDate || !endDate) return -1;

--- a/web/src/lib/components/ScheduleViewer/WBSTree.svelte
+++ b/web/src/lib/components/ScheduleViewer/WBSTree.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { WBSAggregate, FlatRow } from './types';
 	import { formatDateCompact } from './utils';
-	import { t } from '$lib/i18n';
+	import { t, locale, dateLocale } from '$lib/i18n';
 
 	interface Props {
 		flatRows: FlatRow[];
@@ -26,6 +26,9 @@
 	}: Props = $props();
 
 	const BUFFER_ROWS = 20;
+
+	// BCP-47 tag for date VALUE localization (#176) — labels come from $t.
+	const dl = $derived(dateLocale($locale));
 
 	// Virtual scrolling: only render visible rows + buffer
 	const virtualStart = $derived(Math.max(0, Math.floor(scrollTop / rowHeight) - BUFFER_ROWS));
@@ -93,8 +96,8 @@
 						</div>
 						{#if isCollapsed && agg}
 							<span class="w-9 text-center text-[8px] font-mono text-gray-500 dark:text-gray-400 shrink-0 hidden sm:block">{Math.round(agg.total_duration)}d</span>
-							<span class="w-[62px] text-center text-[7px] font-mono text-gray-500 dark:text-gray-400 shrink-0 hidden sm:block">{formatDateCompact(agg.start)}</span>
-							<span class="w-[62px] text-center text-[7px] font-mono text-gray-500 dark:text-gray-400 shrink-0 hidden sm:block">{formatDateCompact(agg.finish)}</span>
+							<span class="w-[62px] text-center text-[7px] font-mono text-gray-500 dark:text-gray-400 shrink-0 hidden sm:block">{formatDateCompact(agg.start, dl)}</span>
+							<span class="w-[62px] text-center text-[7px] font-mono text-gray-500 dark:text-gray-400 shrink-0 hidden sm:block">{formatDateCompact(agg.finish, dl)}</span>
 							<span class="w-9 text-center text-[8px] font-mono shrink-0 {floatColor(agg.min_float)}">{Math.round(agg.min_float)}d</span>
 							<span class="w-8 text-center text-[8px] font-mono shrink-0 pr-1 {progressColor(agg.total_weight > 0 ? agg.weighted_progress / agg.total_weight : 0)}">{agg.total_weight > 0 ? Math.round(agg.weighted_progress / agg.total_weight) : 0}</span>
 						{:else}
@@ -128,8 +131,8 @@
 							<span class="text-[9px] text-gray-600 dark:text-gray-400 truncate">{act.task_name || act.task_code}</span>
 						</div>
 						<span class="w-9 text-center text-[8px] font-mono text-gray-500 dark:text-gray-400 shrink-0 hidden sm:block">{act.duration_days}d</span>
-						<span class="w-[62px] text-center text-[7px] font-mono text-gray-500 dark:text-gray-400 shrink-0 hidden sm:block">{formatDateCompact(act.early_start)}</span>
-						<span class="w-[62px] text-center text-[7px] font-mono text-gray-500 dark:text-gray-400 shrink-0 hidden sm:block">{formatDateCompact(act.early_finish)}</span>
+						<span class="w-[62px] text-center text-[7px] font-mono text-gray-500 dark:text-gray-400 shrink-0 hidden sm:block">{formatDateCompact(act.early_start, dl)}</span>
+						<span class="w-[62px] text-center text-[7px] font-mono text-gray-500 dark:text-gray-400 shrink-0 hidden sm:block">{formatDateCompact(act.early_finish, dl)}</span>
 						<span class="w-9 text-center text-[8px] font-mono shrink-0 {floatColor(act.total_float_days)}">{act.total_float_days}d</span>
 						<span class="w-8 text-center text-[8px] font-mono shrink-0 pr-1 {progressColor(act.progress_pct)}">{act.progress_pct > 0 ? act.progress_pct : ''}</span>
 					</div>

--- a/web/src/lib/components/ScheduleViewer/utils.test.ts
+++ b/web/src/lib/components/ScheduleViewer/utils.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import {
 	generateTimeTicks,
+	formatDateShort,
+	formatDateCompact,
 	applyClientGrouping,
 	defaultGroupLabel,
 	computeDefaultCollapse,
@@ -296,5 +298,66 @@ describe('presetCollapse — shared collapse preset for load + dimension/roll-up
 		const c = presetCollapse('wbs', 2, tree, 50);
 		expect(c.has('C1')).toBe(true); // depth 2 collapsed
 		expect(c.has('R')).toBe(false); // depth 1 stays expanded
+	});
+});
+
+describe('date formatters — locale threading (#176)', () => {
+	it('formatDateShort defaults to en-US (byte-compat for untouched callers)', () => {
+		expect(formatDateShort('2026-01-15')).toBe('Jan 15');
+	});
+
+	// Locale assertions are TOKEN-based (not exact-string) on purpose: Intl
+	// short-month/weekday output is ICU/CLDR-version-dependent (connector words,
+	// casing, and the space character have all drifted across CLDR releases).
+	// Pinning tokens + forbidden characters survives a Node/ICU bump; pinning
+	// the full string does not.
+	const FORBIDDEN = /[.\u202F\u00A0]/; // abbrev dots + NNBSP/NBSP must be normalized out
+
+	it('formatDateShort localizes month tokens, dotless and NNBSP-free', () => {
+		const pt = formatDateShort('2026-01-15', 'pt-BR');
+		const es = formatDateShort('2026-01-15', 'es');
+		expect(pt.toLowerCase()).toContain('jan'); // pt-BR Intl yields "15 de jan." pre-normalization
+		expect(pt).toContain('15');
+		expect(es.toLowerCase()).toContain('ene');
+		expect(es).toContain('15');
+		expect(pt).not.toMatch(FORBIDDEN);
+		expect(es).not.toMatch(FORBIDDEN);
+	});
+
+	it('formatDateCompact keeps the P6 d-MMM-yy skeleton across locales, dotless', () => {
+		expect(formatDateCompact('2026-01-15')).toBe('15-Jan-26');
+		// case-normalized: es/pt month-abbrev casing has shifted across CLDR versions
+		expect(formatDateCompact('2026-01-15', 'pt-BR').toLowerCase()).toBe('15-jan-26');
+		expect(formatDateCompact('2026-01-15', 'es').toLowerCase()).toBe('15-ene-26');
+		expect(formatDateCompact('2026-01-15', 'pt-BR')).not.toMatch(FORBIDDEN);
+		expect(formatDateCompact('2026-01-15', 'es')).not.toMatch(FORBIDDEN);
+	});
+
+	it('empty input still returns empty string regardless of locale', () => {
+		expect(formatDateShort('', 'pt-BR')).toBe('');
+		expect(formatDateCompact('', 'es')).toBe('');
+	});
+
+	it('generateTimeTicks localizes minor + major labels without trailing dots', () => {
+		const axis = generateTimeTicks('2026-01-01', '2026-03-31', 'week', 1200, 'pt-BR');
+		expect(axis.minor[0].label.toLowerCase()).toContain('jan');
+		expect(axis.major[0].label.toLowerCase()).toContain('jan');
+		for (const label of [...axis.minor.map((m) => m.label), ...axis.major.map((m) => m.label)]) {
+			expect(label).not.toContain('.');
+		}
+	});
+
+	it('generateTimeTicks day-zoom weekday labels are localized and dotless (pt-BR "seg." → "seg")', () => {
+		const axis = generateTimeTicks('2026-01-05', '2026-01-16', 'day', 1200, 'pt-BR');
+		for (const tick of axis.minor) {
+			expect(tick.label).not.toContain('.');
+		}
+		// 2026-01-05 is a Monday → "seg" in pt-BR
+		expect(axis.minor[0].label.toLowerCase()).toContain('seg');
+	});
+
+	it('generateTimeTicks default stays en-US (existing pins remain valid)', () => {
+		const axis = generateTimeTicks('2026-01-01', '2026-03-31', 'week');
+		expect(axis.major[0].label).toMatch(/Jan/);
 	});
 });

--- a/web/src/lib/components/ScheduleViewer/utils.ts
+++ b/web/src/lib/components/ScheduleViewer/utils.ts
@@ -10,11 +10,23 @@ export function daysBetween(start: string, end: string): number {
 	return Math.round((e.getTime() - s.getTime()) / 86_400_000);
 }
 
-/** Format date as short label (e.g. "Jan 15"). */
-export function formatDateShort(iso: string): string {
+/** Normalize an Intl month/weekday ABBREVIATION label for P6-style display:
+ *  - NNBSP/NBSP (U+202F/U+00A0) → regular space. Current ICU emits plain
+ *    spaces in these date skeletons, but CLDR has flipped separators across
+ *    versions; normalizing keeps rendered output (and test pins) stable.
+ *  - strips abbreviation dots (pt-BR "jan." → "jan"; P6's locale convention
+ *    is dotless). en-US emits none (no-op).
+ *  CONTRACT: only feed month/weekday/day abbreviation skeletons. NEVER pass
+ *  numeric date skeletons (e.g. de-DE "15.01.2026"), where "." is a separator. */
+function stripAbbrevDots(label: string): string {
+	return label.replace(/[\u202F\u00A0]/g, ' ').replace(/\./g, '');
+}
+
+/** Format date as short label (e.g. "Jan 15"), localized via BCP-47 tag. */
+export function formatDateShort(iso: string, locale: string = 'en-US'): string {
 	if (!iso) return '';
 	const d = parseDate(iso);
-	return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+	return stripAbbrevDots(d.toLocaleDateString(locale, { month: 'short', day: 'numeric' }));
 }
 
 /** Format date as full (e.g. "2026-01-15"). */
@@ -46,6 +58,7 @@ function buildMajorTier(
 	startIso: string,
 	totalDays: number,
 	unit: 'year' | 'month',
+	locale: string,
 ): MajorTick[] {
 	// Boundary dates: the chart start, then each first-of-next-unit up to end.
 	const boundaries: Date[] = [new Date(start)];
@@ -74,7 +87,7 @@ function buildMajorTier(
 		const label =
 			unit === 'year'
 				? String(b.getFullYear())
-				: b.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
+				: stripAbbrevDots(b.toLocaleDateString(locale, { month: 'short', year: 'numeric' }));
 		major.push({ label, x, xEnd });
 	}
 	return major;
@@ -89,6 +102,7 @@ export function generateTimeTicks(
 	endDate: string,
 	zoomLevel: 'day' | 'week' | 'month',
 	svgWidth: number = 1200,
+	locale: string = 'en-US',
 ): TimeAxis {
 	const start = parseDate(startDate);
 	const end = parseDate(endDate);
@@ -117,27 +131,28 @@ export function generateTimeTicks(
 		// stays compact (month name, or month+day at finer zooms).
 		let label: string;
 		if (stepDays >= 28 || zoomLevel === 'month') {
-			label = current.toLocaleDateString('en-US', { month: 'short' });
+			label = current.toLocaleDateString(locale, { month: 'short' });
 		} else if (stepDays >= 5) {
-			label = current.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+			label = current.toLocaleDateString(locale, { month: 'short', day: 'numeric' });
 		} else {
-			label = current.toLocaleDateString('en-US', { weekday: 'short', day: 'numeric' });
+			label = current.toLocaleDateString(locale, { weekday: 'short', day: 'numeric' });
 		}
+		label = stripAbbrevDots(label);
 
 		minor.push({ date: iso, label, x });
 		current.setDate(current.getDate() + stepDays);
 	}
 
 	const majorUnit: 'year' | 'month' = zoomLevel === 'month' ? 'year' : 'month';
-	return { minor, major: buildMajorTier(start, end, startDate, totalDays, majorUnit) };
+	return { minor, major: buildMajorTier(start, end, startDate, totalDays, majorUnit, locale) };
 }
 
-/** Format date as compact column label (e.g. "15-Jan-26"). */
-export function formatDateCompact(iso: string): string {
+/** Format date as compact P6-style column label (e.g. "15-Jan-26"), localized via BCP-47 tag. */
+export function formatDateCompact(iso: string, locale: string = 'en-US'): string {
 	if (!iso) return '';
 	const d = parseDate(iso);
 	const day = d.getDate();
-	const mon = d.toLocaleDateString('en-US', { month: 'short' });
+	const mon = stripAbbrevDots(d.toLocaleDateString(locale, { month: 'short' }));
 	const yr = d.getFullYear().toString().slice(-2);
 	return `${day}-${mon}-${yr}`;
 }

--- a/web/src/lib/i18n/dateLocale.test.ts
+++ b/web/src/lib/i18n/dateLocale.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { dateLocale } from './index';
+
+describe('dateLocale — app locale → BCP-47 tag for Intl date formatting (#176)', () => {
+	it('maps each app locale to its Intl tag', () => {
+		expect(dateLocale('en')).toBe('en-US');
+		expect(dateLocale('pt-BR')).toBe('pt-BR');
+		expect(dateLocale('es')).toBe('es');
+	});
+
+	it('returned tags are actually supported by the runtime ICU (full-icu in Node/CI)', () => {
+		for (const tag of [dateLocale('en'), dateLocale('pt-BR'), dateLocale('es')]) {
+			expect(Intl.DateTimeFormat.supportedLocalesOf(tag)).toContain(tag);
+		}
+	});
+});

--- a/web/src/lib/i18n/index.ts
+++ b/web/src/lib/i18n/index.ts
@@ -20,6 +20,20 @@ export const t = derived(locale, ($locale) => {
 	};
 });
 
+/** Map an app locale to a BCP-47 tag for Intl date formatting.
+ *  Best-effort tag validation only: on a runtime whose ICU lacks the locale
+ *  data we return 'en-US' explicitly rather than relying on the engine's own
+ *  silent fallback (toLocaleDateString does NOT throw on missing data — the
+ *  try/catch covers only a hypothetical supportedLocalesOf failure). */
+export function dateLocale(loc: Locale): string {
+	const tag = loc === 'en' ? 'en-US' : loc;
+	try {
+		return Intl.DateTimeFormat.supportedLocalesOf(tag).length > 0 ? tag : 'en-US';
+	} catch {
+		return 'en-US';
+	}
+}
+
 export function detectLocale(): Locale {
 	if (typeof navigator === 'undefined') return 'en';
 	const lang = navigator.language;


### PR DESCRIPTION
Closes #176.

## What

W4 PR-A (#175) i18n'd the ScheduleViewer **labels**; date **values** still rendered en-US ("Data de Corte: Jan 15" for a pt-BR user). This PR threads the app locale into every date value in the viewer tree:

- `formatDateShort` / `formatDateCompact` / `generateTimeTicks` / `buildMajorTier` gain a trailing `locale: string = 'en-US'` param — pure functions, default arg keeps en behavior byte-identical.
- New `dateLocale(locale)` in `web/src/lib/i18n/index.ts`: en→`en-US`, pt-BR→`pt-BR`, es→`es`, with best-effort `Intl.supportedLocalesOf` validation falling back to `en-US`.
- All five components (WBSTree, ActivityTooltip, ScheduleViewer, TimeScale, GanttCanvas) pass `$derived(dateLocale($locale))`; both print exports read it at click time — **including `printedDate`**, which was browser-default and could disagree with the schedule dates in the same printed page.
- `stripAbbrevDots`: normalizes NNBSP/NBSP→space and strips pt-BR/es abbreviation dots ("15 de jan.", "seg." → "15 de jan", "seg") per P6's dotless locale convention. Contract-commented: abbreviation skeletons only, never numeric dates.
- Dead `formatDateShort` import removed from GanttCanvas.

## Council process

- **Entry-council (frontend-ux): GREEN**, 5 mandatories — all applied (Intl guard, dead import, same locale into both axis consumers, app-locale clock printedDate, en-pin byte-compat).
- **Exit-council: frontend SHIP; devils-advocate SHIP-with-mandatories** — both applied:
  1. Test pins are token-based + case/whitespace-normalized (ICU/CLDR drift across Node bumps), with explicit no-U+202F/U+00A0 assertions; regexes use `\u` escapes, no invisible literals in source.
  2. NNBSP normalization folded into the shared helper so print-export HTML can't carry it.

## Verification

- svelte-check: 641 files, **0 errors / 0 warnings**
- vitest: **186/186** (+11 new: locale pins + dateLocale mapping/guard)
- production build clean (adapter-static)
- Local Node 24.15 ICU output inspected: pt-BR "15 de jan." / es "15 ene" with regular spaces today — normalization is forward-proofing.

## Operator visual checklist (post-merge, pt-BR + es)

- [ ] /schedule hover: status bar "15 de jan — 20 de mar" fits without wrapping (pt-BR short dates are ~3 chars wider than en)
- [ ] ActivityTooltip date rows at 320px width
- [ ] Print export (both): header date + table cells localized, no stray glyphs
- [ ] Gantt time axis labels (month + day zoom) read correctly